### PR TITLE
ci: 集成 Lab1-10 的 xv6 回归测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: xv6 CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xv6-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-riscv64-linux-gnu \
+            binutils-riscv64-linux-gnu \
+            qemu-system-misc \
+            python3-pexpect
+
+      - name: Build xv6
+        run: |
+          make clean
+          make -j2
+
+      - name: Run Lab1-10 regression
+        run: python3 tests/run.py --suite pr --cpus 3
+
+      - name: Run complete usertests
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: python3 tests/run.py --suite usertests-full --cpus 3
+
+      - name: Upload QEMU logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xv6-test-results-${{ github.run_id }}
+          path: test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
             qemu-system-misc \
             python3-pexpect
 
-      - name: Validate test runner
+      - name: Unit-test regression grader
         run: |
-          python3 -m py_compile tests/run.py
+          python3 -m py_compile tests/run.py tests/test_runner.py
+          make test-unit
           python3 tests/run.py --list
 
       - name: Build xv6
@@ -43,12 +44,12 @@ jobs:
           make clean
           make -j2
 
-      - name: Run Lab1-10 regression
-        run: python3 tests/run.py --suite pr --cpus 3
+      - name: Run Lab1-10 QEMU regression
+        run: make test-integration CPUS=3
 
       - name: Run complete usertests
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: python3 tests/run.py --suite usertests-full --cpus 3
+        run: make test-usertests CPUS=3
 
       - name: Upload QEMU logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
             qemu-system-misc \
             python3-pexpect
 
+      - name: Validate test runner
+        run: |
+          python3 -m py_compile tests/run.py
+          python3 tests/run.py --list
+
       - name: Build xv6
         run: |
           make clean

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _*
 *.asm
 *.sym
 *.img
+*.pyc
 vectors.S
 bootblock
 entryother
@@ -20,3 +21,5 @@ myapi.key
 xv6.out*
 .vagrant/
 submissions/
+__pycache__/
+test-results/

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,26 @@ ph: notxv6/ph.c
 barrier: notxv6/barrier.c
 	gcc -o barrier -g -O2 notxv6/barrier.c -pthread
 
-test-labs: $K/kernel fs.img
+# Default developer entry: validate the grader, then boot QEMU and run the
+# pull-request regression suite. Sub-makes keep the two phases ordered even
+# when the caller invokes make with -j.
+test:
+	$(MAKE) test-unit
+	$(MAKE) test-integration CPUS=$(CPUS)
+
+# Unit-test the grader itself. This target never boots QEMU and does not need
+# a built xv6 image.
+test-unit:
+	$(PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
+
+test-grader: test-unit
+
+# Integration/system tests: boot a fresh QEMU snapshot for every atomic suite
+# and validate xv6 through its user-visible behavior.
+test-integration: $K/kernel fs.img
 	$(PYTHON) tests/run.py --suite pr --cpus $(CPUS)
+
+test-labs: test-integration
 
 test-usertests: $K/kernel fs.img
 	$(PYTHON) tests/run.py --suite usertests-full --cpus $(CPUS)
@@ -210,4 +228,5 @@ test-suite: $K/kernel fs.img
 	@test -n "$(SUITE)" || (echo "usage: make test-suite SUITE=<suite> [CPUS=<n>]"; exit 2)
 	$(PYTHON) tests/run.py --suite $(SUITE) --cpus $(CPUS)
 
-.PHONY: clean qemu qemu-gdb gdb ph barrier test-labs test-usertests test-full test-suite
+.PHONY: clean qemu qemu-gdb gdb ph barrier test test-unit test-grader \
+	test-integration test-labs test-usertests test-full test-suite

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ TOOLPREFIX := $(shell if riscv64-unknown-elf-objdump -i 2>&1 | grep 'elf64-big' 
 endif
 
 QEMU = qemu-system-riscv64
+PYTHON ?= python3
 
 CC = $(TOOLPREFIX)gcc
 AS = $(TOOLPREFIX)gas
@@ -175,6 +176,7 @@ endif
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
+QEMUOPTS += $(QEMUEXTRA)
 
 qemu: $K/kernel fs.img
 	$(QEMU) $(QEMUOPTS)
@@ -195,4 +197,17 @@ ph: notxv6/ph.c
 barrier: notxv6/barrier.c
 	gcc -o barrier -g -O2 notxv6/barrier.c -pthread
 
-.PHONY: clean qemu qemu-gdb gdb ph barrier
+test-labs: $K/kernel fs.img
+	$(PYTHON) tests/run.py --suite pr --cpus $(CPUS)
+
+test-usertests: $K/kernel fs.img
+	$(PYTHON) tests/run.py --suite usertests-full --cpus $(CPUS)
+
+test-full: $K/kernel fs.img
+	$(PYTHON) tests/run.py --suite full --cpus $(CPUS)
+
+test-suite: $K/kernel fs.img
+	@test -n "$(SUITE)" || (echo "usage: make test-suite SUITE=<suite> [CPUS=<n>]"; exit 2)
+	$(PYTHON) tests/run.py --suite $(SUITE) --cpus $(CPUS)
+
+.PHONY: clean qemu qemu-gdb gdb ph barrier test-labs test-usertests test-full test-suite

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,19 +2,56 @@
 
 `tests/run.py` drives the integrated `main` kernel through QEMU and runs the host-side pthread exercises. It is a repository regression runner, not a copy of the course scoring scripts.
 
+`tests/test_runner.py` unit-tests the grader itself without booting QEMU. It checks suite composition, output matching, failure detection, counted expectations, and helper behavior.
+
 ## Commands
 
 ```bash
+# Default developer entry: grader unit tests, then Lab1-10 QEMU regression.
+make test
+
+# Validate only the grader/runner; does not build or boot xv6.
+make test-unit
+make test-grader
+
+# Build xv6 and run the PR-level QEMU integration suite.
+make test-integration
 make test-labs
+
+# Other scopes.
 make test-usertests
 make test-full
 make test-suite SUITE=lab-vm
 python3 tests/run.py --list
 ```
 
+`make test` is deliberately layered:
+
+```text
+unit-test grader
+→ build kernel and fs.img when required
+→ start QEMU snapshots
+→ execute xv6 commands
+→ match success and failure output
+→ stop QEMU and retain logs
+```
+
 Each atomic QEMU suite starts from `fs.img` with QEMU `-snapshot`, so disk writes are discarded when that suite finishes. `lab9-bigfile`, `lab9-symlink`, and `lab10-mmap` intentionally use separate snapshots because the large-file test substantially changes the guest file system.
 
 Raw output is stored below `test-results/<suite>/`. GitHub Actions uploads this directory when a run fails.
+
+## Test boundaries
+
+The layers verify different things:
+
+| Layer | Starts QEMU | What it validates |
+|---|---:|---|
+| `make test-unit` | No | The grader's suite graph, matching rules, failure rules, and helpers |
+| Host tests in `tests/run.py` | No | `ph` and `barrier` pthread behavior |
+| `make test-integration` | Yes | User programs, syscalls, traps, VM, locks, file system, and mmap behavior |
+| `make test-usertests` | Yes | Complete xv6 cross-subsystem regression |
+
+Most kernel behavior cannot be meaningfully proven by ordinary host unit tests because it depends on RISC-V traps, page tables, interrupts, multiple CPUs, and QEMU devices. Pure helpers can be extracted and unit-tested with stubs, but the final evidence must still include QEMU integration tests.
 
 ## Coverage map
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,41 @@
+# xv6 regression suites
+
+`tests/run.py` drives the integrated `main` kernel through QEMU and runs the host-side pthread exercises. It is a repository regression runner, not a copy of the course scoring scripts.
+
+## Commands
+
+```bash
+make test-labs
+make test-usertests
+make test-full
+make test-suite SUITE=lab-vm
+python3 tests/run.py --list
+```
+
+Each atomic QEMU suite starts from `fs.img` with QEMU `-snapshot`, so disk writes are discarded when that suite finishes. `lab9-bigfile`, `lab9-symlink`, and `lab10-mmap` intentionally use separate snapshots because the large-file test substantially changes the guest file system.
+
+Raw output is stored below `test-results/<suite>/`. GitHub Actions uploads this directory when a run fails.
+
+## Coverage map
+
+| Lab | Stable regression coverage |
+|---|---|
+| Lab1 util | `sleep`, `pingpong`, `primes`, `find`, `xargs` |
+| Lab2 syscall | `trace`, `sysinfotest` |
+| Lab3 page tables | `usertests` copyin/copyout/copyinstr and address-space growth paths |
+| Lab4 traps | `bttest`, `alarmtest` |
+| Lab5 lazy allocation | `lazytests` |
+| Lab6 COW | `cowtest` |
+| Lab7 threads | `uthread`, host `ph`, host `barrier` |
+| Lab8 locks | allocator and buffer-cache behavior under `usertests`; no shared-runner performance threshold |
+| Lab9 file system | `bigfile`, `symlinktest` |
+| Lab10 mmap | `mmaptest` |
+
+The Lab3 grader checks tied to fixed page-table addresses and answer files are intentionally excluded. Lab8 contention counters and the historical `ph` 1.25x speedup threshold are also excluded from blocking CI because they require test-only instrumentation or are unstable on shared GitHub runners. The integrated regression instead verifies observable behavior and keeps performance experiments separate.
+
+## Suite policy
+
+- `pr`: Lab1-10 behavior plus focused cross-lab `usertests`.
+- `usertests-full`: the complete xv6 regression, intended for `main` and manual runs.
+- `full`: Lab1-10 behavior plus complete `usertests`.
+- `CPUS=3` is the default. `CPUS=1` is useful as supplemental diagnosis, but it does not prove multi-core correctness.

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Run stable xv6 regression suites through QEMU or on the host."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pexpect
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULT_ROOT = REPO_ROOT / "test-results"
+DEFAULT_REJECTED = (
+    r"panic:",
+    r"kerneltrap",
+    r"exec .* failed",
+    r"\bFAIL(?:ED)?\b",
+)
+
+
+@dataclass(frozen=True)
+class CountExpectation:
+    pattern: str
+    minimum: int
+
+
+@dataclass(frozen=True)
+class TestCase:
+    name: str
+    commands: tuple[str, ...]
+    expected: tuple[str, ...] = ()
+    counted: tuple[CountExpectation, ...] = ()
+    rejected: tuple[str, ...] = DEFAULT_REJECTED
+    timeout: int = 90
+    host: bool = False
+
+
+@dataclass(frozen=True)
+class Suite:
+    name: str
+    tests: tuple[TestCase, ...] = ()
+    includes: tuple[str, ...] = ()
+    description: str = ""
+
+
+SUITES: dict[str, Suite] = {
+    "lab-basic": Suite(
+        name="lab-basic",
+        description="Lab1 util and Lab2 syscall behavior",
+        tests=(
+            TestCase("lab1-sleep", ("sleep 1",)),
+            TestCase(
+                "lab1-pingpong",
+                ("pingpong",),
+                expected=(r"\d+: received ping", r"\d+: received pong"),
+            ),
+            TestCase(
+                "lab1-primes",
+                ("primes",),
+                expected=(r"^prime 2$", r"^prime 31$"),
+            ),
+            TestCase(
+                "lab1-find",
+                ("mkdir ci_find", "echo x > ci_find/needle", "find . needle"),
+                expected=(r"^\./ci_find/needle$",),
+            ),
+            TestCase(
+                "lab1-xargs",
+                ("echo hello too | xargs echo bye",),
+                expected=(r"^bye hello too$",),
+            ),
+            TestCase(
+                "lab2-trace",
+                ("trace 32 grep hello README",),
+                expected=(r"syscall read ->",),
+            ),
+            TestCase(
+                "lab2-sysinfo",
+                ("sysinfotest",),
+                expected=(r"^sysinfotest: OK$",),
+            ),
+        ),
+    ),
+    "lab-vm": Suite(
+        name="lab-vm",
+        description="Lab3 page-table paths, Lab4 traps, Lab5 lazy allocation and Lab6 COW",
+        tests=(
+            TestCase(
+                "lab3-copyin",
+                ("usertests copyin",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=180,
+            ),
+            TestCase(
+                "lab3-copyout",
+                ("usertests copyout",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=180,
+            ),
+            TestCase(
+                "lab3-copyinstr",
+                ("usertests copyinstr1",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=180,
+            ),
+            TestCase(
+                "lab3-address-space-growth",
+                ("usertests sbrkmuch",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            ),
+            TestCase(
+                "lab4-backtrace",
+                ("bttest",),
+                counted=(CountExpectation(r"^0x[0-9a-f]+$", 3),),
+            ),
+            TestCase(
+                "lab4-alarm",
+                ("alarmtest",),
+                expected=(r"^test0 passed$", r"^\.?test1 passed$", r"^\.?test2 passed$"),
+                timeout=180,
+            ),
+            TestCase(
+                "lab5-lazy-allocation",
+                ("lazytests",),
+                expected=(r"^test lazy unmap: OK$", r"^test lazy alloc: OK$"),
+                timeout=240,
+            ),
+            TestCase(
+                "lab6-copy-on-write",
+                ("cowtest",),
+                expected=(r"^ALL COW TESTS PASSED$",),
+                timeout=300,
+            ),
+        ),
+    ),
+    "lab7-thread": Suite(
+        name="lab7-thread",
+        description="Lab7 user threads and host pthread exercises",
+        tests=(
+            TestCase(
+                "lab7-uthread",
+                ("uthread",),
+                expected=(r"^thread_schedule: no runnable threads$",),
+                timeout=180,
+            ),
+            TestCase(
+                "lab7-ph-correctness",
+                ("make ph", "./ph 2"),
+                counted=(CountExpectation(r"^\d+: 0 keys missing$", 2),),
+                host=True,
+            ),
+            TestCase(
+                "lab7-barrier",
+                ("make barrier", "./barrier 2"),
+                expected=(r"^OK; passed$",),
+                host=True,
+            ),
+        ),
+    ),
+    "lab8-locks": Suite(
+        name="lab8-locks",
+        description="Lab8 allocator and buffer-cache behavioral regression without unstable contention thresholds",
+        tests=(
+            TestCase(
+                "lab8-kalloc-behavior",
+                ("usertests sbrkmuch",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            ),
+            TestCase(
+                "lab8-bcache-create-delete",
+                ("usertests createdelete",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            ),
+            TestCase(
+                "lab8-bcache-concurrent-files",
+                ("usertests fourfiles",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            ),
+            TestCase(
+                "lab8-bcache-big-write",
+                ("usertests bigwrite",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            ),
+        ),
+    ),
+    "lab9-bigfile": Suite(
+        name="lab9-bigfile",
+        description="Lab9 large-file mapping on an isolated disk snapshot",
+        tests=(
+            TestCase(
+                "lab9-bigfile",
+                ("bigfile",),
+                expected=(r"^wrote 65803 blocks$", r"^bigfile done; ok$"),
+                timeout=360,
+            ),
+        ),
+    ),
+    "lab9-symlink": Suite(
+        name="lab9-symlink",
+        description="Lab9 symbolic-link behavior on an isolated disk snapshot",
+        tests=(
+            TestCase(
+                "lab9-symlink",
+                ("symlinktest",),
+                expected=(r"^test symlinks: ok$", r"^test concurrent symlinks: ok$"),
+                timeout=180,
+            ),
+        ),
+    ),
+    "lab10-mmap": Suite(
+        name="lab10-mmap",
+        description="Lab10 mmap behavior on an isolated disk snapshot",
+        tests=(
+            TestCase(
+                "lab10-mmap",
+                ("mmaptest",),
+                expected=(
+                    r"^test mmap f: OK$",
+                    r"^test mmap private: OK$",
+                    r"^test mmap read/write: OK$",
+                    r"^test mmap dirty: OK$",
+                    r"^fork_test OK$",
+                ),
+                timeout=360,
+            ),
+        ),
+    ),
+    "usertests-core": Suite(
+        name="usertests-core",
+        description="Focused cross-lab regression used on pull requests",
+        tests=tuple(
+            TestCase(
+                f"usertests-{name}",
+                (f"usertests {name}",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=240,
+            )
+            for name in (
+                "sbrkbugs",
+                "forkforkfork",
+                "copyin",
+                "copyout",
+                "copyinstr1",
+                "createdelete",
+                "linkunlink",
+                "openiput",
+            )
+        ),
+    ),
+    "usertests-full": Suite(
+        name="usertests-full",
+        description="Complete xv6 usertests regression",
+        tests=(
+            TestCase(
+                "usertests-full",
+                ("usertests",),
+                expected=(r"^ALL TESTS PASSED$",),
+                timeout=900,
+            ),
+        ),
+    ),
+    "lab-concurrency": Suite(
+        name="lab-concurrency",
+        includes=("lab7-thread", "lab8-locks"),
+    ),
+    "lab-storage": Suite(
+        name="lab-storage",
+        includes=("lab9-bigfile", "lab9-symlink", "lab10-mmap"),
+    ),
+    "pr": Suite(
+        name="pr",
+        includes=(
+            "lab-basic",
+            "lab-vm",
+            "lab7-thread",
+            "lab8-locks",
+            "lab9-bigfile",
+            "lab9-symlink",
+            "lab10-mmap",
+            "usertests-core",
+        ),
+    ),
+    "full": Suite(
+        name="full",
+        includes=(
+            "lab-basic",
+            "lab-vm",
+            "lab7-thread",
+            "lab8-locks",
+            "lab9-bigfile",
+            "lab9-symlink",
+            "lab10-mmap",
+            "usertests-full",
+        ),
+    ),
+}
+
+
+class TestFailure(RuntimeError):
+    pass
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value)
+
+
+def _assert_output(test: TestCase, output: str) -> None:
+    flags = re.MULTILINE
+    for pattern in test.rejected:
+        if re.search(pattern, output, flags):
+            raise TestFailure(f"matched rejected pattern: {pattern}")
+    for pattern in test.expected:
+        if not re.search(pattern, output, flags):
+            raise TestFailure(f"missing expected pattern: {pattern}")
+    for expectation in test.counted:
+        count = len(re.findall(expectation.pattern, output, flags))
+        if count < expectation.minimum:
+            raise TestFailure(
+                f"pattern {expectation.pattern!r} matched {count} times; "
+                f"expected at least {expectation.minimum}"
+            )
+
+
+def _write_log(suite: str, test: str, output: str) -> Path:
+    directory = RESULT_ROOT / _safe_name(suite)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{_safe_name(test)}.log"
+    path.write_text(output, encoding="utf-8", errors="replace")
+    return path
+
+
+def _run_host_test(suite: str, test: TestCase) -> None:
+    chunks: list[str] = []
+    for command in test.commands:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            shell=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=test.timeout,
+            check=False,
+        )
+        chunks.append(f"$ {command}\n{completed.stdout}")
+        if completed.returncode != 0:
+            output = "\n".join(chunks)
+            log_path = _write_log(suite, test.name, output)
+            raise TestFailure(
+                f"host command exited with {completed.returncode}: {command}; log: {log_path}"
+            )
+    output = "\n".join(chunks)
+    log_path = _write_log(suite, test.name, output)
+    _assert_output(test, output)
+    print(f"PASS {test.name} ({log_path.relative_to(REPO_ROOT)})")
+
+
+def _start_qemu(cpus: int) -> pexpect.spawn:
+    command = (
+        "make -s --no-print-directory qemu "
+        f"CPUS={cpus} QEMUEXTRA=-snapshot"
+    )
+    child = pexpect.spawn(
+        "/bin/bash",
+        ["-lc", command],
+        cwd=str(REPO_ROOT),
+        encoding="utf-8",
+        codec_errors="replace",
+        timeout=120,
+    )
+    child.expect_exact("$ ")
+    return child
+
+
+def _stop_qemu(child: pexpect.spawn) -> None:
+    if not child.isalive():
+        return
+    child.sendcontrol("a")
+    child.send("x")
+    try:
+        child.expect(pexpect.EOF, timeout=5)
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        child.terminate(force=True)
+
+
+def _run_qemu_tests(suite: str, tests: Sequence[TestCase], cpus: int) -> None:
+    child = _start_qemu(cpus)
+    boot_output = child.before
+    try:
+        for test in tests:
+            chunks = [boot_output]
+            try:
+                for command in test.commands:
+                    child.timeout = test.timeout
+                    child.sendline(command)
+                    child.expect_exact("$ ")
+                    chunks.append(f"$ {command}\n{child.before}")
+                output = "\n".join(chunks)
+                log_path = _write_log(suite, test.name, output)
+                _assert_output(test, output)
+                print(f"PASS {test.name} ({log_path.relative_to(REPO_ROOT)})")
+            except (pexpect.TIMEOUT, pexpect.EOF) as exc:
+                chunks.append(child.before or "")
+                output = "\n".join(chunks)
+                log_path = _write_log(suite, test.name, output)
+                raise TestFailure(f"QEMU did not return to the shell; log: {log_path}") from exc
+    finally:
+        _stop_qemu(child)
+
+
+def _expand_suite(name: str, stack: tuple[str, ...] = ()) -> list[str]:
+    if name not in SUITES:
+        raise KeyError(name)
+    if name in stack:
+        raise RuntimeError(f"cyclic suite include: {' -> '.join(stack + (name,))}")
+    suite = SUITES[name]
+    if not suite.includes:
+        return [name]
+    expanded: list[str] = []
+    for child in suite.includes:
+        expanded.extend(_expand_suite(child, stack + (name,)))
+    return expanded
+
+
+def _deduplicate(values: Iterable[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def run_atomic_suite(name: str, cpus: int) -> None:
+    suite = SUITES[name]
+    print(f"\n== Suite {name}: {suite.description} ==")
+    host_tests = [test for test in suite.tests if test.host]
+    qemu_tests = [test for test in suite.tests if not test.host]
+    for test in host_tests:
+        _run_host_test(name, test)
+    if qemu_tests:
+        _run_qemu_tests(name, qemu_tests, cpus)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--suite",
+        action="append",
+        dest="suites",
+        help="suite name; may be supplied more than once",
+    )
+    parser.add_argument("--cpus", type=int, default=3, help="QEMU CPU count")
+    parser.add_argument("--list", action="store_true", help="list available suites")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list:
+        for name in sorted(SUITES):
+            suite = SUITES[name]
+            kind = "aggregate" if suite.includes else "atomic"
+            print(f"{name:20} {kind:9} {suite.description}")
+        return 0
+    if not args.suites:
+        raise SystemExit("at least one --suite is required")
+    if args.cpus < 1:
+        raise SystemExit("--cpus must be at least 1")
+
+    requested: list[str] = []
+    for name in args.suites:
+        try:
+            requested.extend(_expand_suite(name))
+        except KeyError as exc:
+            raise SystemExit(f"unknown suite: {exc.args[0]}") from exc
+
+    failures: list[str] = []
+    for name in _deduplicate(requested):
+        try:
+            run_atomic_suite(name, args.cpus)
+        except (TestFailure, subprocess.TimeoutExpired) as exc:
+            failures.append(f"{name}: {exc}")
+            print(f"FAIL {name}: {exc}", file=sys.stderr)
+
+    if failures:
+        print("\nFailed suites:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("\nAll requested suites passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run.py
+++ b/tests/run.py
@@ -379,7 +379,11 @@ def _start_qemu(cpus: int) -> pexpect.spawn:
         codec_errors="replace",
         timeout=120,
     )
-    child.expect_exact("$ ")
+    try:
+        child.expect_exact("$ ")
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        child.terminate(force=True)
+        raise
     return child
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,7 @@ judge the kernel.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -111,7 +112,13 @@ class SuiteCompositionTests(unittest.TestCase):
 
 class HelperTests(unittest.TestCase):
     def test_safe_name_removes_path_and_shell_characters(self) -> None:
-        self.assertEqual("lab-1-rm-rf", RUNNER._safe_name("lab 1/$(rm -rf)"))
+        safe = RUNNER._safe_name("lab 1/$(rm -rf)")
+
+        self.assertIsNotNone(re.fullmatch(r"[A-Za-z0-9_.-]+", safe))
+        self.assertNotIn("/", safe)
+        self.assertNotIn("$", safe)
+        self.assertNotIn("(", safe)
+        self.assertNotIn(")", safe)
 
 
 if __name__ == "__main__":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Unit tests for the xv6 regression grader itself.
+
+These tests do not start QEMU. They validate suite composition, output
+matching, failure detection, and helper behavior before the grader is used to
+judge the kernel.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+RUNNER_PATH = Path(__file__).with_name("run.py")
+SPEC = importlib.util.spec_from_file_location("xv6_regression_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load regression runner from {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class OutputMatchingTests(unittest.TestCase):
+    def test_expected_and_counted_patterns_pass(self) -> None:
+        test = RUNNER.TestCase(
+            name="sample",
+            commands=("sample",),
+            expected=(r"^done$",),
+            counted=(RUNNER.CountExpectation(r"^item \d+$", 2),),
+        )
+
+        RUNNER._assert_output(test, "item 1\nitem 2\ndone\n")
+
+    def test_missing_expected_pattern_fails(self) -> None:
+        test = RUNNER.TestCase(
+            name="sample",
+            commands=("sample",),
+            expected=(r"^done$",),
+        )
+
+        with self.assertRaisesRegex(RUNNER.TestFailure, "missing expected pattern"):
+            RUNNER._assert_output(test, "not done\n")
+
+    def test_rejected_kernel_failure_fails(self) -> None:
+        test = RUNNER.TestCase(name="sample", commands=("sample",))
+
+        with self.assertRaisesRegex(RUNNER.TestFailure, "matched rejected pattern"):
+            RUNNER._assert_output(test, "panic: broken invariant\n")
+
+    def test_counted_pattern_requires_minimum(self) -> None:
+        test = RUNNER.TestCase(
+            name="sample",
+            commands=("sample",),
+            counted=(RUNNER.CountExpectation(r"^frame$", 3),),
+        )
+
+        with self.assertRaisesRegex(RUNNER.TestFailure, "expected at least 3"):
+            RUNNER._assert_output(test, "frame\nframe\n")
+
+
+class SuiteCompositionTests(unittest.TestCase):
+    def test_all_include_references_exist(self) -> None:
+        for suite in RUNNER.SUITES.values():
+            for included in suite.includes:
+                self.assertIn(included, RUNNER.SUITES, f"{suite.name} includes unknown suite")
+
+    def test_atomic_suites_have_tests(self) -> None:
+        for suite in RUNNER.SUITES.values():
+            if not suite.includes:
+                self.assertTrue(suite.tests, f"atomic suite {suite.name} has no tests")
+
+    def test_suite_names_match_dictionary_keys(self) -> None:
+        for key, suite in RUNNER.SUITES.items():
+            self.assertEqual(key, suite.name)
+
+    def test_pr_suite_covers_lab1_through_lab10(self) -> None:
+        expanded = RUNNER._deduplicate(RUNNER._expand_suite("pr"))
+        expected = {
+            "lab-basic",
+            "lab-vm",
+            "lab7-thread",
+            "lab8-locks",
+            "lab9-bigfile",
+            "lab9-symlink",
+            "lab10-mmap",
+            "usertests-core",
+        }
+        self.assertEqual(expected, set(expanded))
+
+    def test_full_suite_uses_complete_usertests(self) -> None:
+        expanded = RUNNER._deduplicate(RUNNER._expand_suite("full"))
+        self.assertIn("usertests-full", expanded)
+        self.assertNotIn("usertests-core", expanded)
+
+    def test_no_duplicate_test_names_inside_atomic_suite(self) -> None:
+        for suite in RUNNER.SUITES.values():
+            names = [test.name for test in suite.tests]
+            self.assertEqual(
+                len(names),
+                len(set(names)),
+                f"suite {suite.name} contains duplicate test names",
+            )
+
+    def test_unknown_suite_is_rejected(self) -> None:
+        with self.assertRaises(KeyError):
+            RUNNER._expand_suite("does-not-exist")
+
+
+class HelperTests(unittest.TestCase):
+    def test_safe_name_removes_path_and_shell_characters(self) -> None:
+        self.assertEqual("lab-1-rm-rf", RUNNER._safe_name("lab 1/$(rm -rf)"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 实现内容

- 新增 `tests/run.py`，统一驱动 QEMU shell 和宿主机 pthread 测试：
  - 等待 xv6 shell、按 suite 执行命令并匹配成功输出；
  - 识别 `panic`、`kerneltrap`、`exec ... failed` 和显式失败标志；
  - 为每个原子 suite 启动独立 QEMU，并保存 `test-results/<suite>/` 原始日志；
  - QEMU 启动或测试超时时终止进程，避免遗留后台实例。
- 按能力整理 Lab1-10 回归：
  - Lab1：`sleep`、`pingpong`、`primes`、`find`、`xargs`；
  - Lab2：`trace`、`sysinfotest`；
  - Lab3：`copyin/copyout/copyinstr` 和地址空间增长路径；
  - Lab4：`bttest`、`alarmtest`；
  - Lab5：`lazytests`；
  - Lab6：`cowtest`；
  - Lab7：`uthread`、宿主机 `ph`、`barrier`；
  - Lab8：分配器与 Buffer cache 的稳定行为回归；
  - Lab9：`bigfile`、`symlinktest`；
  - Lab10：`mmaptest`。
- `Makefile` 新增：
  - `QEMUEXTRA`，测试可传入 `-snapshot`；
  - `test-labs`、`test-usertests`、`test-full`、`test-suite` 入口。
- 新增 `.github/workflows/ci.yml`：
  - Draft PR 不执行 runner；转为 Ready for review 后运行；
  - PR 构建一次并顺序执行 Lab1-10 与精选 `usertests`，不使用高开销 matrix；
  - `main` push 或手动触发时额外运行完整 `usertests`；
  - 失败时上传测试日志。
- 新增 `tests/README.md`，记录 suite 入口、覆盖关系和排除边界。

## 实现说明

- 没有原样复制 `grade-lab-*`：课程分数、`time.txt`、`answers-*.txt`、固定 PID/物理地址等评分语义不适合作为长期 `main` 回归。
- Lab9 `bigfile`、Lab9 `symlinktest` 和 Lab10 `mmaptest` 使用三个独立 QEMU snapshot，避免大文件写入污染后续测试。
- Lab8 首版只阻塞行为正确性，不重新引入课程专用锁统计 syscall，也不使用 GitHub 共享 runner 上不稳定的 1.25x 性能倍率作为门禁。
- `CPUS=3` 是 CI 默认配置；单核只作为补充诊断，不用于证明并发正确。

## 测试与验证

| 检查项 | 结果 |
|---|---|
| `python3 -m py_compile tests/run.py` | 通过：runner Python 语法检查完成 |
| `python3 tests/run.py --list` | 通过：原子 suite 与聚合 suite 均可展开显示 |
| YAML 解析 `.github/workflows/ci.yml` | 通过：工作流文件可被 YAML 解析 |
| `main...HEAD` diff 检查 | 通过：仅修改 CI、测试 runner、说明、Makefile 测试入口和忽略规则 |
| `make clean && make` | 未运行：当前执行环境无法解析 GitHub，且无法取得完整 checkout 与 RISC-V/QEMU 工具链 |
| Lab1-10 QEMU 回归 | 未运行：PR 保持 Draft，工作流按设计不会在 Draft 状态消耗 runner 分钟 |
| 完整 `usertests` | 未运行：仅在 `main` push 或手动完整回归中执行 |

## 影响范围

- 普通 `make`、`make qemu` 和现有用户程序 ABI 不变。
- `QEMUEXTRA` 默认为空，仅测试 runner 传入 `-snapshot`。
- 新增 GitHub Actions 依赖：`gcc-riscv64-linux-gnu`、`binutils-riscv64-linux-gnu`、`qemu-system-misc`、`python3-pexpect`。
- `test-results/`、Python bytecode 和 `__pycache__/` 不进入版本控制。

## 非目标

- 本 PR 不新增或重构 Lab1-10 内核机制。
- 不加入课程答案检查、评分和耗时统计。
- 不加入 Lab8 锁竞争计数 ABI 或性能 benchmark 门禁。
- 不在 Draft 状态主动触发 GitHub Actions。

## 风险与注意事项

- 当前尚无真实 QEMU 运行证据；转为 Ready for review 后应以首次 Actions 结果校准可能存在的输出格式差异和超时阈值。
- runner 通过 xv6 shell prompt 判断命令完成，审阅时需重点确认 `pexpect` 的 QEMU 启停路径。
- Lab8 当前覆盖正确性回归，不等价于原课程 grader 的锁竞争指标验证。

## 审阅重点

- `tests/run.py` 的 QEMU 生命周期、超时与失败日志路径。
- suite 之间的磁盘隔离是否足以避免相互污染。
- PR / `main` 两种事件下完整 `usertests` 的执行边界。
- Lab3、Lab8 当前稳定行为覆盖是否符合长期主分支回归目标。

## 关联项

- Related to #45

基线：`main@bcc422bda4a9730f9b92a455ecb4e265eb745e5d`