### PR TITLE
fix: 收敛 bigfile 到 MAXFILE 寻址边界

### DIFF
--- a/kernel/param.h
+++ b/kernel/param.h
@@ -11,4 +11,4 @@
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
 // 文件系统镜像需要容纳 MAXFILE 数据块、间接索引块和仓库内置用户程序。
 #define FSSIZE       200000  // size of file system in blocks
-#define MAXPATH      128   // maximum path name
+#define MAXPATH      128   // maximum file path name

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -9,5 +9,6 @@
 #define MAXOPBLOCKS  10  // max # of blocks any FS op writes
 #define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
 #define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
-#define FSSIZE       1000  // size of file system in blocks
-#define MAXPATH      128   // maximum file path name
+// 文件系统镜像需要容纳 MAXFILE 数据块、间接索引块和仓库内置用户程序。
+#define FSSIZE       200000  // size of file system in blocks
+#define MAXPATH      128   // maximum path name

--- a/tests/guest/bigfile.c
+++ b/tests/guest/bigfile.c
@@ -4,11 +4,20 @@
 #include "kernel/fcntl.h"
 #include "kernel/fs.h"
 
+/**
+ * 验证 inode 能映射并读回 MAXFILE 个数据块，同时拒绝第 MAXFILE + 1 个块。
+ *
+ * 测试使用由 fs.h 定义的 MAXFILE 作为唯一边界，避免文件系统配置或寻址布局
+ * 变化后继续无限写入，最终以磁盘耗尽或 QEMU 超时结束。
+ *
+ * @return 成功时调用 exit(0)；任一写入、边界或读回校验失败时调用 exit(-1)。
+ */
 int
-main()
+main(void)
 {
-  char buf[BSIZE];
+  char buf[BSIZE] = {0};
   int fd, i, blocks;
+  const int max_blocks = (int)MAXFILE;
 
   fd = open("big.file", O_CREATE | O_WRONLY);
   if(fd < 0){
@@ -16,32 +25,36 @@ main()
     exit(-1);
   }
 
-  blocks = 0;
-  while(1){
+  // 只写入寻址布局明确允许的块数，避免依赖“持续写到失败”终止测试。
+  for(blocks = 0; blocks < max_blocks; blocks++){
     *(int*)buf = blocks;
-    int cc = write(fd, buf, sizeof(buf));
-    if(cc <= 0)
-      break;
-    blocks++;
-    if (blocks % 100 == 0)
+    int cc = write(fd, buf, BSIZE);
+    if(cc != BSIZE){
+      printf("bigfile: write error at block %d\n", blocks);
+      exit(-1);
+    }
+    if((blocks + 1) % 100 == 0)
       printf(".");
   }
 
-  printf("\nwrote %d blocks\n", blocks);
-  if(blocks != 65803) {
-    printf("bigfile: file is too small\n");
+  // writei 必须在 MAXFILE * BSIZE 边界拒绝写入，且不能推进文件偏移。
+  *(int*)buf = max_blocks;
+  if(write(fd, buf, BSIZE) >= 0){
+    printf("bigfile: accepted block %d beyond MAXFILE\n", max_blocks);
     exit(-1);
   }
 
+  printf("\nwrote %d blocks\n", blocks);
   close(fd);
+
   fd = open("big.file", O_RDONLY);
   if(fd < 0){
     printf("bigfile: cannot re-open big.file for reading\n");
     exit(-1);
   }
   for(i = 0; i < blocks; i++){
-    int cc = read(fd, buf, sizeof(buf));
-    if(cc <= 0){
+    int cc = read(fd, buf, BSIZE);
+    if(cc != BSIZE){
       printf("bigfile: read error at block %d\n", i);
       exit(-1);
     }
@@ -52,7 +65,7 @@ main()
     }
   }
 
+  close(fd);
   printf("bigfile done; ok\n");
-
   exit(0);
 }


### PR DESCRIPTION
## 中心认知与范围

`bigfile` 应验证 inode 的逻辑寻址上限，而不是通过无限写入等待任意失败。文件系统镜像容量必须足以让测试抵达 `MAXFILE`，测试本身明确区分：

1. `MAXFILE` 个数据块可以完整写入并读回；
2. 第 `MAXFILE + 1` 个数据块必须被拒绝。

本 PR 只修复该文件系统回归，不包含 PR #62 的内存可视化实现。

## 基线

- Base branch: `main`
- Base commit: `012201b2f6f0d9bf4fa22134186316c373a91ba0`
- 该基线已包含 PR #60 的 guest-first 测试机制。

## 实现了什么（功能清单一览）

- 将默认 `FSSIZE` 从 `1000` 扩大到 `200000` blocks，使 `fs.img` 能容纳 `MAXFILE` 数据块、间接索引块、元数据和内置程序。
- 在 `tests/guest/bigfile.c` 中使用 `MAXFILE` 作为唯一边界：
  - 写入恰好 `MAXFILE` 个块；
  - 第一次越界写必须失败；
  - 重新打开并逐块验证逻辑块序号；
  - 任一异常通过非零退出状态传播给 `xv6test`。
- Python runner 不再硬编码 `65803`，只消费 guest 的 `XV6TEST done status=0` 协议。

## 添加/修改了什么单元测试（断言类）

`tests/guest/bigfile.c` 断言：

- 最后一个合法逻辑块可写；
- 第一个非法逻辑块被拒绝；
- 全部合法块可读回且内容与逻辑块号一致；
- 测试通过 `xv6test --run lab9-bigfile` 注册入口执行。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
git fetch origin
git switch concept/63-bigfile-boundary
git pull --ff-only
make clean
make
make test-suite SUITE=lab9-bigfile CPUS=3
```

预期包含：

```text
wrote 65803 blocks
bigfile done; ok
XV6TEST ok 1 - lab9-bigfile
XV6TEST done status=0
All requested suites passed.
```

不得出现：

```text
balloc: out of blocks
bmap: out of range
bigfile: accepted block 65803 beyond MAXFILE
```

## 单元自动化测试结果

GitHub Actions run `29912931192`：

| 检查项 | 结果 |
|---|---|
| runner 单测 | 通过 |
| `make clean && make` | 通过，200000-block `fs.img` 正常生成 |
| `xv6test --run lab9-bigfile`，`CPUS=3` | 通过：写入 65803 块、越界被拒绝、完整读回 |
| symlink / mmap / Lab7 / Lab8 / focused core | artifact 中均为 `XV6TEST done status=0` |
| integration step | 被 runner 的 CRLF 假阴性判为失败；根因由 #65 / PR #66 单独修复 |
| complete usertests | 原 workflow 在 integration 非零后跳过 |

本 PR 的文件系统断言已真实通过；整条 CI 尚需等待 PR #66 修复 QEMU `\r\n` 匹配后重新运行。

## 影响与风险

- `fs.img` 逻辑容量由约 1 MiB 增加到约 200 MiB。
- 完整 `bigfile` 执行 65,803 次写入和读回，明显慢于普通用户测试。
- `MAXFILE`、inode 磁盘布局、直接/间接层级和文件偏移 ABI 均不变。
- PR 保持 Draft，等待 runner 修复合入并重新验证。

## review 主线（先看什么，再看什么）

1. `tests/guest/bigfile.c` 的最后合法块与第一个非法块；
2. 越界失败后是否仍能完整读回；
3. `kernel/param.h::FSSIZE` 是否只提供测试到达边界所需容量；
4. 确认没有修改 `kernel/fs.c` 或 inode ABI。

## 关联项

- Closes #63
- Related to #39
- Related to #60
- Related to #65
- Related to #62