### PR TITLE
refactor: encapsulate alarm user context

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -9,6 +9,8 @@ struct sleeplock;
 struct stat;
 struct superblock;
 struct sysinfo;
+struct trapframe;
+struct user_context;
 struct VMA;
 
 // bio.c
@@ -152,6 +154,8 @@ void            trapinit(void);
 void            trapinithart(void);
 extern struct spinlock tickslock;
 void            usertrapret(void);
+void            save_user_context(struct user_context*, const struct trapframe*);
+void            restore_user_context(struct trapframe*, const struct user_context*);
 
 // uart.c
 void            uartinit(void);

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -80,6 +80,13 @@ struct trapframe {
   /* 280 */ uint64 t6;
 };
 
+// A snapshot of the user-visible execution state.
+// gpr[] stores x1 (ra) through x31 (t6) in trapframe order.
+struct user_context {
+  uint64 epc;
+  uint64 gpr[31];
+};
+
 enum procstate { UNUSED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 
 // Per-process state
@@ -108,39 +115,7 @@ struct proc {
   void (*handler)();
   int alarm_interval;
   int total_ticks;
-
   uint64 in_handler;
-  uint64 epc;           // saved user program counter
-  uint64 ra;
-  uint64 sp;
-  uint64 gp;
-  uint64 tp;
-  uint64 t0;
-  uint64 t1;
-  uint64 t2;
-  uint64 s0;
-  uint64 s1;
-  uint64 a0;
-  uint64 a1;
-  uint64 a2;
-  uint64 a3;
-  uint64 a4;
-  uint64 a5;
-  uint64 a6;
-  uint64 a7;
-  uint64 s2;
-  uint64 s3;
-  uint64 s4;
-  uint64 s5;
-  uint64 s6;
-  uint64 s7;
-  uint64 s8;
-  uint64 s9;
-  uint64 s10;
-  uint64 s11;
-  uint64 t3;
-  uint64 t4;
-  uint64 t5;
-  uint64 t6;
+  struct user_context alarm_context;
   struct VMA* vma[NOFILE];
 };

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -160,39 +160,7 @@ uint64
 sys_sigreturn(void)
 {
     struct proc* p = myproc();
-    uint64 saved_a0 = p->a0;
-    p->trapframe->epc = p->epc;
-    p->trapframe->ra = p->ra;
-    p->trapframe->sp = p->sp;
-    p->trapframe->gp = p->gp;
-    p->trapframe->tp = p->tp;
-    p->trapframe->t0 = p->t0;
-    p->trapframe->t1 = p->t1;
-    p->trapframe->t2 = p->t2;
-    p->trapframe->s0 = p->s0;
-    p->trapframe->s1 = p->s1;
-    p->trapframe->a0 = p->a0;
-    p->trapframe->a1 = p->a1;
-    p->trapframe->a2 = p->a2;
-    p->trapframe->a3 = p->a3;
-    p->trapframe->a4 = p->a4;
-    p->trapframe->a5 = p->a5;
-    p->trapframe->a6 = p->a6;
-    p->trapframe->a7 = p->a7;
-    p->trapframe->s2 = p->s2;
-    p->trapframe->s3 = p->s3;
-    p->trapframe->s4 = p->s4;
-    p->trapframe->s5 = p->s5;
-    p->trapframe->s6 = p->s6;
-    p->trapframe->s7 = p->s7;
-    p->trapframe->s8 = p->s8;
-    p->trapframe->s9 = p->s9;
-    p->trapframe->s10 = p->s10;
-    p->trapframe->s11 = p->s11;
-    p->trapframe->t3 = p->t3;
-    p->trapframe->t4 = p->t4;
-    p->trapframe->t5 = p->t5;
-    p->trapframe->t6 = p->t6;
+    restore_user_context(p->trapframe, &p->alarm_context);
     p->in_handler = 0;
-    return saved_a0;
+    return p->trapframe->a0;
 }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -34,6 +34,21 @@ trapinithart(void)
   w_stvec((uint64)kernelvec);
 }
 
+void
+save_user_context(struct user_context *context,
+                  const struct trapframe *trapframe)
+{
+  context->epc = trapframe->epc;
+  memmove(context->gpr, &trapframe->ra, sizeof(context->gpr));
+}
+
+void
+restore_user_context(struct trapframe *trapframe,
+                     const struct user_context *context)
+{
+  trapframe->epc = context->epc;
+  memmove(&trapframe->ra, context->gpr, sizeof(context->gpr));
+}
 
 static int
 mmap_fault(struct proc *p, uint64 va)
@@ -136,44 +151,12 @@ usertrap(void)
   if(which_dev == 2){
     p->total_ticks++;
     if(p->alarm_interval > 0 && p->total_ticks == p->alarm_interval){
-        p->total_ticks = 0;
-        if(p->in_handler == 0){
-          p->epc = p->trapframe->epc;
-          p->ra = p->trapframe->ra;
-          p->sp = p->trapframe->sp;
-          p->gp = p->trapframe->gp;
-          p->tp = p->trapframe->tp;
-          p->t0 = p->trapframe->t0;
-          p->t1 = p->trapframe->t1;
-          p->t2 = p->trapframe->t2;
-          p->s0 = p->trapframe->s0;
-          p->s1 = p->trapframe->s1;
-          p->a0 = p->trapframe->a0;
-          p->a1 = p->trapframe->a1;
-          p->a2 = p->trapframe->a2;
-          p->a3 = p->trapframe->a3;
-          p->a4 = p->trapframe->a4;
-          p->a5 = p->trapframe->a5;
-          p->a6 = p->trapframe->a6;
-          p->a7 = p->trapframe->a7;
-          p->s2 = p->trapframe->s2;
-          p->s3 = p->trapframe->s3;
-          p->s4 = p->trapframe->s4;
-          p->s5 = p->trapframe->s5;
-          p->s6 = p->trapframe->s6;
-          p->s7 = p->trapframe->s7;
-          p->s8 = p->trapframe->s8;
-          p->s9 = p->trapframe->s9;
-          p->s10 = p->trapframe->s10;
-          p->s11 = p->trapframe->s11;
-          p->t3 = p->trapframe->t3;
-          p->t4 = p->trapframe->t4;
-          p->t5 = p->trapframe->t5;
-          p->t6 = p->trapframe->t6;
-          p->trapframe->epc = (uint64)p->handler;
-          p->in_handler = 1;
-        }
-
+      p->total_ticks = 0;
+      if(p->in_handler == 0){
+        save_user_context(&p->alarm_context, p->trapframe);
+        p->trapframe->epc = (uint64)p->handler;
+        p->in_handler = 1;
+      }
     }
     yield();
   }
@@ -315,4 +298,3 @@ devintr()
     return 0;
   }
 }
-


### PR DESCRIPTION
## 中心认知与范围

Lab4 alarm 需要保存的是一次完整的用户态执行上下文，而不是散落在 `struct proc` 中的一组无归属寄存器字段。本 PR 将该状态收敛为一个明确的 `user_context` 快照，并统一保存/恢复入口。

Closes #19

## 基线

- Base branch: `main`
- Base commit: `033694dd55c2d83830861a5d63e71ff3a2cc6d6d`

## 修改内容

- 在 `kernel/proc.h` 中新增 `struct user_context`：
  - 单独保存 `epc`；
  - `gpr[31]` 保存 RISC-V `x1` 到 `x31`，顺序与 trapframe 的 `ra` 到 `t6` 一致。
- `struct proc` 只保留一个 `alarm_context`，删除 32 个逐项展开的快照字段。
- 在 `kernel/trap.c` 中增加公共接口：
  - `save_user_context()`
  - `restore_user_context()`
- timer interrupt 触发 alarm 时统一保存上下文。
- `sys_sigreturn()` 统一恢复上下文，并继续返回恢复后的 `a0`，保持系统调用分派覆盖 `a0` 时的原语义。

## 状态、所有权与不变量

- `alarm_context` 由对应 `proc` 独占。
- 仅在 `in_handler == 0` 时覆盖快照，保持 handler 不可重入。
- `trapframe` 中 `ra` 到 `t6` 必须连续对应 RISC-V `x1` 到 `x31`；复制长度固定为 `sizeof(user_context.gpr)`。
- `sigreturn` 恢复 `epc` 与全部通用寄存器后，再清除 `in_handler`。

## 教学边界

- 这是 xv6 Lab4 的单层 alarm 上下文快照，不是完整 POSIX signal frame。
- 不支持嵌套 signal、signal mask、用户栈 signal frame 或多种 signal 类型。

## 验证

已完成：

- 使用宿主机 GCC 对 `trapframe` / `user_context` 布局及保存恢复函数进行了独立编译验证：`LAYOUT_HELPER_TEST_OK`。
- 核对 `ra` 到 `t6` 的连续区域大小为 `31 * sizeof(uint64)`，保存后恢复结果逐字节一致。

当前执行环境无法解析 GitHub 域名，不能拉取完整仓库，因此以下项目尚未真实执行，不能标记为通过：

- [ ] `make clean && make`
- [ ] QEMU 中运行 `alarmtest`
- [ ] 相关 `usertests` 回归

## 未覆盖边界

- 未改变用户态 API 与 alarm 行为。
- 未新增 alarm 功能或无关重构。
- PR 保持 Draft，待完整 xv6 构建和 QEMU 验证后再进入评审。