### PR TITLE
ci: 仅在 Ready PR 上运行 xv6 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: xv6 CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,7 +13,7 @@ concurrency:
 
 jobs:
   regression:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 50
 
@@ -48,7 +45,6 @@ jobs:
         run: make test-integration CPUS=3
 
       - name: Run complete usertests
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: make test-usertests CPUS=3
 
       - name: Upload QEMU logs


### PR DESCRIPTION
## 实现内容
- 移除默认分支 `push` 与 `workflow_dispatch` 入口。
- 保留 PR 生命周期事件，并通过非 Draft 门禁阻止 Draft PR 分配 runner。
- 将完整 `usertests` 纳入 Ready PR 的统一回归路径。

## 验证
- 改动基于最新 `main` 重新创建，分支不落后默认分支。
- 已反查工作流触发器和完整测试步骤。
- PR 转为 Ready for review 后，由 GitHub Actions 实际解析并运行。

## 影响与风险
- 合并后不再支持直接推送或手动按钮运行 CI。
- Ready PR 的测试负载会包含完整 `usertests`，耗时高于原普通 PR 路径。