### PR TITLE
refactor: 迭代式多级间接块映射与释放

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -365,126 +365,137 @@ iunlockput(struct inode *ip)
   iput(ip);
 }
 
-// Inode content
-//
-// The content (data) associated with each inode is stored
-// in blocks on the disk. The first NDIRECT block numbers
-// are listed in ip->addrs[].  The next NINDIRECT blocks are
-// listed in block ip->addrs[NDIRECT].
+// 每个 inode 先保存直接块地址，随后每个槽位分别保存一棵
+// 深度为 1、2 ... 的间接索引树根块。
+#define NINDIRECT_LEVELS 2
 
-// Return the disk block address of the nth block in inode ip.
-// If there is no such block, bmap allocates one.
+static const uint64 indirect_capacity[NINDIRECT_LEVELS] = {
+  NINDIRECT,
+  NDOUBLEINDIRECT,
+};
+
+// 沿指定深度的间接索引树逐层定位数据块；缺失的索引块或数据块按需分配。
+static uint
+bmap_indirect(struct inode *ip, uint addr, uint64 bn, int depth)
+{
+  uint64 divisor = 1;
+
+  // divisor 表示当前层一个入口能够覆盖的叶子数据块数量。
+  for(int level = 1; level < depth; level++)
+    divisor *= NINDIRECT;
+
+  for(int level = depth; level > 0; level--){
+    struct buf *bp = bread(ip->dev, addr);
+    uint *entries = (uint*)bp->data;
+    uint index = bn / divisor;
+
+    bn %= divisor;
+    if(entries[index] == 0){
+      entries[index] = balloc(ip->dev);
+      log_write(bp);
+    }
+    addr = entries[index];
+    brelse(bp);
+
+    if(level > 1)
+      divisor /= NINDIRECT;
+  }
+
+  return addr;
+}
+
+// 返回 inode 中第 bn 个逻辑数据块对应的磁盘块号；不存在时按需分配。
 static uint
 bmap(struct inode *ip, uint bn)
 {
-  uint addr, *a;
-  struct buf *bp;
-
   if(bn < NDIRECT){
-    if((addr = ip->addrs[bn]) == 0)
-      ip->addrs[bn] = addr = balloc(ip->dev);
-    return addr;
+    if(ip->addrs[bn] == 0)
+      ip->addrs[bn] = balloc(ip->dev);
+    return ip->addrs[bn];
   }
-  bn -= NDIRECT;
 
-  if(bn < NINDIRECT){
-    // Load indirect block, allocating if necessary.
-    if((addr = ip->addrs[NDIRECT]) == 0)
-      ip->addrs[NDIRECT] = addr = balloc(ip->dev);
+  uint64 indirect_bn = bn - NDIRECT;
+  for(int depth = 1; depth <= NINDIRECT_LEVELS; depth++){
+    uint64 capacity = indirect_capacity[depth - 1];
 
-    bp = bread(ip->dev, addr);
-    a = (uint*)bp->data;
-    if((addr = a[bn]) == 0){
-      a[bn] = addr = balloc(ip->dev);
-      log_write(bp);
+    if(indirect_bn < capacity){
+      uint root_index = NDIRECT + depth - 1;
+      if(ip->addrs[root_index] == 0)
+        ip->addrs[root_index] = balloc(ip->dev);
+      return bmap_indirect(ip, ip->addrs[root_index], indirect_bn, depth);
     }
-    brelse(bp);
-    return addr;
-  }
-  
-  bn -= NINDIRECT;
-
-  if(bn < NDOUBLEINDIRECT){
-    // Load  double indirect block, allocating if necessary.
-    if((addr = ip->addrs[NDIRECT+1]) == 0)
-      ip->addrs[NDIRECT+1] = addr = balloc(ip->dev);
-    
-    bp = bread(ip->dev, addr);
-    a = (uint*)bp->data;
-
-    uint level1 = bn / NINDIRECT;
-    if((addr = a[level1]) == 0){
-      a[level1] = addr = balloc(ip->dev);
-      log_write(bp);
-    }
-    brelse(bp);
-
-    bp = bread(ip->dev, addr);
-    a = (uint*)bp->data;
-
-    uint level2 = bn % NINDIRECT;
-    if((addr = a[level2]) == 0){
-      a[level2] = addr = balloc(ip->dev);
-      log_write(bp);
-    }
-    brelse(bp);
-
-    return addr;
+    indirect_bn -= capacity;
   }
 
   panic("bmap: out of range");
 }
 
-// Truncate inode (discard contents).
-// Caller must hold ip->lock.
+struct indirect_frame {
+  uint addr;
+  uint next;
+  struct buf *bp;
+};
+
+// 使用显式栈后序遍历间接索引树：先释放叶子数据块，再逐层释放索引块。
+static void
+bfree_indirect(uint dev, uint root, int depth)
+{
+  struct indirect_frame stack[NINDIRECT_LEVELS];
+  int level = 0;
+
+  stack[0].addr = root;
+  stack[0].next = 0;
+  stack[0].bp = bread(dev, root);
+
+  while(level >= 0){
+    struct indirect_frame *frame = &stack[level];
+    uint *entries = (uint*)frame->bp->data;
+
+    if(level == depth - 1){
+      // 最后一层索引块直接指向数据块。
+      while(frame->next < NINDIRECT){
+        uint addr = entries[frame->next++];
+        if(addr)
+          bfree(dev, addr);
+      }
+    } else {
+      // 中间层索引块指向下一层索引块，逐个压栈处理。
+      while(frame->next < NINDIRECT && entries[frame->next] == 0)
+        frame->next++;
+      if(frame->next < NINDIRECT){
+        uint child = entries[frame->next++];
+        level++;
+        stack[level].addr = child;
+        stack[level].next = 0;
+        stack[level].bp = bread(dev, child);
+        continue;
+      }
+    }
+
+    brelse(frame->bp);
+    bfree(dev, frame->addr);
+    level--;
+  }
+}
+
+// 截断 inode 并释放全部数据块和各级间接索引块。
+// 调用者必须持有 ip->lock。
 void
 itrunc(struct inode *ip)
 {
-  int i, j, k;
-  struct buf *bp, *nbp;//level 1, 2
-  uint *a, *na;//level 1, 2
-
-  for(i = 0; i < NDIRECT; i++){
+  for(int i = 0; i < NDIRECT; i++){
     if(ip->addrs[i]){
       bfree(ip->dev, ip->addrs[i]);
       ip->addrs[i] = 0;
     }
   }
 
-  if(ip->addrs[NDIRECT]){
-    bp = bread(ip->dev, ip->addrs[NDIRECT]);
-    a = (uint*)bp->data;
-    for(j = 0; j < NINDIRECT; j++){
-      if(a[j])
-        bfree(ip->dev, a[j]);
+  for(int depth = 1; depth <= NINDIRECT_LEVELS; depth++){
+    uint root_index = NDIRECT + depth - 1;
+    if(ip->addrs[root_index]){
+      bfree_indirect(ip->dev, ip->addrs[root_index], depth);
+      ip->addrs[root_index] = 0;
     }
-    brelse(bp);
-    bfree(ip->dev, ip->addrs[NDIRECT]);
-    ip->addrs[NDIRECT] = 0;
-  }
-
-  if(ip->addrs[NDIRECT+1]){
-    
-    bp = bread(ip->dev, ip->addrs[NDIRECT+1]);
-    a = (uint*)bp->data;
-    for(j = 0; j < NINDIRECT; j++){
-      //level 1
-      if(a[j]){
-        nbp = bread(ip->dev, a[j]);
-        na = (uint*)nbp->data;
-        for(k = 0; k < NINDIRECT; k++){
-          //level 2
-          if(na[k])
-            bfree(ip->dev, na[k]);
-        }
-        bfree(ip->dev, a[j]);
-        brelse(nbp);
-        //a[j] = 0;
-      }
-    }
-    brelse(bp);
-    bfree(ip->dev, ip->addrs[NDIRECT+1]);
-    ip->addrs[NDIRECT+1] = 0;
   }
 
   ip->size = 0;


### PR DESCRIPTION
## 中心认知

多级间接块的分配与释放应由同一套“层级深度 + 每层容量”模型驱动，而不是为一级、二级、三级分别复制分支和嵌套循环。

Closes #33
Related to #29

## 基线

- 当前 `main` 基线：`0a7ecdf4fc543ce33b0157a7a49cc4b5d114775e`
- 原始提交分支：`xv6-lab9`
- `xv6-lab9` 提交：`b98a8ff2e16b8d5a3f01cced6b0975af552a9824`
- 基于 `main` 的移植提交：`88cc427262358b626b6caaa5e23b0b587cb3e379`
- 移植提交信息保留了 `cherry picked from` 来源。

## 改动

- `bmap()`：
  - 保留直接块快速路径；
  - 通过容量表选择间接树深度；
  - `bmap_indirect()` 迭代计算每层索引并按需分配；
- `itrunc()`：
  - 直接块循环释放；
  - `bfree_indirect()` 使用显式栈进行后序遍历；
  - 先释放叶子数据块，再自底向上释放索引块；
- 新增和修改的相关注释统一使用中文；
- 磁盘格式、`NDIRECT`、`MAXFILE` 和现有单文件容量保持不变。

## 不变量

- 一级、二级间接块的逻辑块号映射与原实现一致；
- 缺失索引块和数据块仍按需分配并调用 `log_write()`；
- 每个 `bread()` 均对应 `brelse()`；
- 截断完成后直接块与所有间接根地址归零，`size` 归零并写回 inode。

## 验证

当前执行环境无法联网克隆仓库，因此尚未运行 xv6 的真实 `make`、QEMU、`bigfile` 和 `usertests`，不得标记为通过。

已完成独立 C 内存模型验证（`gcc -std=gnu11 -Wall -Wextra -Werror`）：

- 覆盖全部直接块、一级间接块和二级间接块；
- 重复映射同一逻辑块返回相同物理块；
- 不同逻辑块不会错误复用同一块；
- `itrunc()` 后数据块和索引块全部释放；
- 结果：`iterative indirect mapping/free: ok`。

## 待补真实验证

- [ ] `make clean && make`
- [ ] QEMU 中运行 `bigfile`
- [ ] 删除 `big.file` 后再次运行 `bigfile`，验证空间回收
- [ ] 运行文件系统相关 `usertests`
- [ ] 按需补 `CPUS=1` 验证

## 教学边界

本次只重构当前直接块、一级间接块、二级间接块的实现方式，不增加三级间接块，也不实现 4 GiB 文件长度和偏移量支持。后续 #29 增加更深层级时，可以扩展容量表和 inode 根槽位，而无需继续复制 `bmap()` / `itrunc()` 分支。