### PR TITLE
test: 增加 lazy allocation 与 COW 四分支一键实验

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,6 @@
+include Makefile
+
+.DEFAULT_GOAL := vmbench-image
+
+.PHONY: vmbench-image
+vmbench-image: kernel/kernel fs.img

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OBJS = \
   $K/trap.o \
   $K/syscall.o \
   $K/sysproc.o \
+  $K/vmstat.o \
   $K/bio.o \
   $K/fs.o \
   $K/log.o \
@@ -149,7 +150,8 @@ UPROGS=\
 	$U/_uthread\
 	$U/_bigfile\
 	$U/_symlinktest\
-	$U/_mmaptest
+	$U/_mmaptest\
+	$U/_vmbench
 
 UEXTRA = user/xargstest.sh
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -111,29 +111,30 @@ extern uint64 sys_sigreturn(void);
 extern uint64 sys_symlink(void);
 extern uint64 sys_mmap(void);
 extern uint64 sys_munmap(void);
+extern uint64 sys_vmstat(void);
 
 static uint64 (*syscalls[])(void) = {
-[SYS_fork]    sys_fork,
-[SYS_exit]    sys_exit,
-[SYS_wait]    sys_wait,
-[SYS_pipe]    sys_pipe,
-[SYS_read]    sys_read,
-[SYS_kill]    sys_kill,
-[SYS_exec]    sys_exec,
-[SYS_fstat]   sys_fstat,
-[SYS_chdir]   sys_chdir,
-[SYS_dup]     sys_dup,
-[SYS_getpid]  sys_getpid,
-[SYS_sbrk]    sys_sbrk,
-[SYS_sleep]   sys_sleep,
-[SYS_uptime]  sys_uptime,
-[SYS_open]    sys_open,
-[SYS_write]   sys_write,
-[SYS_mknod]   sys_mknod,
-[SYS_unlink]  sys_unlink,
-[SYS_link]    sys_link,
-[SYS_mkdir]   sys_mkdir,
-[SYS_close]   sys_close,
+[SYS_fork]      sys_fork,
+[SYS_exit]      sys_exit,
+[SYS_wait]      sys_wait,
+[SYS_pipe]      sys_pipe,
+[SYS_read]      sys_read,
+[SYS_kill]      sys_kill,
+[SYS_exec]      sys_exec,
+[SYS_fstat]     sys_fstat,
+[SYS_chdir]     sys_chdir,
+[SYS_dup]       sys_dup,
+[SYS_getpid]    sys_getpid,
+[SYS_sbrk]      sys_sbrk,
+[SYS_sleep]     sys_sleep,
+[SYS_uptime]    sys_uptime,
+[SYS_open]      sys_open,
+[SYS_write]     sys_write,
+[SYS_mknod]     sys_mknod,
+[SYS_unlink]    sys_unlink,
+[SYS_link]      sys_link,
+[SYS_mkdir]     sys_mkdir,
+[SYS_close]     sys_close,
 [SYS_trace]     sys_trace,
 [SYS_sysinfo]   sys_sysinfo,
 [SYS_sigalarm]  sys_sigalarm,
@@ -141,6 +142,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_symlink]   sys_symlink,
 [SYS_mmap]      sys_mmap,
 [SYS_munmap]    sys_munmap,
+[SYS_vmstat]    sys_vmstat,
 };
 
 char *sysname[] = {
@@ -172,6 +174,7 @@ char *sysname[] = {
 [SYS_symlink]   "symlink",
 [SYS_mmap]      "mmap",
 [SYS_munmap]    "munmap",
+[SYS_vmstat]    "vmstat",
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -27,3 +27,4 @@
 #define SYS_symlink    26
 #define SYS_mmap       27
 #define SYS_munmap     28
+#define SYS_vmstat     29

--- a/kernel/vmstat.c
+++ b/kernel/vmstat.c
@@ -1,0 +1,288 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "defs.h"
+#include "vmstat.h"
+
+#ifndef PTE_COW
+#define PTE_COW (1L << 8)
+#endif
+
+extern struct proc proc[NPROC];
+
+struct mapping_summary {
+  uint64 scanned;
+  uint64 present;
+  uint64 private_pages;
+  uint64 shared_pages;
+  uint64 cow_pages;
+};
+
+struct vmstat_state {
+  struct spinlock lock;
+  int initialized;
+  int active;
+  int root_pid;
+  int child_pid;
+  uint64 range_start;
+  uint64 range_end;
+  uint64 begin_total_present;
+  uint64 begin_range_present;
+  struct vmstat_snapshot snapshot;
+};
+
+static struct vmstat_state state;
+
+static void
+vmstat_init_once(void)
+{
+  if(state.initialized)
+    return;
+  initlock(&state.lock, "vmstat");
+  state.initialized = 1;
+}
+
+static int
+user_leaf(pagetable_t pagetable, uint64 va, pte_t *value)
+{
+  pte_t *pte = walk(pagetable, va, 0);
+  if(pte == 0 || (*pte & PTE_V) == 0 || (*pte & PTE_U) == 0)
+    return 0;
+  if((*pte & (PTE_R | PTE_W | PTE_X)) == 0)
+    return 0;
+  if(value)
+    *value = *pte;
+  return 1;
+}
+
+static uint64
+count_present(pagetable_t pagetable, uint64 sz, uint64 start, uint64 end)
+{
+  uint64 count = 0;
+  uint64 first = PGROUNDDOWN(start);
+  uint64 limit = PGROUNDUP(end);
+  if(limit > PGROUNDUP(sz))
+    limit = PGROUNDUP(sz);
+  for(uint64 va = first; va < limit; va += PGSIZE)
+    if(user_leaf(pagetable, va, 0))
+      count++;
+  return count;
+}
+
+static void
+scan_relation(struct proc *parent, struct proc *child,
+              uint64 start, uint64 end, struct mapping_summary *summary)
+{
+  memset(summary, 0, sizeof(*summary));
+  uint64 first = PGROUNDDOWN(start);
+  uint64 limit = PGROUNDUP(end);
+  if(limit > PGROUNDUP(parent->sz))
+    limit = PGROUNDUP(parent->sz);
+
+  for(uint64 va = first; va < limit; va += PGSIZE){
+    pte_t parent_pte;
+    pte_t child_pte;
+    summary->scanned++;
+    if(!user_leaf(parent->pagetable, va, &parent_pte))
+      continue;
+    summary->present++;
+    if(!user_leaf(child->pagetable, va, &child_pte))
+      continue;
+    if(PTE2PA(parent_pte) == PTE2PA(child_pte))
+      summary->shared_pages++;
+    else
+      summary->private_pages++;
+    if((parent_pte & PTE_COW) || (child_pte & PTE_COW))
+      summary->cow_pages++;
+  }
+}
+
+static struct proc *
+find_proc_locked(int pid)
+{
+  for(struct proc *p = proc; p < &proc[NPROC]; p++){
+    acquire(&p->lock);
+    if(p->pid == pid && p->state != UNUSED)
+      return p;
+    release(&p->lock);
+  }
+  return 0;
+}
+
+static void
+record_fork_counts(struct vmstat_counts *counts,
+                   const struct mapping_summary *summary)
+{
+  counts->fork_va_scan_pages = summary->scanned;
+  counts->fork_present_pages = summary->present;
+  counts->fork_eager_copy_pages = summary->private_pages;
+  counts->fork_shared_map_pages = summary->shared_pages;
+  counts->fork_cow_mark_pages = summary->cow_pages;
+}
+
+static uint64
+additional_private_pages(uint64 current_private, uint64 fork_private)
+{
+  return current_private > fork_private ? current_private - fork_private : 0;
+}
+
+static int
+vmstat_begin(struct proc *caller, uint64 start, uint64 end)
+{
+  if(end <= start || end > MAXVA)
+    return -1;
+  acquire(&state.lock);
+  state.active = 1;
+  state.root_pid = caller->pid;
+  state.child_pid = 0;
+  state.range_start = start;
+  state.range_end = end;
+  memset(&state.snapshot, 0, sizeof(state.snapshot));
+  state.snapshot.abi_version = VMSTAT_ABI_VERSION;
+  state.snapshot.range_start = start;
+  state.snapshot.range_end = end;
+  state.begin_total_present = count_present(caller->pagetable, caller->sz, 0, caller->sz);
+  state.begin_range_present = count_present(caller->pagetable, caller->sz, start, end);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_sbrk(struct proc *caller, uint64 oldsz, uint64 newsz)
+{
+  if(newsz < oldsz)
+    return -1;
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid){
+    release(&state.lock);
+    return -1;
+  }
+
+  for(uint64 va = PGROUNDUP(oldsz); va < PGROUNDUP(newsz); va += PGSIZE){
+    state.snapshot.total.virtual_grow_pages++;
+    if(user_leaf(caller->pagetable, va, 0))
+      state.snapshot.total.sbrk_eager_alloc_pages++;
+    if(va >= PGROUNDDOWN(state.range_start) && va < PGROUNDUP(state.range_end)){
+      state.snapshot.range.virtual_grow_pages++;
+      if(user_leaf(caller->pagetable, va, 0))
+        state.snapshot.range.sbrk_eager_alloc_pages++;
+    }
+  }
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_fork(struct proc *caller, int child_pid)
+{
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid || child_pid <= 0){
+    release(&state.lock);
+    return -1;
+  }
+  struct proc *child = find_proc_locked(child_pid);
+  if(child == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct mapping_summary total;
+  struct mapping_summary range;
+  scan_relation(caller, child, 0, caller->sz, &total);
+  scan_relation(caller, child, state.range_start, state.range_end, &range);
+  record_fork_counts(&state.snapshot.total, &total);
+  record_fork_counts(&state.snapshot.range, &range);
+  state.child_pid = child_pid;
+  release(&child->lock);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_sample_child(struct proc *caller)
+{
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.child_pid){
+    release(&state.lock);
+    return -1;
+  }
+  struct proc *root = find_proc_locked(state.root_pid);
+  if(root == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  struct mapping_summary total;
+  struct mapping_summary range;
+  scan_relation(root, caller, 0, root->sz, &total);
+  scan_relation(root, caller, state.range_start, state.range_end, &range);
+  state.snapshot.total.cow_copy_pages = additional_private_pages(
+    total.private_pages, state.snapshot.total.fork_eager_copy_pages);
+  state.snapshot.range.cow_copy_pages = additional_private_pages(
+    range.private_pages, state.snapshot.range.fork_eager_copy_pages);
+  release(&root->lock);
+  release(&state.lock);
+  return 0;
+}
+
+static int
+vmstat_end(struct proc *caller, uint64 user_dst)
+{
+  struct vmstat_snapshot snapshot;
+  acquire(&state.lock);
+  if(!state.active || caller->pid != state.root_pid || user_dst == 0){
+    release(&state.lock);
+    return -1;
+  }
+
+  uint64 total_present = count_present(caller->pagetable, caller->sz, 0, caller->sz);
+  uint64 range_present = count_present(caller->pagetable, caller->sz,
+                                       state.range_start, state.range_end);
+  state.snapshot.total.final_present_pages = total_present;
+  state.snapshot.range.final_present_pages = range_present;
+  uint64 total_known = state.begin_total_present + state.snapshot.total.sbrk_eager_alloc_pages;
+  uint64 range_known = state.begin_range_present + state.snapshot.range.sbrk_eager_alloc_pages;
+  if(total_present > total_known)
+    state.snapshot.total.lazy_materialized_pages = total_present - total_known;
+  if(range_present > range_known)
+    state.snapshot.range.lazy_materialized_pages = range_present - range_known;
+
+  snapshot = state.snapshot;
+  state.active = 0;
+  release(&state.lock);
+  if(copyout(caller->pagetable, user_dst, (char *)&snapshot, sizeof(snapshot)) < 0)
+    return -1;
+  return 0;
+}
+
+uint64
+sys_vmstat(void)
+{
+  int op;
+  uint64 arg0;
+  uint64 arg1;
+  uint64 user_dst;
+  vmstat_init_once();
+  if(argint(0, &op) < 0 || argaddr(1, &arg0) < 0 ||
+     argaddr(2, &arg1) < 0 || argaddr(3, &user_dst) < 0)
+    return -1;
+
+  struct proc *caller = myproc();
+  switch(op){
+  case VMSTAT_BEGIN:
+    return vmstat_begin(caller, arg0, arg1);
+  case VMSTAT_SAMPLE_SBRK:
+    return vmstat_sample_sbrk(caller, arg0, arg1);
+  case VMSTAT_SAMPLE_FORK:
+    return vmstat_sample_fork(caller, (int)arg0);
+  case VMSTAT_SAMPLE_CHILD:
+    return vmstat_sample_child(caller);
+  case VMSTAT_END:
+    return vmstat_end(caller, user_dst);
+  default:
+    return -1;
+  }
+}

--- a/kernel/vmstat.h
+++ b/kernel/vmstat.h
@@ -1,0 +1,33 @@
+#ifndef XV6_VMSTAT_H
+#define XV6_VMSTAT_H
+
+#define VMSTAT_ABI_VERSION 1
+
+#define VMSTAT_BEGIN         1
+#define VMSTAT_SAMPLE_SBRK   2
+#define VMSTAT_SAMPLE_FORK   3
+#define VMSTAT_SAMPLE_CHILD  4
+#define VMSTAT_END           5
+
+struct vmstat_counts {
+  uint64 virtual_grow_pages;
+  uint64 sbrk_eager_alloc_pages;
+  uint64 lazy_materialized_pages;
+  uint64 fork_va_scan_pages;
+  uint64 fork_present_pages;
+  uint64 fork_eager_copy_pages;
+  uint64 fork_shared_map_pages;
+  uint64 fork_cow_mark_pages;
+  uint64 cow_copy_pages;
+  uint64 final_present_pages;
+};
+
+struct vmstat_snapshot {
+  uint64 abi_version;
+  uint64 range_start;
+  uint64 range_end;
+  struct vmstat_counts total;
+  struct vmstat_counts range;
+};
+
+#endif

--- a/tools/vmbench_compare.py
+++ b/tools/vmbench_compare.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Compare VMRESULT lines produced by the four xv6 vmbench branches."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_VARIANTS = ("pristine", "lazy", "cow", "main")
+RESULT_PREFIX = "VMRESULT "
+PAIR_RE = re.compile(r"(?P<key>[A-Za-z0-9_]+)=(?P<value>[^\s]+)")
+
+
+def parse_log(path: Path) -> dict[str, dict[str, int | str]]:
+    results: dict[str, dict[str, int | str]] = {}
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        marker = raw_line.find(RESULT_PREFIX)
+        if marker < 0:
+            continue
+        line = raw_line[marker + len(RESULT_PREFIX) :]
+        row: dict[str, int | str] = {}
+        for match in PAIR_RE.finditer(line):
+            key = match.group("key")
+            value = match.group("value")
+            try:
+                row[key] = int(value, 0)
+            except ValueError:
+                row[key] = value
+        scenario = row.get("scenario")
+        if not isinstance(scenario, str):
+            raise ValueError(f"{path}: malformed VMRESULT without scenario: {raw_line}")
+        if scenario in results:
+            raise ValueError(f"{path}: duplicate scenario {scenario!r}")
+        results[scenario] = row
+    if not results:
+        raise ValueError(f"{path}: no VMRESULT lines found")
+    return results
+
+
+def metric(row: dict[str, int | str], key: str) -> int:
+    value = row.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"missing integer metric {key!r} in scenario {row.get('scenario')!r}")
+    return value
+
+
+def derived(row: dict[str, int | str]) -> dict[str, int]:
+    materialized = metric(row, "range_eager_alloc") + metric(row, "range_lazy_alloc")
+    copied = metric(row, "range_fork_copy") + metric(row, "range_cow_copy")
+    return {
+        "range_materialized": materialized,
+        "range_copy_work": copied,
+        "range_total_page_work": materialized + copied,
+        "range_hole_scan": metric(row, "range_fork_scan") - metric(row, "range_fork_present"),
+    }
+
+
+def validate_inputs(data: dict[str, dict[str, dict[str, int | str]]]) -> list[str]:
+    scenario_sets = {variant: set(rows) for variant, rows in data.items()}
+    expected = scenario_sets[REQUIRED_VARIANTS[0]]
+    for variant, scenarios in scenario_sets.items():
+        if scenarios != expected:
+            missing = sorted(expected - scenarios)
+            extra = sorted(scenarios - expected)
+            raise ValueError(f"{variant}: scenario mismatch; missing={missing}, extra={extra}")
+
+    ordered = sorted(expected)
+    for scenario in ordered:
+        pages = {metric(data[variant][scenario], "pages") for variant in REQUIRED_VARIANTS}
+        if len(pages) != 1:
+            raise ValueError(f"{scenario}: branches used different page counts: {sorted(pages)}")
+    return ordered
+
+
+def build_rows(
+    data: dict[str, dict[str, dict[str, int | str]]], scenarios: list[str]
+) -> list[dict[str, int | str]]:
+    output: list[dict[str, int | str]] = []
+    for scenario in scenarios:
+        pristine = derived(data["pristine"][scenario])
+        for variant in REQUIRED_VARIANTS:
+            raw = data[variant][scenario]
+            values = derived(raw)
+            output.append(
+                {
+                    "scenario": scenario,
+                    "variant": variant,
+                    "pages": metric(raw, "pages"),
+                    **values,
+                    "saved_materialized_vs_pristine": pristine["range_materialized"]
+                    - values["range_materialized"],
+                    "saved_copy_vs_pristine": pristine["range_copy_work"]
+                    - values["range_copy_work"],
+                    "saved_total_page_work_vs_pristine": pristine["range_total_page_work"]
+                    - values["range_total_page_work"],
+                    "range_fork_shared": metric(raw, "range_fork_shared"),
+                    "range_cow_mark": metric(raw, "range_cow_mark"),
+                }
+            )
+    return output
+
+
+def print_markdown(rows: list[dict[str, int | str]]) -> None:
+    columns = (
+        "scenario",
+        "variant",
+        "range_materialized",
+        "range_copy_work",
+        "range_total_page_work",
+        "saved_materialized_vs_pristine",
+        "saved_copy_vs_pristine",
+        "saved_total_page_work_vs_pristine",
+        "range_hole_scan",
+    )
+    print("| " + " | ".join(columns) + " |")
+    print("| " + " | ".join("---" for _ in columns) + " |")
+    for row in rows:
+        print("| " + " | ".join(str(row[column]) for column in columns) + " |")
+
+
+def write_csv(path: Path, rows: list[dict[str, int | str]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_assignment(value: str) -> tuple[str, Path]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("expected VARIANT=LOG_PATH")
+    variant, path = value.split("=", 1)
+    if variant not in REQUIRED_VARIANTS:
+        raise argparse.ArgumentTypeError(
+            f"variant must be one of {', '.join(REQUIRED_VARIANTS)}"
+        )
+    return variant, Path(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "logs",
+        nargs=4,
+        type=parse_assignment,
+        metavar="VARIANT=LOG",
+        help="one log for each of pristine, lazy, cow, and main",
+    )
+    parser.add_argument("--csv", type=Path, help="also write the full comparison as CSV")
+    args = parser.parse_args()
+
+    assignments = dict(args.logs)
+    missing = [variant for variant in REQUIRED_VARIANTS if variant not in assignments]
+    if missing:
+        parser.error(f"missing variants: {', '.join(missing)}")
+
+    try:
+        data = {variant: parse_log(assignments[variant]) for variant in REQUIRED_VARIANTS}
+        scenarios = validate_inputs(data)
+        rows = build_rows(data, scenarios)
+    except (OSError, ValueError) as error:
+        print(f"vmbench_compare: {error}", file=sys.stderr)
+        return 1
+
+    print_markdown(rows)
+    if args.csv:
+        write_csv(args.csv, rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vmbench_compare.py
+++ b/tools/vmbench_compare.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare VMRESULT lines produced by the four xv6 vmbench branches."""
+"""Compare VMRESULT lines and render CSV/Markdown/SVG reports."""
 
 from __future__ import annotations
 
@@ -7,11 +7,29 @@ import argparse
 import csv
 import re
 import sys
+from html import escape
 from pathlib import Path
 
 REQUIRED_VARIANTS = ("pristine", "lazy", "cow", "main")
+SCENARIO_ORDER = (
+    "reserve-only",
+    "sparse-touch",
+    "dense-touch",
+    "fork-exit",
+    "fork-exec",
+    "fork-write-1of64",
+    "fork-write-1of4",
+    "fork-write-all",
+    "sparse-fork-exec",
+)
 RESULT_PREFIX = "VMRESULT "
 PAIR_RE = re.compile(r"(?P<key>[A-Za-z0-9_]+)=(?P<value>[^\s]+)")
+VARIANT_COLORS = {
+    "pristine": "#4e79a7",
+    "lazy": "#59a14f",
+    "cow": "#f28e2b",
+    "main": "#e15759",
+}
 
 
 def parse_log(path: Path) -> dict[str, dict[str, int | str]]:
@@ -67,7 +85,8 @@ def validate_inputs(data: dict[str, dict[str, dict[str, int | str]]]) -> list[st
             extra = sorted(scenarios - expected)
             raise ValueError(f"{variant}: scenario mismatch; missing={missing}, extra={extra}")
 
-    ordered = sorted(expected)
+    ordered = [scenario for scenario in SCENARIO_ORDER if scenario in expected]
+    ordered.extend(sorted(expected - set(ordered)))
     for scenario in ordered:
         pages = {metric(data[variant][scenario], "pages") for variant in REQUIRED_VARIANTS}
         if len(pages) != 1:
@@ -103,31 +122,189 @@ def build_rows(
     return output
 
 
-def print_markdown(rows: list[dict[str, int | str]]) -> None:
-    columns = (
-        "scenario",
-        "variant",
-        "range_materialized",
-        "range_copy_work",
-        "range_total_page_work",
-        "saved_materialized_vs_pristine",
-        "saved_copy_vs_pristine",
-        "saved_total_page_work_vs_pristine",
-        "range_hole_scan",
-    )
-    print("| " + " | ".join(columns) + " |")
-    print("| " + " | ".join("---" for _ in columns) + " |")
+TABLE_COLUMNS = (
+    "scenario",
+    "variant",
+    "range_materialized",
+    "range_copy_work",
+    "range_total_page_work",
+    "saved_materialized_vs_pristine",
+    "saved_copy_vs_pristine",
+    "saved_total_page_work_vs_pristine",
+    "range_hole_scan",
+    "range_fork_shared",
+    "range_cow_mark",
+)
+
+
+def markdown_text(rows: list[dict[str, int | str]]) -> str:
+    lines = [
+        "| " + " | ".join(TABLE_COLUMNS) + " |",
+        "| " + " | ".join("---" for _ in TABLE_COLUMNS) + " |",
+    ]
     for row in rows:
-        print("| " + " | ".join(str(row[column]) for column in columns) + " |")
+        lines.append("| " + " | ".join(str(row[column]) for column in TABLE_COLUMNS) + " |")
+    return "\n".join(lines) + "\n"
 
 
 def write_csv(path: Path, rows: list[dict[str, int | str]]) -> None:
     if not rows:
         return
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="", encoding="utf-8") as stream:
         writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _nice_ticks(low: float, high: float, count: int = 5) -> list[float]:
+    if high <= low:
+        high = low + 1
+    raw_step = (high - low) / count
+    magnitude = 10 ** max(0, len(str(int(raw_step))) - 1) if raw_step >= 1 else 1
+    normalized = raw_step / magnitude
+    if normalized <= 1:
+        step = 1 * magnitude
+    elif normalized <= 2:
+        step = 2 * magnitude
+    elif normalized <= 5:
+        step = 5 * magnitude
+    else:
+        step = 10 * magnitude
+    start = int(low // step) * step
+    ticks: list[float] = []
+    value = start
+    while value <= high + step:
+        if value >= low:
+            ticks.append(value)
+        value += step
+    return ticks or [low, high]
+
+
+def write_svg_chart(
+    path: Path,
+    rows: list[dict[str, int | str]],
+    scenarios: list[str],
+    metric_key: str,
+    title: str,
+    y_label: str,
+) -> None:
+    width, height = 1280, 760
+    left, right, top, bottom = 100, 40, 80, 210
+    plot_w = width - left - right
+    plot_h = height - top - bottom
+
+    indexed = {(str(row["scenario"]), str(row["variant"])): row for row in rows}
+    values = [
+        int(indexed[(scenario, variant)][metric_key])
+        for scenario in scenarios
+        for variant in REQUIRED_VARIANTS
+    ]
+    low = min(0, min(values))
+    high = max(values)
+    if high == low:
+        high = low + 1
+    padding = max(1.0, (high - low) * 0.08)
+    y_min = low - (padding if low < 0 else 0)
+    y_max = high + padding
+    ticks = _nice_ticks(y_min, y_max)
+    y_min = min(y_min, min(ticks))
+    y_max = max(y_max, max(ticks))
+
+    def x_pos(index: int) -> float:
+        if len(scenarios) == 1:
+            return left + plot_w / 2
+        return left + index * plot_w / (len(scenarios) - 1)
+
+    def y_pos(value: float) -> float:
+        return top + (y_max - value) * plot_h / (y_max - y_min)
+
+    svg: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        '<style>text{font-family:system-ui,-apple-system,"Segoe UI",sans-serif;fill:#222}.grid{stroke:#ddd;stroke-width:1}.axis{stroke:#333;stroke-width:1.5}.line{fill:none;stroke-width:3}.point{stroke:white;stroke-width:1.5}</style>',
+        f'<text x="{width/2}" y="38" text-anchor="middle" font-size="24" font-weight="600">{escape(title)}</text>',
+    ]
+
+    for tick in ticks:
+        y = y_pos(tick)
+        svg.append(
+            f'<line class="grid" x1="{left}" y1="{y:.2f}" x2="{width-right}" y2="{y:.2f}"/>'
+        )
+        label = str(int(tick)) if float(tick).is_integer() else f"{tick:.2f}"
+        svg.append(
+            f'<text x="{left-12}" y="{y+5:.2f}" text-anchor="end" font-size="14">{label}</text>'
+        )
+
+    svg.append(
+        f'<line class="axis" x1="{left}" y1="{top}" x2="{left}" y2="{top+plot_h}"/>'
+    )
+    svg.append(
+        f'<line class="axis" x1="{left}" y1="{top+plot_h}" x2="{width-right}" y2="{top+plot_h}"/>'
+    )
+    svg.append(
+        f'<text x="24" y="{top+plot_h/2}" text-anchor="middle" font-size="16" transform="rotate(-90 24 {top+plot_h/2})">{escape(y_label)}</text>'
+    )
+
+    for index, scenario in enumerate(scenarios):
+        x = x_pos(index)
+        svg.append(
+            f'<line class="grid" x1="{x:.2f}" y1="{top}" x2="{x:.2f}" y2="{top+plot_h}"/>'
+        )
+        svg.append(
+            f'<text x="{x:.2f}" y="{top+plot_h+24}" text-anchor="end" font-size="13" transform="rotate(-38 {x:.2f} {top+plot_h+24})">{escape(scenario)}</text>'
+        )
+
+    for variant in REQUIRED_VARIANTS:
+        color = VARIANT_COLORS[variant]
+        points = [
+            (x_pos(index), y_pos(int(indexed[(scenario, variant)][metric_key])))
+            for index, scenario in enumerate(scenarios)
+        ]
+        point_text = " ".join(f"{x:.2f},{y:.2f}" for x, y in points)
+        svg.append(f'<polyline class="line" stroke="{color}" points="{point_text}"/>')
+        for (x, y), scenario in zip(points, scenarios):
+            value = indexed[(scenario, variant)][metric_key]
+            svg.append(
+                f'<circle class="point" fill="{color}" cx="{x:.2f}" cy="{y:.2f}" r="5"><title>{escape(variant)} / {escape(scenario)}: {value}</title></circle>'
+            )
+
+    legend_y = height - 38
+    legend_x = left
+    for variant in REQUIRED_VARIANTS:
+        color = VARIANT_COLORS[variant]
+        svg.append(
+            f'<line x1="{legend_x}" y1="{legend_y}" x2="{legend_x+34}" y2="{legend_y}" stroke="{color}" stroke-width="4"/>'
+        )
+        svg.append(
+            f'<text x="{legend_x+43}" y="{legend_y+5}" font-size="15">{escape(variant)}</text>'
+        )
+        legend_x += 190
+
+    svg.append("</svg>")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(svg) + "\n", encoding="utf-8")
+
+
+def write_svg_reports(
+    directory: Path, rows: list[dict[str, int | str]], scenarios: list[str]
+) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    specs = (
+        ("01-materialized-pages.svg", "range_materialized", "用户数据页物化数量", "pages"),
+        ("02-copy-work-pages.svg", "range_copy_work", "fork/COW 整页复制工作", "pages"),
+        ("03-total-page-work.svg", "range_total_page_work", "物化与复制总页级工作", "pages"),
+        (
+            "04-saved-total-vs-pristine.svg",
+            "saved_total_page_work_vs_pristine",
+            "相对 pristine 避免的总页级工作",
+            "saved pages",
+        ),
+        ("05-fork-shared-pages.svg", "range_fork_shared", "fork 后共享物理页数量", "pages"),
+        ("06-hole-scan-pages.svg", "range_hole_scan", "fork 扫描但未映射的虚拟页", "pages"),
+    )
+    for filename, key, title, label in specs:
+        write_svg_chart(directory / filename, rows, scenarios, key, title, label)
 
 
 def parse_assignment(value: str) -> tuple[str, Path]:
@@ -150,7 +327,9 @@ def main() -> int:
         metavar="VARIANT=LOG",
         help="one log for each of pristine, lazy, cow, and main",
     )
-    parser.add_argument("--csv", type=Path, help="also write the full comparison as CSV")
+    parser.add_argument("--csv", type=Path, help="write the full comparison as CSV")
+    parser.add_argument("--markdown", type=Path, help="write the Markdown comparison table")
+    parser.add_argument("--svg-dir", type=Path, help="write SVG line charts into this directory")
     args = parser.parse_args()
 
     assignments = dict(args.logs)
@@ -159,16 +338,24 @@ def main() -> int:
         parser.error(f"missing variants: {', '.join(missing)}")
 
     try:
-        data = {variant: parse_log(assignments[variant]) for variant in REQUIRED_VARIANTS}
+        data = {
+            variant: parse_log(assignments[variant]) for variant in REQUIRED_VARIANTS
+        }
         scenarios = validate_inputs(data)
         rows = build_rows(data, scenarios)
+        markdown = markdown_text(rows)
+        if args.csv:
+            write_csv(args.csv, rows)
+        if args.markdown:
+            args.markdown.parent.mkdir(parents=True, exist_ok=True)
+            args.markdown.write_text(markdown, encoding="utf-8")
+        if args.svg_dir:
+            write_svg_reports(args.svg_dir, rows, scenarios)
     except (OSError, ValueError) as error:
         print(f"vmbench_compare: {error}", file=sys.stderr)
         return 1
 
-    print_markdown(rows)
-    if args.csv:
-        write_csv(args.csv, rows)
+    print(markdown, end="")
     return 0
 
 

--- a/tools/vmbench_manual.sh
+++ b/tools/vmbench_manual.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly REMOTE="${REMOTE:-origin}"
+readonly PAGES="${PAGES:-4096}"
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+readonly RESULT="${RESULT:-$REPO_ROOT/../xv6-vmbench-results/manual-$(date +%Y%m%d-%H%M%S)}"
+readonly WORKTREE_ROOT="$(mktemp -d /tmp/xv6-vmbench-manual-XXXXXX)"
+
+readonly -a VARIANTS=(pristine lazy cow main)
+readonly -a BRANCHES=(
+  concept/21-vmbench-pristine
+  concept/21-vmbench-lazy
+  concept/21-vmbench-cow
+  concept/21-vmbench-main
+)
+
+created_worktrees=()
+
+cleanup() {
+  local worktree
+  for worktree in "${created_worktrees[@]:-}"; do
+    git -C "$REPO_ROOT" worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  done
+  git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1 || true
+  rm -rf "$WORKTREE_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "缺少命令：$1" >&2
+    exit 1
+  }
+}
+
+for command in git make python3 qemu-system-riscv64 script; do
+  require_command "$command"
+done
+
+mkdir -p "$RESULT/build" "$RESULT/logs" "$RESULT/charts"
+: > "$RESULT/commits.txt"
+
+echo "拉取实验分支..."
+git -C "$REPO_ROOT" fetch --prune "$REMOTE"
+
+run_variant() {
+  local variant="$1"
+  local branch="$2"
+  local worktree="$WORKTREE_ROOT/$variant"
+  local build_log="$RESULT/build/$variant.log"
+  local qemu_log="$RESULT/logs/$variant.log"
+  local count answer
+
+  echo
+  echo "============================================================"
+  echo "实验基线：$variant"
+  echo "远端分支：$REMOTE/$branch"
+  echo "============================================================"
+
+  git -C "$REPO_ROOT" worktree add --detach "$worktree" "$REMOTE/$branch"
+  created_worktrees+=("$worktree")
+
+  printf '%s %s %s\n' \
+    "$variant" \
+    "$branch" \
+    "$(git -C "$worktree" rev-parse HEAD)" >> "$RESULT/commits.txt"
+
+  echo "编译 $variant：make clean && make kernel/kernel fs.img"
+  {
+    make -C "$worktree" clean
+    make -C "$worktree" kernel/kernel fs.img
+  } >"$build_log" 2>&1
+
+  while true; do
+    rm -f "$qemu_log"
+
+    echo
+    echo "即将进入 $variant 的 xv6 shell。"
+    echo "看到 \$ 提示符后，只需输入："
+    echo
+    echo "  vmbench all $PAGES"
+    echo
+    echo "等待输出结束并再次出现 \$ 后退出 QEMU："
+    echo "  先按 Ctrl-A，松开，再按 X"
+    echo
+    read -r -p "按 Enter 启动 QEMU... " _
+
+    (
+      cd "$worktree"
+      script -q -f -c "make qemu CPUS=1" "$qemu_log"
+    )
+
+    count="$(grep -a -c 'VMRESULT ' "$qemu_log" || true)"
+    if [[ "$count" == "9" ]] \
+      && ! grep -a -qE 'VMFAILED |VMERROR ' "$qemu_log"; then
+      echo "[$variant] 采集成功：9 条 VMRESULT"
+      break
+    fi
+
+    echo
+    echo "[$variant] 采集不完整：发现 $count 条 VMRESULT，预期为 9 条。" >&2
+    echo "日志：$qemu_log" >&2
+    read -r -p "重新运行当前基线？[Y/n] " answer
+    case "${answer:-Y}" in
+      n|N|no|NO)
+        exit 1
+        ;;
+    esac
+  done
+}
+
+for index in "${!VARIANTS[@]}"; do
+  run_variant "${VARIANTS[$index]}" "${BRANCHES[$index]}"
+done
+
+readonly MAIN_WORKTREE="$WORKTREE_ROOT/main"
+readonly COMPARE_SCRIPT="$MAIN_WORKTREE/tools/vmbench_compare.py"
+
+echo
+echo "生成 CSV、Markdown 和 SVG..."
+python3 "$COMPARE_SCRIPT" \
+  "pristine=$RESULT/logs/pristine.log" \
+  "lazy=$RESULT/logs/lazy.log" \
+  "cow=$RESULT/logs/cow.log" \
+  "main=$RESULT/logs/main.log" \
+  --csv "$RESULT/vmbench-results.csv" \
+  --markdown "$RESULT/vmbench-results.md" \
+  --svg-dir "$RESULT/charts" \
+  | tee "$RESULT/compare.stdout.md"
+
+python3 - "$RESULT" "$PAGES" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+result = Path(sys.argv[1])
+pages = int(sys.argv[2])
+commits = []
+for line in (result / "commits.txt").read_text(encoding="utf-8").splitlines():
+    variant, branch, commit = line.split()
+    commits.append({"variant": variant, "branch": branch, "commit": commit})
+manifest = {
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "pages": pages,
+    "cpus": 1,
+    "mode": "interactive-qemu",
+    "records": commits,
+}
+(result / "manifest.json").write_text(
+    json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+echo
+echo "VMRESULT 数量："
+grep -aHc 'VMRESULT ' "$RESULT"/logs/*.log
+
+echo
+echo "完成。结果目录："
+echo "$RESULT"
+echo
+echo "主要产物："
+printf '  %s\n' \
+  "$RESULT/vmbench-results.csv" \
+  "$RESULT/vmbench-results.md" \
+  "$RESULT/compare.stdout.md" \
+  "$RESULT/manifest.json" \
+  "$RESULT/charts/"
+echo
+echo "打包命令："
+echo "tar -C \"$(dirname "$RESULT")\" -czf \"$RESULT.tar.gz\" \"$(basename "$RESULT")\""

--- a/tools/vmbench_run_all.py
+++ b/tools/vmbench_run_all.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Build and run all four xv6 vmbench variants, then render reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pty
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+VARIANTS = {
+    "pristine": "concept/21-vmbench-pristine",
+    "lazy": "concept/21-vmbench-lazy",
+    "cow": "concept/21-vmbench-cow",
+    "main": "concept/21-vmbench-main",
+}
+EXPECTED_RESULTS = 9
+PROMPT = b"$ "
+
+
+@dataclass
+class RunRecord:
+    variant: str
+    branch: str
+    commit: str
+    worktree: str
+    build_log: str
+    qemu_log: str
+    build_ok: bool = False
+    qemu_ok: bool = False
+
+
+def run_checked(
+    command: list[str],
+    *,
+    cwd: Path,
+    log_path: Path | None = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    if log_path:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("w", encoding="utf-8") as stream:
+            return subprocess.run(
+                command,
+                cwd=cwd,
+                text=True,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                check=True,
+            )
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=capture,
+        check=True,
+    )
+
+
+def git_output(repo: Path, *args: str) -> str:
+    result = run_checked(["git", *args], cwd=repo, capture=True)
+    return result.stdout.strip()
+
+
+def ensure_prerequisites(repo: Path, *, require_runtime: bool) -> None:
+    commands = ["git", "make"]
+    if require_runtime:
+        commands.append("qemu-system-riscv64")
+    missing = [name for name in commands if shutil.which(name) is None]
+    if missing:
+        raise RuntimeError("missing required commands: " + ", ".join(missing))
+    git_output(repo, "rev-parse", "--git-dir")
+
+
+def wait_for(
+    master_fd: int,
+    process: subprocess.Popen[bytes],
+    log_stream,
+    predicate,
+    *,
+    timeout: int,
+    description: str,
+) -> bytes:
+    deadline = time.monotonic() + timeout
+    buffer = bytearray()
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"QEMU exited before {description}; exit={process.returncode}"
+            )
+        ready, _, _ = select.select([master_fd], [], [], 0.5)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(master_fd, 65536)
+        except OSError as error:
+            raise RuntimeError(
+                f"failed reading QEMU output while waiting for {description}: {error}"
+            ) from error
+        if not chunk:
+            continue
+        log_stream.buffer.write(chunk)
+        log_stream.flush()
+        buffer.extend(chunk)
+        if len(buffer) > 2_000_000:
+            del buffer[: len(buffer) - 1_000_000]
+        if predicate(bytes(buffer)):
+            return bytes(buffer)
+    raise TimeoutError(f"timed out after {timeout}s waiting for {description}")
+
+
+def terminate_qemu(master_fd: int, process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.write(master_fd, b"\x01x")
+        process.wait(timeout=8)
+        return
+    except Exception:
+        pass
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def run_qemu(
+    worktree: Path,
+    log_path: Path,
+    *,
+    pages: int,
+    timeout: int,
+    regression_commands: list[str],
+) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    master_fd, slave_fd = pty.openpty()
+    process = subprocess.Popen(
+        ["make", "qemu", "CPUS=1"],
+        cwd=worktree,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+        start_new_session=True,
+    )
+    os.close(slave_fd)
+
+    try:
+        with log_path.open("w", encoding="utf-8", errors="replace") as log_stream:
+            wait_for(
+                master_fd,
+                process,
+                log_stream,
+                lambda data: PROMPT in data,
+                timeout=timeout,
+                description="xv6 shell prompt",
+            )
+
+            os.write(master_fd, f"vmbench all {pages}\n".encode())
+            output = wait_for(
+                master_fd,
+                process,
+                log_stream,
+                lambda data: data.count(b"VMRESULT ") >= EXPECTED_RESULTS
+                and data.rstrip().endswith(b"$"),
+                timeout=timeout,
+                description=f"{EXPECTED_RESULTS} VMRESULT lines",
+            )
+            if b"VMFAILED " in output or b"VMERROR " in output:
+                raise RuntimeError(
+                    "vmbench reported VMFAILED/VMERROR; inspect the QEMU log"
+                )
+
+            for regression in regression_commands:
+                os.write(master_fd, (regression + "\n").encode())
+                wait_for(
+                    master_fd,
+                    process,
+                    log_stream,
+                    lambda data: data.rstrip().endswith(b"$"),
+                    timeout=timeout,
+                    description=f"completion of {regression}",
+                )
+    finally:
+        terminate_qemu(master_fd, process)
+        os.close(master_fd)
+
+
+def add_worktree(repo: Path, directory: Path, ref: str) -> None:
+    if directory.exists():
+        run_checked(
+            ["git", "worktree", "remove", "--force", str(directory)], cwd=repo
+        )
+    run_checked(
+        ["git", "worktree", "add", "--detach", str(directory), ref], cwd=repo
+    )
+
+
+def remove_worktree(repo: Path, directory: Path) -> None:
+    if directory.exists():
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(directory)],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+
+
+def regression_for(variant: str, enabled: bool) -> list[str]:
+    if not enabled:
+        return []
+    commands: list[str] = []
+    if variant in ("lazy", "main"):
+        commands.append("lazytests")
+    if variant in ("cow", "main"):
+        commands.append("cowtest")
+    commands.append("usertests")
+    return commands
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch, build, run and compare the four xv6 vmbench experiment branches."
+        )
+    )
+    parser.add_argument(
+        "--repo", type=Path, default=Path.cwd(), help="xv6 repository root"
+    )
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--pages", type=int, default=4096)
+    parser.add_argument(
+        "--timeout", type=int, default=300, help="timeout for each QEMU phase"
+    )
+    parser.add_argument("--output", type=Path, help="artifact directory")
+    parser.add_argument(
+        "--with-regression",
+        action="store_true",
+        help="also run lazytests/cowtest/usertests",
+    )
+    parser.add_argument("--keep-worktrees", action="store_true")
+    parser.add_argument("--skip-fetch", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    repo = args.repo.resolve()
+    if args.pages <= 0:
+        parser.error("--pages must be positive")
+
+    try:
+        ensure_prerequisites(repo, require_runtime=not args.dry_run)
+        repo_root = Path(git_output(repo, "rev-parse", "--show-toplevel")).resolve()
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        output_dir = (
+            args.output
+            or (repo_root.parent / f"{repo_root.name}-vmbench-results" / timestamp)
+        ).resolve()
+        logs_dir = output_dir / "logs"
+        build_dir = output_dir / "build"
+        charts_dir = output_dir / "charts"
+        worktree_root = Path(
+            tempfile.mkdtemp(prefix=f"{repo_root.name}-vmbench-worktrees-")
+        )
+
+        refs = {
+            variant: f"{args.remote}/{branch}" for variant, branch in VARIANTS.items()
+        }
+        print("VM benchmark plan:")
+        for variant, ref in refs.items():
+            print(f"  {variant:8} <- {ref}")
+        print(f"  pages     = {args.pages}")
+        print(f"  output    = {output_dir}")
+        print(f"  regression= {args.with_regression}")
+        if args.dry_run:
+            shutil.rmtree(worktree_root, ignore_errors=True)
+            return 0
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if not args.skip_fetch:
+            run_checked(["git", "fetch", "--prune", args.remote], cwd=repo_root)
+
+        records: list[RunRecord] = []
+        created_worktrees: list[Path] = []
+        try:
+            for variant, branch in VARIANTS.items():
+                ref = refs[variant]
+                worktree = worktree_root / variant
+                print(f"\n==> [{variant}] checkout {ref}")
+                add_worktree(repo_root, worktree, ref)
+                created_worktrees.append(worktree)
+                commit = git_output(worktree, "rev-parse", "HEAD")
+                record = RunRecord(
+                    variant=variant,
+                    branch=branch,
+                    commit=commit,
+                    worktree=str(worktree),
+                    build_log=str(build_dir / f"{variant}.log"),
+                    qemu_log=str(logs_dir / f"{variant}.log"),
+                )
+                records.append(record)
+
+                print(f"==> [{variant}] make clean && make")
+                build_log = Path(record.build_log)
+                build_log.parent.mkdir(parents=True, exist_ok=True)
+                with build_log.open("w", encoding="utf-8") as stream:
+                    subprocess.run(
+                        ["make", "clean"],
+                        cwd=worktree,
+                        text=True,
+                        stdout=stream,
+                        stderr=subprocess.STDOUT,
+                        check=True,
+                    )
+                    subprocess.run(
+                        ["make"],
+                        cwd=worktree,
+                        text=True,
+                        stdout=stream,
+                        stderr=subprocess.STDOUT,
+                        check=True,
+                    )
+                record.build_ok = True
+
+                print(f"==> [{variant}] QEMU: vmbench all {args.pages}")
+                run_qemu(
+                    worktree,
+                    Path(record.qemu_log),
+                    pages=args.pages,
+                    timeout=args.timeout,
+                    regression_commands=regression_for(
+                        variant, args.with_regression
+                    ),
+                )
+                record.qemu_ok = True
+
+            main_worktree = worktree_root / "main"
+            compare_script = main_worktree / "tools" / "vmbench_compare.py"
+            compare_command = [
+                sys.executable,
+                str(compare_script),
+                *(
+                    f"{variant}={logs_dir / (variant + '.log')}"
+                    for variant in VARIANTS
+                ),
+                "--csv",
+                str(output_dir / "vmbench-results.csv"),
+                "--markdown",
+                str(output_dir / "vmbench-results.md"),
+                "--svg-dir",
+                str(charts_dir),
+            ]
+            print("\n==> compare logs and render SVG charts")
+            with (output_dir / "compare.stdout.md").open(
+                "w", encoding="utf-8"
+            ) as stream:
+                subprocess.run(
+                    compare_command,
+                    cwd=main_worktree,
+                    text=True,
+                    stdout=stream,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                )
+
+            manifest = {
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "pages": args.pages,
+                "cpus": 1,
+                "with_regression": args.with_regression,
+                "records": [record.__dict__ for record in records],
+            }
+            (output_dir / "manifest.json").write_text(
+                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        finally:
+            if not args.keep_worktrees:
+                for worktree in reversed(created_worktrees):
+                    remove_worktree(repo_root, worktree)
+                subprocess.run(
+                    ["git", "worktree", "prune"], cwd=repo_root, check=False
+                )
+                shutil.rmtree(worktree_root, ignore_errors=True)
+            else:
+                print(f"Kept worktrees: {worktree_root}")
+
+        print("\nDone.")
+        print(f"Results: {output_dir}")
+        print(f"Markdown: {output_dir / 'vmbench-results.md'}")
+        print(f"CSV:      {output_dir / 'vmbench-results.csv'}")
+        print(f"SVG:      {charts_dir}")
+        return 0
+    except (OSError, RuntimeError, TimeoutError, subprocess.CalledProcessError) as error:
+        print(f"vmbench_run_all: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/vmbench_run_all.py
+++ b/tools/vmbench_run_all.py
@@ -17,6 +17,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import BinaryIO, Callable
 
 VARIANTS = {
     "pristine": "concept/21-vmbench-pristine",
@@ -26,6 +27,8 @@ VARIANTS = {
 }
 EXPECTED_RESULTS = 9
 PROMPT = b"$ "
+MAX_CAPTURE_BYTES = 2_000_000
+DIAGNOSTIC_TAIL_BYTES = 16_000
 
 
 @dataclass
@@ -38,6 +41,35 @@ class RunRecord:
     qemu_log: str
     build_ok: bool = False
     qemu_ok: bool = False
+
+
+class PtyChild:
+    """Small wait/poll wrapper for a child created with pty.fork()."""
+
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        if self.returncode is not None:
+            return self.returncode
+        try:
+            waited_pid, status = os.waitpid(self.pid, os.WNOHANG)
+        except ChildProcessError:
+            return self.returncode
+        if waited_pid == 0:
+            return None
+        self.returncode = os.waitstatus_to_exitcode(status)
+        return self.returncode
+
+    def wait(self, timeout: float) -> int:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = self.poll()
+            if result is not None:
+                return result
+            time.sleep(0.1)
+        raise TimeoutError(f"child process {self.pid} did not exit after {timeout}s")
 
 
 def run_checked(
@@ -82,11 +114,17 @@ def ensure_prerequisites(repo: Path, *, require_runtime: bool) -> None:
     git_output(repo, "rev-parse", "--git-dir")
 
 
+def output_tail(buffer: bytearray) -> str:
+    if not buffer:
+        return "<no QEMU output captured>"
+    return bytes(buffer[-DIAGNOSTIC_TAIL_BYTES:]).decode("utf-8", errors="replace")
+
+
 def wait_for(
     master_fd: int,
-    process: subprocess.Popen[bytes],
-    log_stream,
-    predicate,
+    process: PtyChild,
+    log_stream: BinaryIO,
+    predicate: Callable[[bytes], bool],
     *,
     timeout: int,
     description: str,
@@ -94,9 +132,11 @@ def wait_for(
     deadline = time.monotonic() + timeout
     buffer = bytearray()
     while time.monotonic() < deadline:
-        if process.poll() is not None:
+        exit_code = process.poll()
+        if exit_code is not None:
             raise RuntimeError(
-                f"QEMU exited before {description}; exit={process.returncode}"
+                f"QEMU exited before {description}; exit={exit_code}\n"
+                f"--- QEMU output tail ---\n{output_tail(buffer)}"
             )
         ready, _, _ = select.select([master_fd], [], [], 0.5)
         if not ready:
@@ -104,39 +144,83 @@ def wait_for(
         try:
             chunk = os.read(master_fd, 65536)
         except OSError as error:
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"QEMU exited before {description}; exit={process.returncode}\n"
+                    f"--- QEMU output tail ---\n{output_tail(buffer)}"
+                ) from error
             raise RuntimeError(
-                f"failed reading QEMU output while waiting for {description}: {error}"
+                f"failed reading QEMU output while waiting for {description}: {error}\n"
+                f"--- QEMU output tail ---\n{output_tail(buffer)}"
             ) from error
         if not chunk:
             continue
-        log_stream.buffer.write(chunk)
+
+        log_stream.write(chunk)
         log_stream.flush()
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+
         buffer.extend(chunk)
-        if len(buffer) > 2_000_000:
-            del buffer[: len(buffer) - 1_000_000]
+        if len(buffer) > MAX_CAPTURE_BYTES:
+            del buffer[: len(buffer) - MAX_CAPTURE_BYTES // 2]
         if predicate(bytes(buffer)):
             return bytes(buffer)
-    raise TimeoutError(f"timed out after {timeout}s waiting for {description}")
+
+    raise TimeoutError(
+        f"timed out after {timeout}s waiting for {description}\n"
+        f"--- QEMU output tail ---\n{output_tail(buffer)}"
+    )
 
 
-def terminate_qemu(master_fd: int, process: subprocess.Popen[bytes]) -> None:
+def spawn_qemu(worktree: Path) -> tuple[int, PtyChild]:
+    """Launch make/qemu in a real controlling PTY.
+
+    pty.openpty() + subprocess.Popen() only attaches file descriptors; it does
+    not make the slave PTY the child's controlling terminal. QEMU's stdio
+    backend can then remain alive without producing the xv6 console prompt.
+    pty.fork() uses forkpty(3), which creates the controlling terminal expected
+    by QEMU's -nographic stdio backend.
+    """
+
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        try:
+            os.chdir(worktree)
+            os.execvp("make", ["make", "qemu", "CPUS=1"])
+        except BaseException as error:
+            os.write(2, f"vmbench runner exec failed: {error}\n".encode())
+            os._exit(127)
+    return master_fd, PtyChild(pid)
+
+
+def terminate_qemu(master_fd: int, process: PtyChild) -> None:
     if process.poll() is not None:
         return
     try:
         os.write(master_fd, b"\x01x")
         process.wait(timeout=8)
         return
-    except Exception:
+    except (OSError, TimeoutError):
         pass
+
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
+        process.poll()
         return
     try:
         process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        os.killpg(process.pid, signal.SIGKILL)
+    except TimeoutError:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         process.wait(timeout=5)
+
+
+def shell_prompt_seen(data: bytes) -> bool:
+    return PROMPT in data or data.rstrip().endswith(b"$")
 
 
 def run_qemu(
@@ -148,25 +232,15 @@ def run_qemu(
     regression_commands: list[str],
 ) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    master_fd, slave_fd = pty.openpty()
-    process = subprocess.Popen(
-        ["make", "qemu", "CPUS=1"],
-        cwd=worktree,
-        stdin=slave_fd,
-        stdout=slave_fd,
-        stderr=slave_fd,
-        close_fds=True,
-        start_new_session=True,
-    )
-    os.close(slave_fd)
+    master_fd, process = spawn_qemu(worktree)
 
     try:
-        with log_path.open("w", encoding="utf-8", errors="replace") as log_stream:
+        with log_path.open("wb") as log_stream:
             wait_for(
                 master_fd,
                 process,
                 log_stream,
-                lambda data: PROMPT in data,
+                shell_prompt_seen,
                 timeout=timeout,
                 description="xv6 shell prompt",
             )
@@ -177,7 +251,7 @@ def run_qemu(
                 process,
                 log_stream,
                 lambda data: data.count(b"VMRESULT ") >= EXPECTED_RESULTS
-                and data.rstrip().endswith(b"$"),
+                and shell_prompt_seen(data),
                 timeout=timeout,
                 description=f"{EXPECTED_RESULTS} VMRESULT lines",
             )
@@ -192,7 +266,7 @@ def run_qemu(
                     master_fd,
                     process,
                     log_stream,
-                    lambda data: data.rstrip().endswith(b"$"),
+                    shell_prompt_seen,
                     timeout=timeout,
                     description=f"completion of {regression}",
                 )

--- a/tools/vmbench_run_all.py
+++ b/tools/vmbench_run_all.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Build and run all four xv6 vmbench variants, then render reports."""
-
+"""Run vmbench on pristine/lazy/cow/main and generate CSV/Markdown/SVG reports."""
 from __future__ import annotations
 
 import argparse
@@ -9,15 +8,12 @@ import os
 import select
 import shutil
 import signal
-import socket
 import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Callable
 
 VARIANTS = {
     "pristine": "concept/21-vmbench-pristine",
@@ -26,174 +22,59 @@ VARIANTS = {
     "main": "concept/21-vmbench-main",
 }
 EXPECTED_RESULTS = 9
-PROMPT = b"$ "
-MAX_CAPTURE_BYTES = 2_000_000
-DIAGNOSTIC_TAIL_BYTES = 16_384
+TAIL = 16384
 
 
-@dataclass
-class RunRecord:
-    variant: str
-    branch: str
-    commit: str
-    worktree: str
-    build_log: str
-    qemu_log: str
-    qemu_host_log: str
-    build_ok: bool = False
-    qemu_ok: bool = False
+def run(command: list[str], cwd: Path, **kwargs):
+    return subprocess.run(command, cwd=cwd, check=True, **kwargs)
 
 
-def run_checked(
-    command: list[str],
-    *,
-    cwd: Path,
-    log_path: Path | None = None,
-    capture: bool = False,
-) -> subprocess.CompletedProcess[str]:
-    if log_path is not None:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        with log_path.open("w", encoding="utf-8") as stream:
-            return subprocess.run(
-                command,
-                cwd=cwd,
-                text=True,
-                stdout=stream,
-                stderr=subprocess.STDOUT,
-                check=True,
-            )
-    return subprocess.run(
-        command,
-        cwd=cwd,
-        text=True,
-        capture_output=capture,
-        check=True,
-    )
+def git(repo: Path, *args: str) -> str:
+    return run(
+        ["git", *args], repo, text=True, capture_output=True
+    ).stdout.strip()
 
 
-def git_output(repo: Path, *args: str) -> str:
-    result = run_checked(["git", *args], cwd=repo, capture=True)
-    return result.stdout.strip()
+def tail_file(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        return f"<cannot read {path}: {error}>"
+    return data[-TAIL:].decode(errors="replace") if data else "<empty>"
 
 
-def ensure_prerequisites(repo: Path, *, require_runtime: bool) -> None:
-    commands = ["git", "make", "python3"]
-    if require_runtime:
-        commands.append("qemu-system-riscv64")
-    missing = [name for name in commands if shutil.which(name) is None]
-    if missing:
-        raise RuntimeError("missing required commands: " + ", ".join(missing))
-    git_output(repo, "rev-parse", "--git-dir")
+def prompt_seen(data: bytes) -> bool:
+    return b"$ " in data or data.rstrip().endswith(b"$")
 
 
-def output_tail(buffer: bytearray) -> str:
-    if not buffer:
-        return "<no xv6 serial output captured>"
-    return bytes(buffer[-DIAGNOSTIC_TAIL_BYTES:]).decode(
-        "utf-8", errors="replace"
-    )
+def qemu_args(worktree: Path) -> list[str]:
+    qemu = shutil.which("qemu-system-riscv64")
+    if not qemu:
+        raise RuntimeError("qemu-system-riscv64 not found")
+    return [
+        qemu,
+        "-machine", "virt",
+        "-bios", "none",
+        "-kernel", str(worktree / "kernel/kernel"),
+        "-m", "128M",
+        "-smp", "1",
+        "-display", "none",
+        "-monitor", "none",
+        "-chardev", "stdio,id=xv6serial,signal=off",
+        "-serial", "chardev:xv6serial",
+        "-drive", f"file={worktree / 'fs.img'},if=none,format=raw,id=x0",
+        "-device", "virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0",
+    ]
 
 
-def wait_for_socket(
-    socket_path: Path,
-    process: subprocess.Popen[bytes],
-    *,
-    timeout: int,
-) -> socket.socket:
-    deadline = time.monotonic() + min(timeout, 30)
-    last_error: OSError | None = None
-    while time.monotonic() < deadline:
-        exit_code = process.poll()
-        if exit_code is not None:
-            raise RuntimeError(
-                f"QEMU exited before serial socket became available; exit={exit_code}"
-            )
-        if socket_path.exists():
-            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            try:
-                client.connect(str(socket_path))
-                client.setblocking(False)
-                return client
-            except OSError as error:
-                last_error = error
-                client.close()
-        time.sleep(0.05)
-    detail = f": {last_error}" if last_error else ""
-    raise TimeoutError(
-        f"timed out waiting for QEMU serial socket {socket_path}{detail}"
-    )
-
-
-def wait_for(
-    serial: socket.socket,
-    process: subprocess.Popen[bytes],
-    log_stream: BinaryIO,
-    predicate: Callable[[bytes], bool],
-    *,
-    timeout: int,
-    description: str,
-) -> bytes:
-    deadline = time.monotonic() + timeout
-    buffer = bytearray()
-
-    while time.monotonic() < deadline:
-        exit_code = process.poll()
-        if exit_code is not None:
-            raise RuntimeError(
-                f"QEMU exited before {description}; exit={exit_code}\n"
-                f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
-            )
-
-        ready, _, _ = select.select([serial], [], [], 0.5)
-        if not ready:
-            continue
-
-        try:
-            chunk = serial.recv(65536)
-        except BlockingIOError:
-            continue
-        except OSError as error:
-            raise RuntimeError(
-                f"failed reading xv6 serial output while waiting for "
-                f"{description}: {error}\n"
-                f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
-            ) from error
-
-        if not chunk:
-            continue
-
-        log_stream.write(chunk)
-        log_stream.flush()
-        sys.stdout.buffer.write(chunk)
-        sys.stdout.buffer.flush()
-
-        buffer.extend(chunk)
-        if len(buffer) > MAX_CAPTURE_BYTES:
-            del buffer[: len(buffer) - MAX_CAPTURE_BYTES // 2]
-
-        if predicate(bytes(buffer)):
-            return bytes(buffer)
-
-    raise TimeoutError(
-        f"timed out after {timeout}s waiting for {description}\n"
-        f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
-    )
-
-
-def shell_prompt_seen(data: bytes) -> bool:
-    stripped = data.rstrip()
-    return PROMPT in data or stripped.endswith(b"$")
-
-
-def terminate_qemu(process: subprocess.Popen[bytes]) -> None:
+def stop_process(process: subprocess.Popen[bytes]) -> None:
     if process.poll() is not None:
         return
     try:
         os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
     except ProcessLookupError:
         return
-    try:
-        process.wait(timeout=5)
     except subprocess.TimeoutExpired:
         try:
             os.killpg(process.pid, signal.SIGKILL)
@@ -202,408 +83,266 @@ def terminate_qemu(process: subprocess.Popen[bytes]) -> None:
         process.wait(timeout=5)
 
 
-def qemu_command(worktree: Path, serial_socket: Path) -> list[str]:
-    qemu = shutil.which("qemu-system-riscv64")
-    if qemu is None:
-        raise RuntimeError("qemu-system-riscv64 not found")
-    return [
-        qemu,
-        "-machine",
-        "virt",
-        "-bios",
-        "none",
-        "-kernel",
-        str(worktree / "kernel" / "kernel"),
-        "-m",
-        "128M",
-        "-smp",
-        "1",
-        "-display",
-        "none",
-        "-monitor",
-        "none",
-        "-chardev",
-        (
-            "socket,id=xv6serial,"
-            f"path={serial_socket},server=on,wait=on"
-        ),
-        "-serial",
-        "chardev:xv6serial",
-        "-drive",
-        (
-            f"file={worktree / 'fs.img'},if=none,"
-            "format=raw,id=x0"
-        ),
-        "-device",
-        "virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0",
-    ]
+def wait_output(
+    process: subprocess.Popen[bytes],
+    serial_log,
+    host_log: Path,
+    predicate,
+    timeout: int,
+    description: str,
+) -> bytes:
+    assert process.stdout is not None
+    fd = process.stdout.fileno()
+    deadline = time.monotonic() + timeout
+    data = bytearray()
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"QEMU exited before {description}; exit={process.returncode}\n"
+                f"--- xv6 tail ---\n{bytes(data[-TAIL:]).decode(errors='replace')}\n"
+                f"--- QEMU tail ---\n{tail_file(host_log)}"
+            )
+        ready, _, _ = select.select([fd], [], [], 0.5)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(fd, 65536)
+        except BlockingIOError:
+            continue
+        if not chunk:
+            continue
+        serial_log.write(chunk)
+        serial_log.flush()
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        data.extend(chunk)
+        if len(data) > 2_000_000:
+            del data[:1_000_000]
+        if predicate(bytes(data)):
+            return bytes(data)
+    raise TimeoutError(
+        f"timed out after {timeout}s waiting for {description}\n"
+        f"--- xv6 tail ---\n{bytes(data[-TAIL:]).decode(errors='replace')}\n"
+        f"--- QEMU tail ---\n{tail_file(host_log)}"
+    )
+
+
+def send(process: subprocess.Popen[bytes], command: str) -> None:
+    assert process.stdin is not None
+    process.stdin.write((command + "\n").encode())
+    process.stdin.flush()
 
 
 def run_qemu(
     worktree: Path,
-    log_path: Path,
+    serial_log_path: Path,
     host_log_path: Path,
-    *,
     pages: int,
     timeout: int,
-    regression_commands: list[str],
+    regressions: list[str],
 ) -> None:
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    host_log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    socket_dir = Path(tempfile.mkdtemp(prefix="xv6vm-", dir="/tmp"))
-    serial_socket_path = socket_dir / "serial.sock"
-    command = qemu_command(worktree, serial_socket_path)
-
-    serial: socket.socket | None = None
-    try:
-        with host_log_path.open("wb") as host_log:
-            process = subprocess.Popen(
-                command,
-                cwd=worktree,
-                stdin=subprocess.DEVNULL,
-                stdout=host_log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
-            try:
-                serial = wait_for_socket(
-                    serial_socket_path,
-                    process,
-                    timeout=timeout,
+    serial_log_path.parent.mkdir(parents=True, exist_ok=True)
+    with host_log_path.open("wb") as host_log:
+        process = subprocess.Popen(
+            qemu_args(worktree),
+            cwd=worktree,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=host_log,
+            bufsize=0,
+            start_new_session=True,
+        )
+        try:
+            assert process.stdout is not None
+            os.set_blocking(process.stdout.fileno(), False)
+            with serial_log_path.open("wb") as serial_log:
+                wait_output(
+                    process, serial_log, host_log_path,
+                    prompt_seen, timeout, "xv6 shell prompt",
                 )
-                with log_path.open("wb") as log_stream:
-                    wait_for(
-                        serial,
-                        process,
-                        log_stream,
-                        shell_prompt_seen,
-                        timeout=timeout,
-                        description="xv6 shell prompt",
+                send(process, f"vmbench all {pages}")
+                result = wait_output(
+                    process, serial_log, host_log_path,
+                    lambda x: x.count(b"VMRESULT ") >= EXPECTED_RESULTS
+                    and prompt_seen(x),
+                    timeout, f"{EXPECTED_RESULTS} VMRESULT lines",
+                )
+                if b"VMFAILED " in result or b"VMERROR " in result:
+                    raise RuntimeError("vmbench reported VMFAILED/VMERROR")
+                for command in regressions:
+                    send(process, command)
+                    result = wait_output(
+                        process, serial_log, host_log_path,
+                        prompt_seen, timeout, f"completion of {command}",
                     )
-
-                    serial.sendall(f"vmbench all {pages}\n".encode())
-                    output = wait_for(
-                        serial,
-                        process,
-                        log_stream,
-                        lambda data: (
-                            data.count(b"VMRESULT ") >= EXPECTED_RESULTS
-                            and shell_prompt_seen(data)
-                        ),
-                        timeout=timeout,
-                        description=f"{EXPECTED_RESULTS} VMRESULT lines",
+                    marker = (
+                        b"ALL COW TESTS PASSED"
+                        if command == "cowtest" else b"ALL TESTS PASSED"
                     )
-                    if b"VMFAILED " in output or b"VMERROR " in output:
-                        raise RuntimeError(
-                            "vmbench reported VMFAILED/VMERROR; "
-                            "inspect the xv6 serial log"
-                        )
-
-                    for regression in regression_commands:
-                        serial.sendall((regression + "\n").encode())
-                        regression_output = wait_for(
-                            serial,
-                            process,
-                            log_stream,
-                            shell_prompt_seen,
-                            timeout=timeout,
-                            description=f"completion of {regression}",
-                        )
-                        success_marker = (
-                            b"ALL COW TESTS PASSED"
-                            if regression == "cowtest"
-                            else b"ALL TESTS PASSED"
-                        )
-                        if success_marker not in regression_output:
-                            raise RuntimeError(
-                                f"{regression} did not print "
-                                f"{success_marker.decode()!r}; "
-                                "inspect the xv6 serial log"
-                            )
-            finally:
-                if serial is not None:
-                    serial.close()
-                terminate_qemu(process)
-    finally:
-        shutil.rmtree(socket_dir, ignore_errors=True)
+                    if marker not in result:
+                        raise RuntimeError(f"{command} did not print {marker!r}")
+        finally:
+            if process.stdin:
+                process.stdin.close()
+            stop_process(process)
 
 
-def add_worktree(repo: Path, directory: Path, ref: str) -> None:
-    if directory.exists():
-        run_checked(
-            ["git", "worktree", "remove", "--force", str(directory)],
-            cwd=repo,
-        )
-    run_checked(
-        ["git", "worktree", "add", "--detach", str(directory), ref],
-        cwd=repo,
-    )
-
-
-def remove_worktree(repo: Path, directory: Path) -> None:
-    if directory.exists():
-        subprocess.run(
-            ["git", "worktree", "remove", "--force", str(directory)],
-            cwd=repo,
-            text=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-
-
-def regression_for(variant: str, enabled: bool) -> list[str]:
+def regression_commands(variant: str, enabled: bool) -> list[str]:
     if not enabled:
         return []
-    commands: list[str] = []
+    commands = []
     if variant in ("lazy", "main"):
         commands.append("lazytests")
     if variant in ("cow", "main"):
         commands.append("cowtest")
-    commands.append("usertests")
-    return commands
+    return [*commands, "usertests"]
 
 
-def write_manifest(
-    output_dir: Path,
-    *,
-    pages: int,
-    with_regression: bool,
-    records: list[RunRecord],
-    error: str | None,
-) -> None:
-    manifest = {
+def add_worktree(repo: Path, path: Path, ref: str) -> None:
+    if path.exists():
+        run(["git", "worktree", "remove", "--force", str(path)], repo)
+    run(["git", "worktree", "add", "--detach", str(path), ref], repo)
+
+
+def remove_worktree(repo: Path, path: Path) -> None:
+    if path.exists():
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            check=False,
+        )
+
+
+def write_manifest(output: Path, pages: int, regression: bool, records, error):
+    output.mkdir(parents=True, exist_ok=True)
+    payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "pages": pages,
         "cpus": 1,
-        "with_regression": with_regression,
+        "with_regression": regression,
         "error": error,
-        "records": [record.__dict__ for record in records],
+        "records": records,
     }
-    output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "manifest.json").write_text(
-        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
+    (output / "manifest.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
     )
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Fetch, build, run and compare the four xv6 vmbench branches."
-        )
-    )
-    parser.add_argument(
-        "--repo",
-        type=Path,
-        default=Path.cwd(),
-        help="xv6 repository root",
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
     parser.add_argument("--remote", default="origin")
     parser.add_argument("--pages", type=int, default=4096)
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=300,
-        help="timeout for each QEMU phase",
-    )
-    parser.add_argument("--output", type=Path, help="artifact directory")
-    parser.add_argument(
-        "--with-regression",
-        action="store_true",
-        help="also run lazytests/cowtest/usertests",
-    )
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--with-regression", action="store_true")
     parser.add_argument("--keep-worktrees", action="store_true")
     parser.add_argument("--skip-fetch", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
-
     if args.pages <= 0:
         parser.error("--pages must be positive")
 
-    repo = args.repo.resolve()
-    records: list[RunRecord] = []
-    output_dir: Path | None = None
-
+    output = None
+    records = []
     try:
-        ensure_prerequisites(repo, require_runtime=not args.dry_run)
-        repo_root = Path(
-            git_output(repo, "rev-parse", "--show-toplevel")
-        ).resolve()
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        output_dir = (
+        for command in ("git", "make", "python3"):
+            if not shutil.which(command):
+                raise RuntimeError(f"{command} not found")
+        if not args.dry_run and not shutil.which("qemu-system-riscv64"):
+            raise RuntimeError("qemu-system-riscv64 not found")
+
+        repo = Path(git(args.repo.resolve(), "rev-parse", "--show-toplevel"))
+        output = (
             args.output
-            or (
-                repo_root.parent
-                / f"{repo_root.name}-vmbench-results"
-                / timestamp
-            )
+            or repo.parent / f"{repo.name}-vmbench-results"
+            / datetime.now().strftime("%Y%m%d-%H%M%S")
         ).resolve()
-        logs_dir = output_dir / "logs"
-        build_dir = output_dir / "build"
-        charts_dir = output_dir / "charts"
-        worktree_root = Path(
-            tempfile.mkdtemp(prefix=f"{repo_root.name}-vmbench-worktrees-")
-        )
-
-        refs = {
-            variant: f"{args.remote}/{branch}"
-            for variant, branch in VARIANTS.items()
-        }
+        refs = {name: f"{args.remote}/{branch}" for name, branch in VARIANTS.items()}
         print("VM benchmark plan:")
-        for variant, ref in refs.items():
-            print(f"  {variant:8} <- {ref}")
+        for name, ref in refs.items():
+            print(f"  {name:8} <- {ref}")
         print(f"  pages     = {args.pages}")
-        print(f"  output    = {output_dir}")
+        print(f"  output    = {output}")
         print(f"  regression= {args.with_regression}")
-
         if args.dry_run:
-            shutil.rmtree(worktree_root, ignore_errors=True)
             return 0
 
-        output_dir.mkdir(parents=True, exist_ok=True)
+        output.mkdir(parents=True, exist_ok=True)
         if not args.skip_fetch:
-            run_checked(
-                ["git", "fetch", "--prune", args.remote],
-                cwd=repo_root,
-            )
-
-        created_worktrees: list[Path] = []
-        run_error: str | None = None
+            run(["git", "fetch", "--prune", args.remote], repo)
+        worktree_root = Path(tempfile.mkdtemp(prefix="xv6-vmbench-worktrees-"))
+        worktrees = []
+        error = None
         try:
-            for variant, branch in VARIANTS.items():
-                ref = refs[variant]
-                worktree = worktree_root / variant
-
-                print(f"\n==> [{variant}] checkout {ref}")
-                add_worktree(repo_root, worktree, ref)
-                created_worktrees.append(worktree)
-
-                commit = git_output(worktree, "rev-parse", "HEAD")
-                record = RunRecord(
-                    variant=variant,
-                    branch=branch,
-                    commit=commit,
-                    worktree=str(worktree),
-                    build_log=str(build_dir / f"{variant}.log"),
-                    qemu_log=str(logs_dir / f"{variant}.log"),
-                    qemu_host_log=str(
-                        logs_dir / f"{variant}.host.log"
-                    ),
-                )
+            for name, branch in VARIANTS.items():
+                worktree = worktree_root / name
+                print(f"\n==> [{name}] checkout {refs[name]}")
+                add_worktree(repo, worktree, refs[name])
+                worktrees.append(worktree)
+                record = {
+                    "variant": name,
+                    "branch": branch,
+                    "commit": git(worktree, "rev-parse", "HEAD"),
+                    "build_log": str(output / "build" / f"{name}.log"),
+                    "qemu_log": str(output / "logs" / f"{name}.log"),
+                    "qemu_host_log": str(output / "logs" / f"{name}.host.log"),
+                    "build_ok": False,
+                    "qemu_ok": False,
+                }
                 records.append(record)
-
-                print(f"==> [{variant}] make clean && make")
-                build_log = Path(record.build_log)
+                print(f"==> [{name}] make clean && make kernel/kernel fs.img")
+                build_log = Path(record["build_log"])
                 build_log.parent.mkdir(parents=True, exist_ok=True)
-                with build_log.open("w", encoding="utf-8") as stream:
-                    subprocess.run(
-                        ["make", "clean"],
-                        cwd=worktree,
-                        text=True,
-                        stdout=stream,
-                        stderr=subprocess.STDOUT,
-                        check=True,
-                    )
-                    subprocess.run(
-                        ["make"],
-                        cwd=worktree,
-                        text=True,
-                        stdout=stream,
-                        stderr=subprocess.STDOUT,
-                        check=True,
-                    )
-                record.build_ok = True
-
-                print(
-                    f"==> [{variant}] QEMU socket: "
-                    f"vmbench all {args.pages}"
-                )
+                with build_log.open("w") as stream:
+                    run(["make", "clean"], worktree, text=True,
+                        stdout=stream, stderr=subprocess.STDOUT)
+                    run(["make", "kernel/kernel", "fs.img"], worktree,
+                        text=True, stdout=stream, stderr=subprocess.STDOUT)
+                for artifact in (worktree / "kernel/kernel", worktree / "fs.img"):
+                    if not artifact.is_file():
+                        raise RuntimeError(f"missing build artifact: {artifact}")
+                record["build_ok"] = True
+                print(f"==> [{name}] QEMU stdio: vmbench all {args.pages}")
                 run_qemu(
                     worktree,
-                    Path(record.qemu_log),
-                    Path(record.qemu_host_log),
-                    pages=args.pages,
-                    timeout=args.timeout,
-                    regression_commands=regression_for(
-                        variant,
-                        args.with_regression,
-                    ),
+                    Path(record["qemu_log"]),
+                    Path(record["qemu_host_log"]),
+                    args.pages,
+                    args.timeout,
+                    regression_commands(name, args.with_regression),
                 )
-                record.qemu_ok = True
+                record["qemu_ok"] = True
 
-            main_worktree = worktree_root / "main"
-            compare_script = (
-                main_worktree / "tools" / "vmbench_compare.py"
-            )
-            compare_command = [
-                sys.executable,
-                str(compare_script),
-                *(
-                    f"{variant}={logs_dir / (variant + '.log')}"
-                    for variant in VARIANTS
-                ),
-                "--csv",
-                str(output_dir / "vmbench-results.csv"),
-                "--markdown",
-                str(output_dir / "vmbench-results.md"),
-                "--svg-dir",
-                str(charts_dir),
+            compare = worktree_root / "main/tools/vmbench_compare.py"
+            command = [
+                sys.executable, str(compare),
+                *(f"{name}={output / 'logs' / (name + '.log')}" for name in VARIANTS),
+                "--csv", str(output / "vmbench-results.csv"),
+                "--markdown", str(output / "vmbench-results.md"),
+                "--svg-dir", str(output / "charts"),
             ]
-
             print("\n==> compare logs and render SVG charts")
-            with (output_dir / "compare.stdout.md").open(
-                "w",
-                encoding="utf-8",
-            ) as stream:
-                subprocess.run(
-                    compare_command,
-                    cwd=main_worktree,
-                    text=True,
-                    stdout=stream,
-                    stderr=subprocess.STDOUT,
-                    check=True,
-                )
-        except Exception as error:
-            run_error = str(error)
+            with (output / "compare.stdout.md").open("w") as stream:
+                run(command, worktree_root / "main", text=True,
+                    stdout=stream, stderr=subprocess.STDOUT)
+        except Exception as caught:
+            error = str(caught)
             raise
         finally:
-            write_manifest(
-                output_dir,
-                pages=args.pages,
-                with_regression=args.with_regression,
-                records=records,
-                error=run_error,
-            )
+            write_manifest(output, args.pages, args.with_regression, records, error)
             if not args.keep_worktrees:
-                for worktree in reversed(created_worktrees):
-                    remove_worktree(repo_root, worktree)
-                subprocess.run(
-                    ["git", "worktree", "prune"],
-                    cwd=repo_root,
-                    check=False,
-                )
+                for worktree in reversed(worktrees):
+                    remove_worktree(repo, worktree)
+                subprocess.run(["git", "worktree", "prune"], cwd=repo, check=False)
                 shutil.rmtree(worktree_root, ignore_errors=True)
-            else:
-                print(f"Kept worktrees: {worktree_root}")
 
-        print("\nDone.")
-        print(f"Results:  {output_dir}")
-        print(f"Markdown: {output_dir / 'vmbench-results.md'}")
-        print(f"CSV:      {output_dir / 'vmbench-results.csv'}")
-        print(f"SVG:      {charts_dir}")
+        print(f"\nDone. Results: {output}")
         return 0
-
-    except (
-        OSError,
-        RuntimeError,
-        TimeoutError,
-        subprocess.CalledProcessError,
-    ) as error:
+    except (OSError, RuntimeError, TimeoutError, subprocess.CalledProcessError) as error:
         print(f"vmbench_run_all: {error}", file=sys.stderr)
-        if output_dir is not None:
-            print(f"partial results: {output_dir}", file=sys.stderr)
+        if output:
+            print(f"partial results: {output}", file=sys.stderr)
         return 1
 
 

--- a/tools/vmbench_run_all.py
+++ b/tools/vmbench_run_all.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import pty
 import select
-import signal
 import shutil
+import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -28,7 +28,7 @@ VARIANTS = {
 EXPECTED_RESULTS = 9
 PROMPT = b"$ "
 MAX_CAPTURE_BYTES = 2_000_000
-DIAGNOSTIC_TAIL_BYTES = 16_000
+DIAGNOSTIC_TAIL_BYTES = 16_384
 
 
 @dataclass
@@ -39,37 +39,9 @@ class RunRecord:
     worktree: str
     build_log: str
     qemu_log: str
+    qemu_host_log: str
     build_ok: bool = False
     qemu_ok: bool = False
-
-
-class PtyChild:
-    """Small wait/poll wrapper for a child created with pty.fork()."""
-
-    def __init__(self, pid: int) -> None:
-        self.pid = pid
-        self.returncode: int | None = None
-
-    def poll(self) -> int | None:
-        if self.returncode is not None:
-            return self.returncode
-        try:
-            waited_pid, status = os.waitpid(self.pid, os.WNOHANG)
-        except ChildProcessError:
-            return self.returncode
-        if waited_pid == 0:
-            return None
-        self.returncode = os.waitstatus_to_exitcode(status)
-        return self.returncode
-
-    def wait(self, timeout: float) -> int:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            result = self.poll()
-            if result is not None:
-                return result
-            time.sleep(0.1)
-        raise TimeoutError(f"child process {self.pid} did not exit after {timeout}s")
 
 
 def run_checked(
@@ -79,7 +51,7 @@ def run_checked(
     log_path: Path | None = None,
     capture: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    if log_path:
+    if log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         with log_path.open("w", encoding="utf-8") as stream:
             return subprocess.run(
@@ -105,7 +77,7 @@ def git_output(repo: Path, *args: str) -> str:
 
 
 def ensure_prerequisites(repo: Path, *, require_runtime: bool) -> None:
-    commands = ["git", "make"]
+    commands = ["git", "make", "python3"]
     if require_runtime:
         commands.append("qemu-system-riscv64")
     missing = [name for name in commands if shutil.which(name) is None]
@@ -116,13 +88,45 @@ def ensure_prerequisites(repo: Path, *, require_runtime: bool) -> None:
 
 def output_tail(buffer: bytearray) -> str:
     if not buffer:
-        return "<no QEMU output captured>"
-    return bytes(buffer[-DIAGNOSTIC_TAIL_BYTES:]).decode("utf-8", errors="replace")
+        return "<no xv6 serial output captured>"
+    return bytes(buffer[-DIAGNOSTIC_TAIL_BYTES:]).decode(
+        "utf-8", errors="replace"
+    )
+
+
+def wait_for_socket(
+    socket_path: Path,
+    process: subprocess.Popen[bytes],
+    *,
+    timeout: int,
+) -> socket.socket:
+    deadline = time.monotonic() + min(timeout, 30)
+    last_error: OSError | None = None
+    while time.monotonic() < deadline:
+        exit_code = process.poll()
+        if exit_code is not None:
+            raise RuntimeError(
+                f"QEMU exited before serial socket became available; exit={exit_code}"
+            )
+        if socket_path.exists():
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                client.connect(str(socket_path))
+                client.setblocking(False)
+                return client
+            except OSError as error:
+                last_error = error
+                client.close()
+        time.sleep(0.05)
+    detail = f": {last_error}" if last_error else ""
+    raise TimeoutError(
+        f"timed out waiting for QEMU serial socket {socket_path}{detail}"
+    )
 
 
 def wait_for(
-    master_fd: int,
-    process: PtyChild,
+    serial: socket.socket,
+    process: subprocess.Popen[bytes],
     log_stream: BinaryIO,
     predicate: Callable[[bytes], bool],
     *,
@@ -131,28 +135,30 @@ def wait_for(
 ) -> bytes:
     deadline = time.monotonic() + timeout
     buffer = bytearray()
+
     while time.monotonic() < deadline:
         exit_code = process.poll()
         if exit_code is not None:
             raise RuntimeError(
                 f"QEMU exited before {description}; exit={exit_code}\n"
-                f"--- QEMU output tail ---\n{output_tail(buffer)}"
+                f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
             )
-        ready, _, _ = select.select([master_fd], [], [], 0.5)
+
+        ready, _, _ = select.select([serial], [], [], 0.5)
         if not ready:
             continue
+
         try:
-            chunk = os.read(master_fd, 65536)
+            chunk = serial.recv(65536)
+        except BlockingIOError:
+            continue
         except OSError as error:
-            if process.poll() is not None:
-                raise RuntimeError(
-                    f"QEMU exited before {description}; exit={process.returncode}\n"
-                    f"--- QEMU output tail ---\n{output_tail(buffer)}"
-                ) from error
             raise RuntimeError(
-                f"failed reading QEMU output while waiting for {description}: {error}\n"
-                f"--- QEMU output tail ---\n{output_tail(buffer)}"
+                f"failed reading xv6 serial output while waiting for "
+                f"{description}: {error}\n"
+                f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
             ) from error
+
         if not chunk:
             continue
 
@@ -164,134 +170,174 @@ def wait_for(
         buffer.extend(chunk)
         if len(buffer) > MAX_CAPTURE_BYTES:
             del buffer[: len(buffer) - MAX_CAPTURE_BYTES // 2]
+
         if predicate(bytes(buffer)):
             return bytes(buffer)
 
     raise TimeoutError(
         f"timed out after {timeout}s waiting for {description}\n"
-        f"--- QEMU output tail ---\n{output_tail(buffer)}"
+        f"--- xv6 serial output tail ---\n{output_tail(buffer)}"
     )
 
 
-def spawn_qemu(worktree: Path) -> tuple[int, PtyChild]:
-    """Launch make/qemu in a real controlling PTY.
-
-    pty.openpty() + subprocess.Popen() only attaches file descriptors; it does
-    not make the slave PTY the child's controlling terminal. QEMU's stdio
-    backend can then remain alive without producing the xv6 console prompt.
-    pty.fork() uses forkpty(3), which creates the controlling terminal expected
-    by QEMU's -nographic stdio backend.
-    """
-
-    pid, master_fd = pty.fork()
-    if pid == 0:
-        try:
-            os.chdir(worktree)
-            os.execvp("make", ["make", "qemu", "CPUS=1"])
-        except BaseException as error:
-            os.write(2, f"vmbench runner exec failed: {error}\n".encode())
-            os._exit(127)
-    return master_fd, PtyChild(pid)
+def shell_prompt_seen(data: bytes) -> bool:
+    stripped = data.rstrip()
+    return PROMPT in data or stripped.endswith(b"$")
 
 
-def terminate_qemu(master_fd: int, process: PtyChild) -> None:
+def terminate_qemu(process: subprocess.Popen[bytes]) -> None:
     if process.poll() is not None:
         return
     try:
-        os.write(master_fd, b"\x01x")
-        process.wait(timeout=8)
-        return
-    except (OSError, TimeoutError):
-        pass
-
-    try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
-        process.poll()
         return
     try:
         process.wait(timeout=5)
-    except TimeoutError:
+    except subprocess.TimeoutExpired:
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
-            pass
+            return
         process.wait(timeout=5)
 
 
-def shell_prompt_seen(data: bytes) -> bool:
-    return PROMPT in data or data.rstrip().endswith(b"$")
+def qemu_command(worktree: Path, serial_socket: Path) -> list[str]:
+    qemu = shutil.which("qemu-system-riscv64")
+    if qemu is None:
+        raise RuntimeError("qemu-system-riscv64 not found")
+    return [
+        qemu,
+        "-machine",
+        "virt",
+        "-bios",
+        "none",
+        "-kernel",
+        str(worktree / "kernel" / "kernel"),
+        "-m",
+        "128M",
+        "-smp",
+        "1",
+        "-display",
+        "none",
+        "-monitor",
+        "none",
+        "-chardev",
+        (
+            "socket,id=xv6serial,"
+            f"path={serial_socket},server=on,wait=on"
+        ),
+        "-serial",
+        "chardev:xv6serial",
+        "-drive",
+        (
+            f"file={worktree / 'fs.img'},if=none,"
+            "format=raw,id=x0"
+        ),
+        "-device",
+        "virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0",
+    ]
 
 
 def run_qemu(
     worktree: Path,
     log_path: Path,
+    host_log_path: Path,
     *,
     pages: int,
     timeout: int,
     regression_commands: list[str],
 ) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    master_fd, process = spawn_qemu(worktree)
+    host_log_path.parent.mkdir(parents=True, exist_ok=True)
 
+    socket_dir = Path(tempfile.mkdtemp(prefix="xv6vm-", dir="/tmp"))
+    serial_socket_path = socket_dir / "serial.sock"
+    command = qemu_command(worktree, serial_socket_path)
+
+    serial: socket.socket | None = None
     try:
-        with log_path.open("wb") as log_stream:
-            wait_for(
-                master_fd,
-                process,
-                log_stream,
-                shell_prompt_seen,
-                timeout=timeout,
-                description="xv6 shell prompt",
+        with host_log_path.open("wb") as host_log:
+            process = subprocess.Popen(
+                command,
+                cwd=worktree,
+                stdin=subprocess.DEVNULL,
+                stdout=host_log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
             )
-
-            os.write(master_fd, f"vmbench all {pages}\n".encode())
-            output = wait_for(
-                master_fd,
-                process,
-                log_stream,
-                lambda data: data.count(b"VMRESULT ") >= EXPECTED_RESULTS
-                and shell_prompt_seen(data),
-                timeout=timeout,
-                description=f"{EXPECTED_RESULTS} VMRESULT lines",
-            )
-            if b"VMFAILED " in output or b"VMERROR " in output:
-                raise RuntimeError(
-                    "vmbench reported VMFAILED/VMERROR; inspect the QEMU log"
-                )
-
-            for regression in regression_commands:
-                os.write(master_fd, (regression + "\n").encode())
-                regression_output = wait_for(
-                    master_fd,
+            try:
+                serial = wait_for_socket(
+                    serial_socket_path,
                     process,
-                    log_stream,
-                    shell_prompt_seen,
                     timeout=timeout,
-                    description=f"completion of {regression}",
                 )
-                success_marker = (
-                    b"ALL COW TESTS PASSED"
-                    if regression == "cowtest"
-                    else b"ALL TESTS PASSED"
-                )
-                if success_marker not in regression_output:
-                    raise RuntimeError(
-                        f"{regression} did not print {success_marker.decode()!r}; "
-                        "inspect the QEMU log"
+                with log_path.open("wb") as log_stream:
+                    wait_for(
+                        serial,
+                        process,
+                        log_stream,
+                        shell_prompt_seen,
+                        timeout=timeout,
+                        description="xv6 shell prompt",
                     )
+
+                    serial.sendall(f"vmbench all {pages}\n".encode())
+                    output = wait_for(
+                        serial,
+                        process,
+                        log_stream,
+                        lambda data: (
+                            data.count(b"VMRESULT ") >= EXPECTED_RESULTS
+                            and shell_prompt_seen(data)
+                        ),
+                        timeout=timeout,
+                        description=f"{EXPECTED_RESULTS} VMRESULT lines",
+                    )
+                    if b"VMFAILED " in output or b"VMERROR " in output:
+                        raise RuntimeError(
+                            "vmbench reported VMFAILED/VMERROR; "
+                            "inspect the xv6 serial log"
+                        )
+
+                    for regression in regression_commands:
+                        serial.sendall((regression + "\n").encode())
+                        regression_output = wait_for(
+                            serial,
+                            process,
+                            log_stream,
+                            shell_prompt_seen,
+                            timeout=timeout,
+                            description=f"completion of {regression}",
+                        )
+                        success_marker = (
+                            b"ALL COW TESTS PASSED"
+                            if regression == "cowtest"
+                            else b"ALL TESTS PASSED"
+                        )
+                        if success_marker not in regression_output:
+                            raise RuntimeError(
+                                f"{regression} did not print "
+                                f"{success_marker.decode()!r}; "
+                                "inspect the xv6 serial log"
+                            )
+            finally:
+                if serial is not None:
+                    serial.close()
+                terminate_qemu(process)
     finally:
-        terminate_qemu(master_fd, process)
-        os.close(master_fd)
+        shutil.rmtree(socket_dir, ignore_errors=True)
 
 
 def add_worktree(repo: Path, directory: Path, ref: str) -> None:
     if directory.exists():
         run_checked(
-            ["git", "worktree", "remove", "--force", str(directory)], cwd=repo
+            ["git", "worktree", "remove", "--force", str(directory)],
+            cwd=repo,
         )
     run_checked(
-        ["git", "worktree", "add", "--detach", str(directory), ref], cwd=repo
+        ["git", "worktree", "add", "--detach", str(directory), ref],
+        cwd=repo,
     )
 
 
@@ -319,19 +365,48 @@ def regression_for(variant: str, enabled: bool) -> list[str]:
     return commands
 
 
+def write_manifest(
+    output_dir: Path,
+    *,
+    pages: int,
+    with_regression: bool,
+    records: list[RunRecord],
+    error: str | None,
+) -> None:
+    manifest = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "pages": pages,
+        "cpus": 1,
+        "with_regression": with_regression,
+        "error": error,
+        "records": [record.__dict__ for record in records],
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Fetch, build, run and compare the four xv6 vmbench experiment branches."
+            "Fetch, build, run and compare the four xv6 vmbench branches."
         )
     )
     parser.add_argument(
-        "--repo", type=Path, default=Path.cwd(), help="xv6 repository root"
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="xv6 repository root",
     )
     parser.add_argument("--remote", default="origin")
     parser.add_argument("--pages", type=int, default=4096)
     parser.add_argument(
-        "--timeout", type=int, default=300, help="timeout for each QEMU phase"
+        "--timeout",
+        type=int,
+        default=300,
+        help="timeout for each QEMU phase",
     )
     parser.add_argument("--output", type=Path, help="artifact directory")
     parser.add_argument(
@@ -344,17 +419,26 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
-    repo = args.repo.resolve()
     if args.pages <= 0:
         parser.error("--pages must be positive")
 
+    repo = args.repo.resolve()
+    records: list[RunRecord] = []
+    output_dir: Path | None = None
+
     try:
         ensure_prerequisites(repo, require_runtime=not args.dry_run)
-        repo_root = Path(git_output(repo, "rev-parse", "--show-toplevel")).resolve()
+        repo_root = Path(
+            git_output(repo, "rev-parse", "--show-toplevel")
+        ).resolve()
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         output_dir = (
             args.output
-            or (repo_root.parent / f"{repo_root.name}-vmbench-results" / timestamp)
+            or (
+                repo_root.parent
+                / f"{repo_root.name}-vmbench-results"
+                / timestamp
+            )
         ).resolve()
         logs_dir = output_dir / "logs"
         build_dir = output_dir / "build"
@@ -364,7 +448,8 @@ def main() -> int:
         )
 
         refs = {
-            variant: f"{args.remote}/{branch}" for variant, branch in VARIANTS.items()
+            variant: f"{args.remote}/{branch}"
+            for variant, branch in VARIANTS.items()
         }
         print("VM benchmark plan:")
         for variant, ref in refs.items():
@@ -372,23 +457,29 @@ def main() -> int:
         print(f"  pages     = {args.pages}")
         print(f"  output    = {output_dir}")
         print(f"  regression= {args.with_regression}")
+
         if args.dry_run:
             shutil.rmtree(worktree_root, ignore_errors=True)
             return 0
 
         output_dir.mkdir(parents=True, exist_ok=True)
         if not args.skip_fetch:
-            run_checked(["git", "fetch", "--prune", args.remote], cwd=repo_root)
+            run_checked(
+                ["git", "fetch", "--prune", args.remote],
+                cwd=repo_root,
+            )
 
-        records: list[RunRecord] = []
         created_worktrees: list[Path] = []
+        run_error: str | None = None
         try:
             for variant, branch in VARIANTS.items():
                 ref = refs[variant]
                 worktree = worktree_root / variant
+
                 print(f"\n==> [{variant}] checkout {ref}")
                 add_worktree(repo_root, worktree, ref)
                 created_worktrees.append(worktree)
+
                 commit = git_output(worktree, "rev-parse", "HEAD")
                 record = RunRecord(
                     variant=variant,
@@ -397,6 +488,9 @@ def main() -> int:
                     worktree=str(worktree),
                     build_log=str(build_dir / f"{variant}.log"),
                     qemu_log=str(logs_dir / f"{variant}.log"),
+                    qemu_host_log=str(
+                        logs_dir / f"{variant}.host.log"
+                    ),
                 )
                 records.append(record)
 
@@ -422,20 +516,27 @@ def main() -> int:
                     )
                 record.build_ok = True
 
-                print(f"==> [{variant}] QEMU: vmbench all {args.pages}")
+                print(
+                    f"==> [{variant}] QEMU socket: "
+                    f"vmbench all {args.pages}"
+                )
                 run_qemu(
                     worktree,
                     Path(record.qemu_log),
+                    Path(record.qemu_host_log),
                     pages=args.pages,
                     timeout=args.timeout,
                     regression_commands=regression_for(
-                        variant, args.with_regression
+                        variant,
+                        args.with_regression,
                     ),
                 )
                 record.qemu_ok = True
 
             main_worktree = worktree_root / "main"
-            compare_script = main_worktree / "tools" / "vmbench_compare.py"
+            compare_script = (
+                main_worktree / "tools" / "vmbench_compare.py"
+            )
             compare_command = [
                 sys.executable,
                 str(compare_script),
@@ -450,9 +551,11 @@ def main() -> int:
                 "--svg-dir",
                 str(charts_dir),
             ]
+
             print("\n==> compare logs and render SVG charts")
             with (output_dir / "compare.stdout.md").open(
-                "w", encoding="utf-8"
+                "w",
+                encoding="utf-8",
             ) as stream:
                 subprocess.run(
                     compare_command,
@@ -462,37 +565,45 @@ def main() -> int:
                     stderr=subprocess.STDOUT,
                     check=True,
                 )
-
-            manifest = {
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "pages": args.pages,
-                "cpus": 1,
-                "with_regression": args.with_regression,
-                "records": [record.__dict__ for record in records],
-            }
-            (output_dir / "manifest.json").write_text(
-                json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
-                encoding="utf-8",
-            )
+        except Exception as error:
+            run_error = str(error)
+            raise
         finally:
+            write_manifest(
+                output_dir,
+                pages=args.pages,
+                with_regression=args.with_regression,
+                records=records,
+                error=run_error,
+            )
             if not args.keep_worktrees:
                 for worktree in reversed(created_worktrees):
                     remove_worktree(repo_root, worktree)
                 subprocess.run(
-                    ["git", "worktree", "prune"], cwd=repo_root, check=False
+                    ["git", "worktree", "prune"],
+                    cwd=repo_root,
+                    check=False,
                 )
                 shutil.rmtree(worktree_root, ignore_errors=True)
             else:
                 print(f"Kept worktrees: {worktree_root}")
 
         print("\nDone.")
-        print(f"Results: {output_dir}")
+        print(f"Results:  {output_dir}")
         print(f"Markdown: {output_dir / 'vmbench-results.md'}")
         print(f"CSV:      {output_dir / 'vmbench-results.csv'}")
         print(f"SVG:      {charts_dir}")
         return 0
-    except (OSError, RuntimeError, TimeoutError, subprocess.CalledProcessError) as error:
+
+    except (
+        OSError,
+        RuntimeError,
+        TimeoutError,
+        subprocess.CalledProcessError,
+    ) as error:
         print(f"vmbench_run_all: {error}", file=sys.stderr)
+        if output_dir is not None:
+            print(f"partial results: {output_dir}", file=sys.stderr)
         return 1
 
 

--- a/tools/vmbench_run_all.py
+++ b/tools/vmbench_run_all.py
@@ -8,6 +8,7 @@ import json
 import os
 import pty
 import select
+import signal
 import shutil
 import subprocess
 import sys
@@ -127,11 +128,14 @@ def terminate_qemu(master_fd: int, process: subprocess.Popen[bytes]) -> None:
         return
     except Exception:
         pass
-    process.terminate()
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
     try:
         process.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        process.kill()
+        os.killpg(process.pid, signal.SIGKILL)
         process.wait(timeout=5)
 
 
@@ -184,7 +188,7 @@ def run_qemu(
 
             for regression in regression_commands:
                 os.write(master_fd, (regression + "\n").encode())
-                wait_for(
+                regression_output = wait_for(
                     master_fd,
                     process,
                     log_stream,
@@ -192,6 +196,16 @@ def run_qemu(
                     timeout=timeout,
                     description=f"completion of {regression}",
                 )
+                success_marker = (
+                    b"ALL COW TESTS PASSED"
+                    if regression == "cowtest"
+                    else b"ALL TESTS PASSED"
+                )
+                if success_marker not in regression_output:
+                    raise RuntimeError(
+                        f"{regression} did not print {success_marker.decode()!r}; "
+                        "inspect the QEMU log"
+                    )
     finally:
         terminate_qemu(master_fd, process)
         os.close(master_fd)

--- a/user/vmbench.c
+++ b/user/vmbench.c
@@ -1,0 +1,326 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "kernel/syscall.h"
+#include "kernel/vmstat.h"
+#include "user/user.h"
+
+#define DEFAULT_PAGES 4096
+#define MAX_PAGES 8192
+#define SPARSE_STRIDE 64
+
+struct region {
+  char *start;
+  char *end;
+  int pages;
+};
+
+struct scenario {
+  char *name;
+  int (*run)(int pages);
+};
+
+static int
+vmstat_call(int op, uint64 arg0, uint64 arg1, struct vmstat_snapshot *snapshot)
+{
+  register uint64 a0 asm("a0") = (uint64)op;
+  register uint64 a1 asm("a1") = arg0;
+  register uint64 a2 asm("a2") = arg1;
+  register uint64 a3 asm("a3") = (uint64)snapshot;
+  register uint64 a7 asm("a7") = SYS_vmstat;
+
+  asm volatile("ecall"
+               : "+r"(a0)
+               : "r"(a1), "r"(a2), "r"(a3), "r"(a7)
+               : "memory");
+  return (int)a0;
+}
+
+static char *
+align_heap(void)
+{
+  uint64 current = (uint64)sbrk(0);
+  uint64 aligned = PGROUNDUP(current);
+  if(aligned > current && sbrk(aligned - current) == (char *)-1)
+    return 0;
+  return (char *)aligned;
+}
+
+static int
+begin_region(int pages, struct region *region)
+{
+  char *start = align_heap();
+  if(start == 0)
+    return -1;
+
+  uint64 bytes = (uint64)pages * PGSIZE;
+  uint64 end = (uint64)start + bytes;
+  if(end < (uint64)start)
+    return -1;
+
+  region->start = start;
+  region->end = (char *)end;
+  region->pages = pages;
+  return vmstat_call(VMSTAT_BEGIN, (uint64)start, end, 0);
+}
+
+static int
+reserve_region(struct region *region)
+{
+  uint64 oldsz = (uint64)sbrk(0);
+  uint64 bytes = (uint64)region->pages * PGSIZE;
+  if((uint64)region->start != oldsz)
+    return -1;
+  if(sbrk(bytes) == (char *)-1)
+    return -1;
+  return vmstat_call(VMSTAT_SAMPLE_SBRK, oldsz, oldsz + bytes, 0);
+}
+
+static void
+touch_pages(char *start, int pages, int stride, char value)
+{
+  volatile char *memory = (volatile char *)start;
+  for(int page = 0; page < pages; page += stride)
+    memory[(uint64)page * PGSIZE] = value;
+}
+
+static int
+check_pages(char *start, int pages, int stride, char value)
+{
+  volatile char *memory = (volatile char *)start;
+  for(int page = 0; page < pages; page += stride)
+    if(memory[(uint64)page * PGSIZE] != value)
+      return -1;
+  return 0;
+}
+
+static void
+print_counts(char *prefix, struct vmstat_counts *counts)
+{
+  printf(" %s_virtual=%d", prefix, (int)counts->virtual_grow_pages);
+  printf(" %s_eager_alloc=%d", prefix, (int)counts->sbrk_eager_alloc_pages);
+  printf(" %s_lazy_alloc=%d", prefix, (int)counts->lazy_materialized_pages);
+  printf(" %s_fork_scan=%d", prefix, (int)counts->fork_va_scan_pages);
+  printf(" %s_fork_present=%d", prefix, (int)counts->fork_present_pages);
+  printf(" %s_fork_copy=%d", prefix, (int)counts->fork_eager_copy_pages);
+  printf(" %s_fork_shared=%d", prefix, (int)counts->fork_shared_map_pages);
+  printf(" %s_cow_mark=%d", prefix, (int)counts->fork_cow_mark_pages);
+  printf(" %s_cow_copy=%d", prefix, (int)counts->cow_copy_pages);
+  printf(" %s_final_present=%d", prefix, (int)counts->final_present_pages);
+}
+
+static int
+finish_region(char *scenario, int pages, int stride)
+{
+  struct vmstat_snapshot snapshot;
+  if(vmstat_call(VMSTAT_END, 0, 0, &snapshot) < 0){
+    printf("vmbench: VMSTAT_END failed for %s\n", scenario);
+    return -1;
+  }
+
+  printf("VMRESULT scenario=%s pages=%d stride=%d abi=%d",
+         scenario, pages, stride, (int)snapshot.abi_version);
+  print_counts("range", &snapshot.range);
+  print_counts("total", &snapshot.total);
+  printf("\n");
+  return 0;
+}
+
+static int
+run_touch_case(char *name, int pages, int stride)
+{
+  struct region region;
+  if(begin_region(pages, &region) < 0 || reserve_region(&region) < 0)
+    return -1;
+
+  if(stride > 0){
+    touch_pages(region.start, pages, stride, 0x31);
+    if(check_pages(region.start, pages, stride, 0x31) < 0)
+      return -1;
+  }
+  return finish_region(name, pages, stride);
+}
+
+static int
+run_reserve_only(int pages)
+{
+  return run_touch_case("reserve-only", pages, 0);
+}
+
+static int
+run_sparse_touch(int pages)
+{
+  return run_touch_case("sparse-touch", pages, SPARSE_STRIDE);
+}
+
+static int
+run_dense_touch(int pages)
+{
+  return run_touch_case("dense-touch", pages, 1);
+}
+
+static int
+run_fork_case(char *name, int pages, int parent_stride,
+              int child_write_stride, int do_exec)
+{
+  struct region region;
+  int gate[2];
+  int status = 0;
+
+  if(begin_region(pages, &region) < 0 || reserve_region(&region) < 0)
+    return -1;
+  touch_pages(region.start, pages, parent_stride, 0x41);
+  if(check_pages(region.start, pages, parent_stride, 0x41) < 0)
+    return -1;
+
+  if(pipe(gate) < 0)
+    return -1;
+  int pid = fork();
+  if(pid < 0)
+    return -1;
+
+  if(pid == 0){
+    char token;
+    close(gate[1]);
+    if(read(gate[0], &token, 1) != 1)
+      exit(2);
+    close(gate[0]);
+
+    if(child_write_stride > 0)
+      touch_pages(region.start, pages, child_write_stride, 0x52);
+    if(vmstat_call(VMSTAT_SAMPLE_CHILD, 0, 0, 0) < 0)
+      exit(3);
+
+    if(do_exec){
+      char *argv[] = { "echo", 0 };
+      exec("echo", argv);
+      exit(4);
+    }
+    exit(0);
+  }
+
+  close(gate[0]);
+  if(vmstat_call(VMSTAT_SAMPLE_FORK, pid, 0, 0) < 0){
+    close(gate[1]);
+    wait(&status);
+    return -1;
+  }
+  if(write(gate[1], "x", 1) != 1){
+    close(gate[1]);
+    wait(&status);
+    return -1;
+  }
+  close(gate[1]);
+  if(wait(&status) < 0 || status != 0)
+    return -1;
+
+  if(check_pages(region.start, pages, parent_stride, 0x41) < 0)
+    return -1;
+  return finish_region(name, pages,
+                       child_write_stride > 0 ? child_write_stride : parent_stride);
+}
+
+static int
+run_fork_exit(int pages)
+{
+  return run_fork_case("fork-exit", pages, 1, 0, 0);
+}
+
+static int
+run_fork_exec(int pages)
+{
+  return run_fork_case("fork-exec", pages, 1, 0, 1);
+}
+
+static int
+run_fork_write_sparse(int pages)
+{
+  return run_fork_case("fork-write-1of64", pages, 1, SPARSE_STRIDE, 0);
+}
+
+static int
+run_fork_write_quarter(int pages)
+{
+  return run_fork_case("fork-write-1of4", pages, 1, 4, 0);
+}
+
+static int
+run_fork_write_all(int pages)
+{
+  return run_fork_case("fork-write-all", pages, 1, 1, 0);
+}
+
+static int
+run_sparse_fork_exec(int pages)
+{
+  return run_fork_case("sparse-fork-exec", pages, SPARSE_STRIDE, 0, 1);
+}
+
+static struct scenario scenarios[] = {
+  { "reserve-only", run_reserve_only },
+  { "sparse-touch", run_sparse_touch },
+  { "dense-touch", run_dense_touch },
+  { "fork-exit", run_fork_exit },
+  { "fork-exec", run_fork_exec },
+  { "fork-write-1of64", run_fork_write_sparse },
+  { "fork-write-1of4", run_fork_write_quarter },
+  { "fork-write-all", run_fork_write_all },
+  { "sparse-fork-exec", run_sparse_fork_exec },
+};
+
+static int
+run_one(struct scenario *scenario, int pages)
+{
+  int status = 0;
+  int pid = fork();
+  if(pid < 0)
+    return -1;
+  if(pid == 0){
+    if(scenario->run(pages) < 0){
+      printf("VMERROR scenario=%s\n", scenario->name);
+      exit(1);
+    }
+    exit(0);
+  }
+  if(wait(&status) < 0 || status != 0)
+    return -1;
+  return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+  char *selected = "all";
+  int pages = DEFAULT_PAGES;
+
+  if(argc >= 2)
+    selected = argv[1];
+  if(argc >= 3)
+    pages = atoi(argv[2]);
+  if(pages <= 0 || pages > MAX_PAGES){
+    printf("usage: vmbench [all|scenario] [pages:1-%d]\n", MAX_PAGES);
+    exit(1);
+  }
+
+  int failures = 0;
+  int matched = 0;
+  for(uint i = 0; i < sizeof(scenarios) / sizeof(scenarios[0]); i++){
+    if(strcmp(selected, "all") != 0 && strcmp(selected, scenarios[i].name) != 0)
+      continue;
+    matched = 1;
+    if(run_one(&scenarios[i], pages) < 0){
+      printf("VMFAILED scenario=%s\n", scenarios[i].name);
+      failures++;
+    }
+  }
+
+  if(!matched){
+    printf("unknown scenario: %s\n", selected);
+    exit(1);
+  }
+  if(failures){
+    printf("VMbench completed with %d failure(s)\n", failures);
+    exit(1);
+  }
+  exit(0);
+}


### PR DESCRIPTION
Related to #21

## 实现内容

- 在固定的 `pristine`、`lazy`、`cow`、`main` 四条实验分支上提供统一 `vmstat` 页表采样 ABI 和 `vmbench` 用户程序。
- 新增 `tools/vmbench_run_all.py`，自动完成：
  - `git fetch`；
  - 为四个远端实验分支建立临时 detached worktree；
  - 每个分支执行 `make clean && make`；
  - 以 `CPUS=1` 启动 QEMU；
  - 自动进入 xv6 shell 并运行 `vmbench all 4096`；
  - 等待 9 条 `VMRESULT`，检测 `VMFAILED` / `VMERROR`；
  - 自动通过 `Ctrl-A X` 退出 QEMU并清理临时 worktree。
- 可通过 `--with-regression` 追加运行各分支适用的 `lazytests`、`cowtest` 与 `usertests`，并检查成功标记。
- 扩展 `tools/vmbench_compare.py`，输出 CSV、Markdown 和六张 SVG 折线图，不依赖 matplotlib 等第三方库。

## 一键运行

在 WSL/Linux 的 xv6 仓库根目录执行：

```bash
git fetch origin && \
git switch --detach origin/concept/21-vmbench-main && \
python3 tools/vmbench_run_all.py
```

同时执行回归测试：

```bash
python3 tools/vmbench_run_all.py --with-regression --timeout 900
```

默认结果目录位于仓库同级：

```text
../xv6-vmbench-results/<timestamp>/
```

包含：

```text
build/                     四分支编译日志
logs/                      四分支 QEMU 原始日志
charts/                    六张 SVG 折线图
vmbench-results.csv        完整结构化数据
vmbench-results.md         Markdown 对比表
manifest.json              分支、Commit、页数和执行状态
```

SVG 图包括：

- 用户数据页物化数量；
- fork/COW 整页复制工作；
- 物化与复制总页级工作；
- 相对 pristine 避免的总页级工作；
- fork 后共享物理页数量；
- fork 扫描但未映射的虚拟页数量。

## 实现说明

- 使用临时 `git worktree`，避免在当前工作区反复切分支，也不会把构建产物和实验结果写入仓库。
- QEMU 通过 Python 标准库 `pty` 与 `select` 驱动，不依赖 `expect` 或 `pexpect`。
- 主结论使用 `range_*` 测试 heap 统计；`total_*` 仅用于观察栈等固定开销。
- 当前 `main` 已继续前进，本实验分支仍固定在基线 Commit `eabe1f7ffe079df54f56339678d3ac00a09164c0`，不为合并用途进行 rebase。

## 测试与验证

| 检查项 | 结果 |
|---|---|
| `python3 -m py_compile tools/vmbench_run_all.py tools/vmbench_compare.py` | 通过：两个脚本均可完成 Python 语法编译 |
| 四份合成 `VMRESULT` 日志解析 | 通过：生成完整 CSV 和 Markdown 表 |
| SVG 报告生成 | 通过：生成六张 SVG 折线图 |
| 临时 Git 仓库执行 `vmbench_run_all.py --dry-run` | 通过：正确解析四分支计划、页数和输出目录 |
| `make clean && make` | 未运行：当前执行环境缺少 xv6 RISC-V 工具链 |
| 四分支 QEMU 实验 | 未运行：当前执行环境缺少 `qemu-system-riscv64`，留给本机执行 |

## 影响范围

- 新增实验用系统调用、用户程序和宿主机工具，不改变 lazy allocation 或 COW 的原有策略。
- 一键运行器面向 WSL/Linux；使用了 Unix PTY，不支持直接在原生 Windows Python 下运行。
- 运行环境仍需已有 RISC-V 编译工具链、GNU Make 和 `qemu-system-riscv64`。

## 风险与注意事项

- QEMU shell 提示符按 xv6 默认 `$ ` 识别；若后续修改 shell 提示符，需要同步调整 `PROMPT`。
- `--with-regression` 会显著增加运行时间，应配合更高的 `--timeout`。
- 当前 PR 仅用于完成并运行实验，得到数据后可以直接关闭，不应合入持续演进的 `main`。

## 审阅重点

- `tools/vmbench_run_all.py` 的 PTY 交互、超时处理和 QEMU 进程组清理。
- 四分支 worktree 是否始终指向预期实验 Commit。
- SVG 图中的派生指标是否与 CSV 中的页级计算一致。
