### PR TITLE
[Refactor] 清理 page fault 路径中的魔数与重复 VMA 查找

### DIFF
--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -21,6 +21,11 @@ void kernelvec();
 
 extern int devintr();
 
+enum scause_code {
+  SCAUSE_LOAD_PAGE_FAULT = 13,
+  SCAUSE_STORE_PAGE_FAULT = 15,
+};
+
 void
 trapinit(void)
 {
@@ -51,12 +56,8 @@ restore_user_context(struct trapframe *trapframe,
 }
 
 static int
-mmap_fault(struct proc *p, uint64 va)
+mmap_fault(struct proc *p, struct VMA *v, uint64 va)
 {
-  struct VMA *v = vma_find(p, va);
-  if(v == 0)
-    return -1;
-
   uint64 va0 = PGROUNDDOWN(va);
   pte_t *existing = walk(p->pagetable, va0, 0);
   if(existing && (*existing & PTE_V))
@@ -99,11 +100,11 @@ mmap_fault(struct proc *p, uint64 va)
 static int
 handle_user_page_fault(struct proc *p, uint64 scause, uint64 va)
 {
-  // TODO: 15等数还是用枚举维护更好，不然就是魔数猜这里是store page fault
-  if(scause == 15 && cow_alloc(p->pagetable, va) == 0)
+  if(scause == SCAUSE_STORE_PAGE_FAULT && cow_alloc(p->pagetable, va) == 0)
     return 0;
-  // TODO: 这里mmap_fault中也会调用一次vma_find，重复调用了
-  if(vma_find(p, va) && mmap_fault(p, va) == 0)
+
+  struct VMA *v = vma_find(p, va);
+  if(v && mmap_fault(p, v, va) == 0)
     return 0;
   return uvmlazyalloc(p, va);
 }
@@ -137,7 +138,8 @@ usertrap(void)
     syscall();
   } else if((which_dev = devintr()) != 0){
     // device interrupt
-  } else if(r_scause() == 13 || r_scause() == 15){
+  } else if(r_scause() == SCAUSE_LOAD_PAGE_FAULT ||
+            r_scause() == SCAUSE_STORE_PAGE_FAULT){
     if(handle_user_page_fault(p, r_scause(), r_stval()) < 0)
       p->killed = 1;
   } else {


### PR DESCRIPTION
Closes #42

Follow-up: #44

## 中心范围

清理用户态 page fault 分发路径中的两个局部 TODO，不改变 COW、mmap 与 lazy allocation 的处理顺序和既有语义。

## 基线

- `main`: `bcc422bda4a9730f9b92a455ecb4e265eb745e5d`

## 修改内容

- 在 `kernel/trap.c` 内增加局部 `enum scause_code`，具名表示 load/store page fault。
- 用 `SCAUSE_LOAD_PAGE_FAULT` 和 `SCAUSE_STORE_PAGE_FAULT` 替换 page fault 分支中的 `13`、`15`。
- `handle_user_page_fault()` 只执行一次 `vma_find()`。
- `mmap_fault()` 接收已经解析出的 `struct VMA *`，不再重复扫描当前进程的 VMA 数组。
- 删除对应的两个 TODO 注释。

## 行为边界

- COW 仍只在 store page fault 时优先处理。
- mmap fault 仍位于 COW 之后、lazy allocation 之前。
- 不调整 mmap 地址空间布局、VMA 生命周期、锁或全局池策略。

## 变更文件

- `kernel/trap.c`

## 验证

- [x] 分支相对基线仅包含一个提交、一个文件。
- [x] 检查最终 diff，不包含无关注释或格式变化。
- [ ] `make clean && make`：当前执行环境无法取得完整仓库工作区，未运行。
- [ ] `mmaptest`：未运行。
- [ ] `lazytests`：未运行。
- [ ] `cowtest`：未运行。

本 PR 保持 Draft，待在完整 xv6 环境中完成构建与相关回归后再进入 review。