### PR TITLE
[Concept Lab] vmbench：lazy allocation 基线

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,6 @@
+include Makefile
+
+.DEFAULT_GOAL := vmbench-image
+
+.PHONY: vmbench-image
+vmbench-image: kernel/kernel fs.img

--- a/conf/lab.mk
+++ b/conf/lab.mk
@@ -1,1 +1,51 @@
 LAB=lazy
+
+override OBJS = \
+  $(K)/entry.o \
+  $(K)/start.o \
+  $(K)/console.o \
+  $(K)/printf.o \
+  $(K)/uart.o \
+  $(K)/kalloc.o \
+  $(K)/spinlock.o \
+  $(K)/string.o \
+  $(K)/main.o \
+  $(K)/vm.o \
+  $(K)/proc.o \
+  $(K)/swtch.o \
+  $(K)/trampoline.o \
+  $(K)/trap.o \
+  $(K)/syscall.o \
+  $(K)/sysproc.o \
+  $(K)/vmstat.o \
+  $(K)/bio.o \
+  $(K)/fs.o \
+  $(K)/log.o \
+  $(K)/sleeplock.o \
+  $(K)/file.o \
+  $(K)/pipe.o \
+  $(K)/exec.o \
+  $(K)/sysfile.o \
+  $(K)/kernelvec.o \
+  $(K)/plic.o \
+  $(K)/virtio_disk.o
+
+override UPROGS = \
+  $(U)/_cat \
+  $(U)/_echo \
+  $(U)/_forktest \
+  $(U)/_grep \
+  $(U)/_init \
+  $(U)/_kill \
+  $(U)/_ln \
+  $(U)/_ls \
+  $(U)/_mkdir \
+  $(U)/_rm \
+  $(U)/_sh \
+  $(U)/_stressfs \
+  $(U)/_usertests \
+  $(U)/_grind \
+  $(U)/_wc \
+  $(U)/_zombie \
+  $(U)/_lazytests \
+  $(U)/_vmbench

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -168,6 +168,7 @@ void            uvmfree(pagetable_t, uint64);
 void            uvmunmap(pagetable_t, uint64, uint64, int);
 void            uvmclear(pagetable_t, uint64);
 uint64          walkaddr(pagetable_t, uint64);
+pte_t*          walk(pagetable_t, uint64, int);
 int             copyout(pagetable_t, uint64, char *, uint64);
 int             copyin(pagetable_t, char *, uint64, uint64);
 int             copyinstr(pagetable_t, char *, uint64, uint64);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -104,6 +104,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_wait(void);
 extern uint64 sys_write(void);
 extern uint64 sys_uptime(void);
+extern uint64 sys_vmstat(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -127,6 +128,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_vmstat]  sys_vmstat,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_vmstat 22

--- a/kernel/vmstat.c
+++ b/kernel/vmstat.c
@@ -1,0 +1,324 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "defs.h"
+#include "vmstat.h"
+
+#ifndef PTE_COW
+#define PTE_COW (1L << 8)
+#endif
+
+extern struct proc proc[NPROC];
+
+struct mapping_summary {
+  uint64 scanned;
+  uint64 present;
+  uint64 private_pages;
+  uint64 shared_pages;
+  uint64 cow_pages;
+};
+
+struct vmstat_state {
+  struct spinlock lock;
+  int initialized;
+  int active;
+  int root_pid;
+  int child_pid;
+  uint64 range_start;
+  uint64 range_end;
+  uint64 begin_total_present;
+  uint64 begin_range_present;
+  struct vmstat_snapshot snapshot;
+};
+
+static struct vmstat_state state;
+
+static void
+vmstat_init_once(void)
+{
+  if(state.initialized)
+    return;
+  initlock(&state.lock, "vmstat");
+  state.initialized = 1;
+}
+
+static int
+user_leaf(pagetable_t pagetable, uint64 va, pte_t *value)
+{
+  pte_t *pte = walk(pagetable, va, 0);
+  if(pte == 0 || (*pte & PTE_V) == 0 || (*pte & PTE_U) == 0)
+    return 0;
+  if((*pte & (PTE_R | PTE_W | PTE_X)) == 0)
+    return 0;
+  if(value)
+    *value = *pte;
+  return 1;
+}
+
+static uint64
+count_present(pagetable_t pagetable, uint64 sz, uint64 start, uint64 end)
+{
+  uint64 count = 0;
+  uint64 first = PGROUNDDOWN(start);
+  uint64 limit = PGROUNDUP(end);
+
+  if(limit > PGROUNDUP(sz))
+    limit = PGROUNDUP(sz);
+  for(uint64 va = first; va < limit; va += PGSIZE)
+    if(user_leaf(pagetable, va, 0))
+      count++;
+  return count;
+}
+
+static void
+scan_relation(struct proc *parent, struct proc *child,
+              uint64 start, uint64 end, struct mapping_summary *summary)
+{
+  memset(summary, 0, sizeof(*summary));
+
+  uint64 first = PGROUNDDOWN(start);
+  uint64 limit = PGROUNDUP(end);
+  if(limit > PGROUNDUP(parent->sz))
+    limit = PGROUNDUP(parent->sz);
+
+  for(uint64 va = first; va < limit; va += PGSIZE){
+    pte_t parent_pte;
+    pte_t child_pte;
+
+    summary->scanned++;
+    if(!user_leaf(parent->pagetable, va, &parent_pte))
+      continue;
+    summary->present++;
+    if(!user_leaf(child->pagetable, va, &child_pte))
+      continue;
+
+    if(PTE2PA(parent_pte) == PTE2PA(child_pte))
+      summary->shared_pages++;
+    else
+      summary->private_pages++;
+
+    if((parent_pte & PTE_COW) || (child_pte & PTE_COW))
+      summary->cow_pages++;
+  }
+}
+
+static struct proc *
+find_proc_locked(int pid)
+{
+  for(struct proc *p = proc; p < &proc[NPROC]; p++){
+    acquire(&p->lock);
+    if(p->pid == pid && p->state != UNUSED)
+      return p;
+    release(&p->lock);
+  }
+  return 0;
+}
+
+static void
+record_fork_counts(struct vmstat_counts *counts,
+                   const struct mapping_summary *summary)
+{
+  counts->fork_va_scan_pages = summary->scanned;
+  counts->fork_present_pages = summary->present;
+  counts->fork_eager_copy_pages = summary->private_pages;
+  counts->fork_shared_map_pages = summary->shared_pages;
+  counts->fork_cow_mark_pages = summary->cow_pages;
+}
+
+static uint64
+additional_private_pages(uint64 current_private, uint64 fork_private)
+{
+  if(current_private <= fork_private)
+    return 0;
+  return current_private - fork_private;
+}
+
+static int
+vmstat_begin(struct proc *caller, uint64 start, uint64 end)
+{
+  if(end <= start || end > MAXVA)
+    return -1;
+
+  acquire(&state.lock);
+  state.active = 1;
+  state.root_pid = caller->pid;
+  state.child_pid = 0;
+  state.range_start = start;
+  state.range_end = end;
+  memset(&state.snapshot, 0, sizeof(state.snapshot));
+  state.snapshot.abi_version = VMSTAT_ABI_VERSION;
+  state.snapshot.range_start = start;
+  state.snapshot.range_end = end;
+  state.begin_total_present = count_present(caller->pagetable, caller->sz, 0, caller->sz);
+  state.begin_range_present = count_present(caller->pagetable, caller->sz, start, end);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_sbrk(struct proc *caller, uint64 oldsz, uint64 newsz)
+{
+  if(newsz < oldsz)
+    return -1;
+
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid){
+    release(&state.lock);
+    return -1;
+  }
+
+  uint64 grow_start = PGROUNDUP(oldsz);
+  uint64 grow_end = PGROUNDUP(newsz);
+  uint64 total_pages = 0;
+  uint64 range_pages = 0;
+  uint64 total_eager = 0;
+  uint64 range_eager = 0;
+
+  for(uint64 va = grow_start; va < grow_end; va += PGSIZE){
+    total_pages++;
+    if(user_leaf(caller->pagetable, va, 0))
+      total_eager++;
+    if(va >= PGROUNDDOWN(state.range_start) && va < PGROUNDUP(state.range_end)){
+      range_pages++;
+      if(user_leaf(caller->pagetable, va, 0))
+        range_eager++;
+    }
+  }
+
+  state.snapshot.total.virtual_grow_pages += total_pages;
+  state.snapshot.range.virtual_grow_pages += range_pages;
+  state.snapshot.total.sbrk_eager_alloc_pages += total_eager;
+  state.snapshot.range.sbrk_eager_alloc_pages += range_eager;
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_fork(struct proc *caller, int child_pid)
+{
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid || child_pid <= 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct proc *child = find_proc_locked(child_pid);
+  if(child == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct mapping_summary total;
+  struct mapping_summary range;
+  scan_relation(caller, child, 0, caller->sz, &total);
+  scan_relation(caller, child, state.range_start, state.range_end, &range);
+  record_fork_counts(&state.snapshot.total, &total);
+  record_fork_counts(&state.snapshot.range, &range);
+  state.child_pid = child_pid;
+
+  release(&child->lock);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_child(struct proc *caller)
+{
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.child_pid){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct proc *root = find_proc_locked(state.root_pid);
+  if(root == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct mapping_summary total;
+  struct mapping_summary range;
+  scan_relation(root, caller, 0, root->sz, &total);
+  scan_relation(root, caller, state.range_start, state.range_end, &range);
+
+  state.snapshot.total.cow_copy_pages =
+    additional_private_pages(total.private_pages,
+                             state.snapshot.total.fork_eager_copy_pages);
+  state.snapshot.range.cow_copy_pages =
+    additional_private_pages(range.private_pages,
+                             state.snapshot.range.fork_eager_copy_pages);
+
+  release(&root->lock);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_end(struct proc *caller, uint64 user_dst)
+{
+  struct vmstat_snapshot snapshot;
+
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid || user_dst == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  uint64 total_present = count_present(caller->pagetable, caller->sz, 0, caller->sz);
+  uint64 range_present = count_present(caller->pagetable, caller->sz,
+                                       state.range_start, state.range_end);
+  state.snapshot.total.final_present_pages = total_present;
+  state.snapshot.range.final_present_pages = range_present;
+
+  uint64 total_known = state.begin_total_present +
+                       state.snapshot.total.sbrk_eager_alloc_pages;
+  uint64 range_known = state.begin_range_present +
+                       state.snapshot.range.sbrk_eager_alloc_pages;
+  if(total_present > total_known)
+    state.snapshot.total.lazy_materialized_pages = total_present - total_known;
+  if(range_present > range_known)
+    state.snapshot.range.lazy_materialized_pages = range_present - range_known;
+
+  snapshot = state.snapshot;
+  state.active = 0;
+  release(&state.lock);
+
+  if(copyout(caller->pagetable, user_dst, (char *)&snapshot, sizeof(snapshot)) < 0)
+    return -1;
+  return 0;
+}
+
+uint64
+sys_vmstat(void)
+{
+  int op;
+  uint64 arg0;
+  uint64 arg1;
+  uint64 user_dst;
+
+  vmstat_init_once();
+  if(argint(0, &op) < 0 ||
+     argaddr(1, &arg0) < 0 ||
+     argaddr(2, &arg1) < 0 ||
+     argaddr(3, &user_dst) < 0)
+    return -1;
+
+  struct proc *caller = myproc();
+  switch(op){
+  case VMSTAT_BEGIN:
+    return vmstat_begin(caller, arg0, arg1);
+  case VMSTAT_SAMPLE_SBRK:
+    return vmstat_sample_sbrk(caller, arg0, arg1);
+  case VMSTAT_SAMPLE_FORK:
+    return vmstat_sample_fork(caller, (int)arg0);
+  case VMSTAT_SAMPLE_CHILD:
+    return vmstat_sample_child(caller);
+  case VMSTAT_END:
+    return vmstat_end(caller, user_dst);
+  default:
+    return -1;
+  }
+}

--- a/kernel/vmstat.h
+++ b/kernel/vmstat.h
@@ -1,0 +1,33 @@
+#ifndef XV6_VMSTAT_H
+#define XV6_VMSTAT_H
+
+#define VMSTAT_ABI_VERSION 1
+
+#define VMSTAT_BEGIN         1
+#define VMSTAT_SAMPLE_SBRK   2
+#define VMSTAT_SAMPLE_FORK   3
+#define VMSTAT_SAMPLE_CHILD  4
+#define VMSTAT_END           5
+
+struct vmstat_counts {
+  uint64 virtual_grow_pages;
+  uint64 sbrk_eager_alloc_pages;
+  uint64 lazy_materialized_pages;
+  uint64 fork_va_scan_pages;
+  uint64 fork_present_pages;
+  uint64 fork_eager_copy_pages;
+  uint64 fork_shared_map_pages;
+  uint64 fork_cow_mark_pages;
+  uint64 cow_copy_pages;
+  uint64 final_present_pages;
+};
+
+struct vmstat_snapshot {
+  uint64 abi_version;
+  uint64 range_start;
+  uint64 range_end;
+  struct vmstat_counts total;
+  struct vmstat_counts range;
+};
+
+#endif

--- a/user/vmbench.c
+++ b/user/vmbench.c
@@ -1,0 +1,326 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "kernel/syscall.h"
+#include "kernel/vmstat.h"
+#include "user/user.h"
+
+#define DEFAULT_PAGES 4096
+#define MAX_PAGES 8192
+#define SPARSE_STRIDE 64
+
+struct region {
+  char *start;
+  char *end;
+  int pages;
+};
+
+struct scenario {
+  char *name;
+  int (*run)(int pages);
+};
+
+static int
+vmstat_call(int op, uint64 arg0, uint64 arg1, struct vmstat_snapshot *snapshot)
+{
+  register uint64 a0 asm("a0") = (uint64)op;
+  register uint64 a1 asm("a1") = arg0;
+  register uint64 a2 asm("a2") = arg1;
+  register uint64 a3 asm("a3") = (uint64)snapshot;
+  register uint64 a7 asm("a7") = SYS_vmstat;
+
+  asm volatile("ecall"
+               : "+r"(a0)
+               : "r"(a1), "r"(a2), "r"(a3), "r"(a7)
+               : "memory");
+  return (int)a0;
+}
+
+static char *
+align_heap(void)
+{
+  uint64 current = (uint64)sbrk(0);
+  uint64 aligned = PGROUNDUP(current);
+  if(aligned > current && sbrk(aligned - current) == (char *)-1)
+    return 0;
+  return (char *)aligned;
+}
+
+static int
+begin_region(int pages, struct region *region)
+{
+  char *start = align_heap();
+  if(start == 0)
+    return -1;
+
+  uint64 bytes = (uint64)pages * PGSIZE;
+  uint64 end = (uint64)start + bytes;
+  if(end < (uint64)start)
+    return -1;
+
+  region->start = start;
+  region->end = (char *)end;
+  region->pages = pages;
+  return vmstat_call(VMSTAT_BEGIN, (uint64)start, end, 0);
+}
+
+static int
+reserve_region(struct region *region)
+{
+  uint64 oldsz = (uint64)sbrk(0);
+  uint64 bytes = (uint64)region->pages * PGSIZE;
+  if((uint64)region->start != oldsz)
+    return -1;
+  if(sbrk(bytes) == (char *)-1)
+    return -1;
+  return vmstat_call(VMSTAT_SAMPLE_SBRK, oldsz, oldsz + bytes, 0);
+}
+
+static void
+touch_pages(char *start, int pages, int stride, char value)
+{
+  volatile char *memory = (volatile char *)start;
+  for(int page = 0; page < pages; page += stride)
+    memory[(uint64)page * PGSIZE] = value;
+}
+
+static int
+check_pages(char *start, int pages, int stride, char value)
+{
+  volatile char *memory = (volatile char *)start;
+  for(int page = 0; page < pages; page += stride)
+    if(memory[(uint64)page * PGSIZE] != value)
+      return -1;
+  return 0;
+}
+
+static void
+print_counts(char *prefix, struct vmstat_counts *counts)
+{
+  printf(" %s_virtual=%d", prefix, (int)counts->virtual_grow_pages);
+  printf(" %s_eager_alloc=%d", prefix, (int)counts->sbrk_eager_alloc_pages);
+  printf(" %s_lazy_alloc=%d", prefix, (int)counts->lazy_materialized_pages);
+  printf(" %s_fork_scan=%d", prefix, (int)counts->fork_va_scan_pages);
+  printf(" %s_fork_present=%d", prefix, (int)counts->fork_present_pages);
+  printf(" %s_fork_copy=%d", prefix, (int)counts->fork_eager_copy_pages);
+  printf(" %s_fork_shared=%d", prefix, (int)counts->fork_shared_map_pages);
+  printf(" %s_cow_mark=%d", prefix, (int)counts->fork_cow_mark_pages);
+  printf(" %s_cow_copy=%d", prefix, (int)counts->cow_copy_pages);
+  printf(" %s_final_present=%d", prefix, (int)counts->final_present_pages);
+}
+
+static int
+finish_region(char *scenario, int pages, int stride)
+{
+  struct vmstat_snapshot snapshot;
+  if(vmstat_call(VMSTAT_END, 0, 0, &snapshot) < 0){
+    printf("vmbench: VMSTAT_END failed for %s\n", scenario);
+    return -1;
+  }
+
+  printf("VMRESULT scenario=%s pages=%d stride=%d abi=%d",
+         scenario, pages, stride, (int)snapshot.abi_version);
+  print_counts("range", &snapshot.range);
+  print_counts("total", &snapshot.total);
+  printf("\n");
+  return 0;
+}
+
+static int
+run_touch_case(char *name, int pages, int stride)
+{
+  struct region region;
+  if(begin_region(pages, &region) < 0 || reserve_region(&region) < 0)
+    return -1;
+
+  if(stride > 0){
+    touch_pages(region.start, pages, stride, 0x31);
+    if(check_pages(region.start, pages, stride, 0x31) < 0)
+      return -1;
+  }
+  return finish_region(name, pages, stride);
+}
+
+static int
+run_reserve_only(int pages)
+{
+  return run_touch_case("reserve-only", pages, 0);
+}
+
+static int
+run_sparse_touch(int pages)
+{
+  return run_touch_case("sparse-touch", pages, SPARSE_STRIDE);
+}
+
+static int
+run_dense_touch(int pages)
+{
+  return run_touch_case("dense-touch", pages, 1);
+}
+
+static int
+run_fork_case(char *name, int pages, int parent_stride,
+              int child_write_stride, int do_exec)
+{
+  struct region region;
+  int gate[2];
+  int status = 0;
+
+  if(begin_region(pages, &region) < 0 || reserve_region(&region) < 0)
+    return -1;
+  touch_pages(region.start, pages, parent_stride, 0x41);
+  if(check_pages(region.start, pages, parent_stride, 0x41) < 0)
+    return -1;
+
+  if(pipe(gate) < 0)
+    return -1;
+  int pid = fork();
+  if(pid < 0)
+    return -1;
+
+  if(pid == 0){
+    char token;
+    close(gate[1]);
+    if(read(gate[0], &token, 1) != 1)
+      exit(2);
+    close(gate[0]);
+
+    if(child_write_stride > 0)
+      touch_pages(region.start, pages, child_write_stride, 0x52);
+    if(vmstat_call(VMSTAT_SAMPLE_CHILD, 0, 0, 0) < 0)
+      exit(3);
+
+    if(do_exec){
+      char *argv[] = { "echo", 0 };
+      exec("echo", argv);
+      exit(4);
+    }
+    exit(0);
+  }
+
+  close(gate[0]);
+  if(vmstat_call(VMSTAT_SAMPLE_FORK, pid, 0, 0) < 0){
+    close(gate[1]);
+    wait(&status);
+    return -1;
+  }
+  if(write(gate[1], "x", 1) != 1){
+    close(gate[1]);
+    wait(&status);
+    return -1;
+  }
+  close(gate[1]);
+  if(wait(&status) < 0 || status != 0)
+    return -1;
+
+  if(check_pages(region.start, pages, parent_stride, 0x41) < 0)
+    return -1;
+  return finish_region(name, pages,
+                       child_write_stride > 0 ? child_write_stride : parent_stride);
+}
+
+static int
+run_fork_exit(int pages)
+{
+  return run_fork_case("fork-exit", pages, 1, 0, 0);
+}
+
+static int
+run_fork_exec(int pages)
+{
+  return run_fork_case("fork-exec", pages, 1, 0, 1);
+}
+
+static int
+run_fork_write_sparse(int pages)
+{
+  return run_fork_case("fork-write-1of64", pages, 1, SPARSE_STRIDE, 0);
+}
+
+static int
+run_fork_write_quarter(int pages)
+{
+  return run_fork_case("fork-write-1of4", pages, 1, 4, 0);
+}
+
+static int
+run_fork_write_all(int pages)
+{
+  return run_fork_case("fork-write-all", pages, 1, 1, 0);
+}
+
+static int
+run_sparse_fork_exec(int pages)
+{
+  return run_fork_case("sparse-fork-exec", pages, SPARSE_STRIDE, 0, 1);
+}
+
+static struct scenario scenarios[] = {
+  { "reserve-only", run_reserve_only },
+  { "sparse-touch", run_sparse_touch },
+  { "dense-touch", run_dense_touch },
+  { "fork-exit", run_fork_exit },
+  { "fork-exec", run_fork_exec },
+  { "fork-write-1of64", run_fork_write_sparse },
+  { "fork-write-1of4", run_fork_write_quarter },
+  { "fork-write-all", run_fork_write_all },
+  { "sparse-fork-exec", run_sparse_fork_exec },
+};
+
+static int
+run_one(struct scenario *scenario, int pages)
+{
+  int status = 0;
+  int pid = fork();
+  if(pid < 0)
+    return -1;
+  if(pid == 0){
+    if(scenario->run(pages) < 0){
+      printf("VMERROR scenario=%s\n", scenario->name);
+      exit(1);
+    }
+    exit(0);
+  }
+  if(wait(&status) < 0 || status != 0)
+    return -1;
+  return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+  char *selected = "all";
+  int pages = DEFAULT_PAGES;
+
+  if(argc >= 2)
+    selected = argv[1];
+  if(argc >= 3)
+    pages = atoi(argv[2]);
+  if(pages <= 0 || pages > MAX_PAGES){
+    printf("usage: vmbench [all|scenario] [pages:1-%d]\n", MAX_PAGES);
+    exit(1);
+  }
+
+  int failures = 0;
+  int matched = 0;
+  for(uint i = 0; i < sizeof(scenarios) / sizeof(scenarios[0]); i++){
+    if(strcmp(selected, "all") != 0 && strcmp(selected, scenarios[i].name) != 0)
+      continue;
+    matched = 1;
+    if(run_one(&scenarios[i], pages) < 0){
+      printf("VMFAILED scenario=%s\n", scenarios[i].name);
+      failures++;
+    }
+  }
+
+  if(!matched){
+    printf("unknown scenario: %s\n", selected);
+    exit(1);
+  }
+  if(failures){
+    printf("VMbench completed with %d failure(s)\n", failures);
+    exit(1);
+  }
+  exit(0);
+}


### PR DESCRIPTION
Relates to #21

## 中心认知与范围

为 lazy allocation + eager fork copy 的 `lazy` 基线增加与其他三条实验分支一致的页表采样 ABI 和 QEMU benchmark，用于量化未访问页没有被物化，以及稀疏地址空间进入 fork 后仍发生的扫描和复制。

## 基线

- Base branch: `lazy`
- Base commit: `e68279d54acd8fd39bec96e4349f1e9f00607963`

## 关键文件

- `kernel/vmstat.h`：统一统计 ABI。
- `kernel/vmstat.c`：在受控同步点读取实际用户叶子页和父子物理页关系。
- `kernel/syscall.[ch]`：注册 `vmstat` 系统调用。
- `kernel/defs.h`：导出已有 `walk()` 供统计模块只读检查 PTE。
- `user/vmbench.c`：九组统一场景和机器可解析的 `VMRESULT`。
- `conf/lab.mk`：保留 lazy lab 配置并加入统计模块、`lazytests` 和 `vmbench`。

## 场景

- `reserve-only`
- `sparse-touch`
- `dense-touch`
- `fork-exit`
- `fork-exec`
- `fork-write-1of64`
- `fork-write-1of4`
- `fork-write-all`
- `sparse-fork-exec`

## 统计口径

- `range_eager_alloc`：`sbrk` 后立即存在的测试区间页。
- `range_lazy_alloc`：后续首次访问才出现的测试区间页。
- `range_fork_scan` 与 `range_fork_present`：区分“扫描虚拟地址”和“实际处理有效页”。
- `range_fork_copy`：eager fork 实际创建的私有副本。
- `range_*` 是跨分支主口径，`total_*` 只用于观察固定进程开销。

## 已完成验证

- 对新增内核统计模块和 `vmbench.c` 执行 RISC-V target 的 Clang `-Wall -Werror -fsyntax-only` 静态编译检查。
- 检查实验分支相对 `lazy` 基线只包含统计、用户程序、声明和构建接线改动。

## 待本机验证

本环境没有 xv6 所需的 RISC-V GCC/QEMU，以下项目尚未运行，不能标记为通过：

```bash
make clean
make
make qemu CPUS=1
```

QEMU 内待执行：

```text
vmbench all 4096
lazytests
usertests
```

## 教学边界

该实验统计固定 xv6 实现中的页级物化、扫描和复制数量，不把一次 QEMU 结果泛化为所有操作系统的 demand paging 性能。