### PR TITLE
[Concept Lab] 重构 Buffer cache bget 锁路径

### DIFF
--- a/.github/workflows/verify-buffer-cache-refactor.yml
+++ b/.github/workflows/verify-buffer-cache-refactor.yml
@@ -4,56 +4,77 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - concept/30-buffer-cache-bget-refactor
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  compare-usertests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case_name: refactor
+            checkout_ref: concept/30-buffer-cache-bget-refactor
+          - case_name: baseline
+            checkout_ref: eabe1f7ffe079df54f56339678d3ac00a09164c0
 
     steps:
-      - name: Checkout
+      - name: Checkout ${{ matrix.case_name }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.checkout_ref }}
 
       - name: Install RISC-V toolchain and QEMU
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-riscv64-linux-gnu binutils-riscv64-linux-gnu qemu-system-misc expect
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcc-riscv64-linux-gnu binutils-riscv64-linux-gnu qemu-system-misc expect
 
-      - name: Build
+      - name: Build ${{ matrix.case_name }}
         run: |
           make clean
           make -j2
 
-      - name: Run usertests with three CPUs
+      - name: Run three-CPU usertests and capture output
+        id: usertests
+        continue-on-error: true
+        shell: bash
         run: |
-          expect <<'EOF' | tee usertests-cpus3.log
+          set -o pipefail
+          expect <<'EOF' | tee usertests-${{ matrix.case_name }}.log
           set timeout 300
           spawn make qemu
           expect "$ "
           send "usertests\r"
           expect {
-            "ALL TESTS PASSED" { exit 0 }
-            timeout { exit 1 }
-            eof { exit 1 }
+            "ALL TESTS PASSED" {
+              send "\001x"
+              expect eof
+              exit 0
+            }
+            "SOME TESTS FAILED" {
+              send "\001x"
+              expect eof
+              exit 1
+            }
+            timeout {
+              send "\001x"
+              exit 2
+            }
+            eof { exit 3 }
           }
           EOF
-          grep -q "ALL TESTS PASSED" usertests-cpus3.log
+          printf 'expect_status=%s\n' "${PIPESTATUS[0]}" | tee usertests-${{ matrix.case_name }}.status
+          test "${PIPESTATUS[0]}" -eq 0
 
-      - name: Run usertests with one CPU
-        run: |
-          expect <<'EOF' | tee usertests-cpus1.log
-          set timeout 300
-          spawn make qemu CPUS=1
-          expect "$ "
-          send "usertests\r"
-          expect {
-            "ALL TESTS PASSED" { exit 0 }
-            timeout { exit 1 }
-            eof { exit 1 }
-          }
-          EOF
-          grep -q "ALL TESTS PASSED" usertests-cpus1.log
+      - name: Upload QEMU log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: usertests-${{ matrix.case_name }}
+          path: |
+            usertests-${{ matrix.case_name }}.log
+            usertests-${{ matrix.case_name }}.status
+
+      - name: Require successful usertests
+        run: grep -q "ALL TESTS PASSED" usertests-${{ matrix.case_name }}.log

--- a/.github/workflows/verify-buffer-cache-refactor.yml
+++ b/.github/workflows/verify-buffer-cache-refactor.yml
@@ -1,6 +1,9 @@
 name: Verify buffer cache refactor
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - concept/30-buffer-cache-bget-refactor

--- a/.github/workflows/verify-buffer-cache-refactor.yml
+++ b/.github/workflows/verify-buffer-cache-refactor.yml
@@ -1,0 +1,40 @@
+name: Verify buffer cache refactor
+
+on:
+  push:
+    branches:
+      - concept/30-buffer-cache-bget-refactor
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install RISC-V toolchain and QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-riscv64-linux-gnu binutils-riscv64-linux-gnu qemu-system-misc
+
+      - name: Build
+        run: |
+          make clean
+          make -j2
+
+      - name: Run usertests with three CPUs
+        shell: bash
+        run: |
+          set -o pipefail
+          { sleep 2; echo usertests; } | timeout 240 make qemu | tee usertests-cpus3.log || test $? -eq 124
+          grep -q "ALL TESTS PASSED" usertests-cpus3.log
+
+      - name: Run usertests with one CPU
+        shell: bash
+        run: |
+          set -o pipefail
+          { sleep 2; echo usertests; } | timeout 240 make qemu CPUS=1 | tee usertests-cpus1.log || test $? -eq 124
+          grep -q "ALL TESTS PASSED" usertests-cpus1.log

--- a/.github/workflows/verify-buffer-cache-refactor.yml
+++ b/.github/workflows/verify-buffer-cache-refactor.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install RISC-V toolchain and QEMU
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-riscv64-linux-gnu binutils-riscv64-linux-gnu qemu-system-misc
+          sudo apt-get install -y gcc-riscv64-linux-gnu binutils-riscv64-linux-gnu qemu-system-misc expect
 
       - name: Build
         run: |
@@ -29,15 +29,31 @@ jobs:
           make -j2
 
       - name: Run usertests with three CPUs
-        shell: bash
         run: |
-          set -o pipefail
-          { sleep 2; echo usertests; } | timeout 240 make qemu | tee usertests-cpus3.log || test $? -eq 124
+          expect <<'EOF' | tee usertests-cpus3.log
+          set timeout 300
+          spawn make qemu
+          expect "$ "
+          send "usertests\r"
+          expect {
+            "ALL TESTS PASSED" { exit 0 }
+            timeout { exit 1 }
+            eof { exit 1 }
+          }
+          EOF
           grep -q "ALL TESTS PASSED" usertests-cpus3.log
 
       - name: Run usertests with one CPU
-        shell: bash
         run: |
-          set -o pipefail
-          { sleep 2; echo usertests; } | timeout 240 make qemu CPUS=1 | tee usertests-cpus1.log || test $? -eq 124
+          expect <<'EOF' | tee usertests-cpus1.log
+          set timeout 300
+          spawn make qemu CPUS=1
+          expect "$ "
+          send "usertests\r"
+          expect {
+            "ALL TESTS PASSED" { exit 0 }
+            timeout { exit 1 }
+            eof { exit 1 }
+          }
+          EOF
           grep -q "ALL TESTS PASSED" usertests-cpus1.log

--- a/kernel/bio.c
+++ b/kernel/bio.c
@@ -69,6 +69,107 @@ binit(void)
   // Create linked list of buffers
 }
 
+// Caller must hold bcache.lock[idx].
+static struct buf*
+find_unused_locked(uint idx)
+{
+  struct buf *b;
+  struct buf *head = &bcache.head[idx];
+
+  for(b = head->prev; b != head; b = b->prev){
+    if(b->refcnt == 0)
+      return b;
+  }
+
+  return 0;
+}
+
+// Caller must have exclusive access to b.
+static void
+prepare_buf(struct buf *b, uint dev, uint blockno)
+{
+  b->dev = dev;
+  b->blockno = blockno;
+  b->valid = 0;
+  b->refcnt = 1;
+}
+
+// Caller must hold the source and target bucket locks.
+static void
+move_buf_locked(struct buf *b, uint target_idx)
+{
+  b->prev->next = b->next;
+  b->next->prev = b->prev;
+
+  b->next = bcache.head[target_idx].next;
+  b->prev = &bcache.head[target_idx];
+  b->next->prev = b;
+  b->prev->next = b;
+}
+
+// Find the requested block or recycle an unused buffer in one bucket.
+// Caller must hold bcache.lock[idx].
+static struct buf*
+try_get_local_locked(uint idx, uint dev, uint blockno)
+{
+  struct buf *b;
+  struct buf *head = &bcache.head[idx];
+
+  for(b = head->next; b != head; b = b->next){
+    if(b->dev == dev && b->blockno == blockno){
+      b->refcnt++;
+      return b;
+    }
+  }
+
+  b = find_unused_locked(idx);
+  if(b != 0)
+    prepare_buf(b, dev, blockno);
+
+  return b;
+}
+
+// Recheck the target bucket while cross-bucket moves are serialized.
+// If the target bucket still has no usable buffer, steal one from another bucket.
+static struct buf*
+get_or_steal(uint target_idx, uint dev, uint blockno)
+{
+  struct buf *b;
+
+  acquire(&bcache.steal_lock);
+  acquire(&bcache.lock[target_idx]);
+
+  b = try_get_local_locked(target_idx, dev, blockno);
+  if(b != 0)
+    goto found;
+
+  for(uint victim_idx = ihash(target_idx + 1);
+      victim_idx != target_idx;
+      victim_idx = ihash(victim_idx + 1)){
+    acquire(&bcache.lock[victim_idx]);
+
+    b = find_unused_locked(victim_idx);
+    if(b == 0){
+      release(&bcache.lock[victim_idx]);
+      continue;
+    }
+
+    prepare_buf(b, dev, blockno);
+    move_buf_locked(b, target_idx);
+    release(&bcache.lock[victim_idx]);
+    goto found;
+  }
+
+  release(&bcache.lock[target_idx]);
+  release(&bcache.steal_lock);
+  panic("bget: no buffers");
+
+found:
+  release(&bcache.lock[target_idx]);
+  release(&bcache.steal_lock);
+  return b;
+}
+
 // Look through buffer cache for block on device dev.
 // If not found, allocate a buffer.
 // In either case, return locked buffer.
@@ -76,96 +177,17 @@ static struct buf*
 bget(uint dev, uint blockno)
 {
   struct buf *b;
-
   uint idx = ihash(blockno);
 
-
   acquire(&bcache.lock[idx]);
-
-  // Is the block already cached?
-  for(b = bcache.head[idx].next; b != &bcache.head[idx]; b = b->next){
-    if(b->dev == dev && b->blockno == blockno){
-      b->refcnt++;
-      release(&bcache.lock[idx]);
-      acquiresleep(&b->lock);
-      return b;
-    }
-  }
-
-  // Not cached. find LRU
-  // Recycle the least recently used (LRU) unused buffer.
-  for(b = bcache.head[idx].prev; b != &bcache.head[idx]; b = b->prev){
-    if(b->refcnt == 0) {
-      b->dev = dev;
-      b->blockno = blockno;
-      b->valid = 0;
-      b->refcnt = 1;
-      release(&bcache.lock[idx]);
-      acquiresleep(&b->lock);
-      return b;
-    }
-  }
+  b = try_get_local_locked(idx, dev, blockno);
   release(&bcache.lock[idx]);
 
-  acquire(&bcache.steal_lock);
-  acquire(&bcache.lock[idx]);
+  if(b == 0)
+    b = get_or_steal(idx, dev, blockno);
 
-  for (b = bcache.head[idx].next; b!= &bcache.head[idx]; b = b->next){
-    //already exists.  
-    if(b->dev == dev && b->blockno == blockno) {
-      b->refcnt++;
-      release(&bcache.lock[idx]);
-      release(&bcache.steal_lock);
-      acquiresleep(&b->lock);
-      return b;
-    }
-  }
-
-  for (b = bcache.head[idx].prev; b != &bcache.head[idx]; b = b->prev){
-    //Find LRU
-    if(b->refcnt == 0){
-      b->dev = dev;
-      b->blockno = blockno;
-      b->valid = 0;
-      b->refcnt = 1;
-      release(&bcache.lock[idx]);
-      release(&bcache.steal_lock);
-      acquiresleep(&b->lock);
-      return b;
-    }
-  }
-
-  uint _idx = idx;
-  idx = ihash(idx + 1);
-  while(idx != _idx){
-    acquire(&bcache.lock[idx]);
-    for(b = bcache.head[idx].prev; b != &bcache.head[idx]; b = b->prev) {
-      if(b->refcnt == 0) {
-        b->dev = dev;
-        b->blockno = blockno;
-        b->valid = 0;
-        b->refcnt = 1;
-        b->prev->next = b->next;
-        b->next->prev = b->prev;
-        release(&bcache.lock[idx]);//the bucket being stolen.
-        //Actual LRU  
-        b->next = bcache.head[_idx].next;
-        b->prev = &bcache.head[_idx];
-        b->next->prev = b;
-        b->prev->next = b;
-        release(&bcache.lock[_idx]);//original buckets.
-        release(&bcache.steal_lock);
-        acquiresleep(&b->lock);
-        return b;
-      }
-    }
-    release(&bcache.lock[idx]);//switch to the next bucket.
-    idx = ihash(idx+1);
-  }
-  release(&bcache.lock[_idx]);
-  release(&bcache.steal_lock);
-
-  panic("bget: no buffers");
+  acquiresleep(&b->lock);
+  return b;
 }
 
 // Return a locked buf with the contents of the indicated block.
@@ -232,5 +254,3 @@ bunpin(struct buf *b) {
   b->refcnt--;
   release(&bcache.lock[idx]);
 }
-
-


### PR DESCRIPTION
## 中心认知与范围

在不改变现有哈希桶、LRU、`steal_lock` 与 buffer sleeplock 语义的前提下，重构 `kernel/bio.c:bget()`，把重复的本桶查找、空闲 buffer 选择、身份重置和跨桶链表移动收敛为职责明确的 helper。

Relates to #30
Obsidian: mental1104/Obsidian#69

## 基线 Commit

- `main`: `eabe1f7ffe079df54f56339678d3ac00a09164c0`

## 关键文件

- `kernel/bio.c`

## 实现变化

- `find_unused_locked()`：从 bucket 的 LRU 端查找 `refcnt == 0` 的 buffer。
- `prepare_buf()`：统一设置 `dev`、`blockno`、`valid` 与 `refcnt`。
- `move_buf_locked()`：统一完成跨 bucket 双向链表摘除与插入。
- `try_get_local_locked()`：统一目标桶命中和本桶复用逻辑。
- `get_or_steal()`：持有 `steal_lock` 后重新检查目标桶，再进入跨桶偷取慢路径。
- `bget()`：只保留目标桶快路径、慢路径调用以及统一的 sleeplock 获取。

## 锁边界与不变量

- 同一个 `(dev, blockno)` 最多对应一个 buffer。
- `refcnt` 在 bucket spinlock 保护下增加或初始化，避免等待 sleeplock 时被回收。
- 获取 `steal_lock` 后必须重新检查目标桶，覆盖第一次释放桶锁后的并发变化。
- 跨桶移动遵循固定顺序：`steal_lock -> target bucket -> victim bucket`。
- 所有 spinlock 都在 `acquiresleep()` 前释放。

## 验证结果

已通过：

- `clang -std=gnu11 -Wall -Wextra -Werror -ffreestanding -fsyntax-only`（使用最小 xv6 兼容声明验证 `kernel/bio.c` 语法与类型路径）。
- 本地行为 harness：覆盖本桶空闲复用、同块命中、跨桶偷取、链表迁移以及返回前 spinlock 全部释放。

尚未完成：

- `make clean && make`
- QEMU 下 `bcachetest`
- QEMU 下 `usertests`

当前执行环境无法拉取完整仓库，且没有 RISC-V 交叉编译工具链，因此本 PR 保持 Draft，不能把上述项目标记为通过。

## 教学边界

本次只是等价重构，没有新增 buffer cache 策略，也没有把 xv6 的分桶实现泛化为生产内核的通用设计。