### PR TITLE
fix: 规范化 QEMU 行尾后匹配 guest 协议

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -250,18 +250,25 @@ def _safe_name(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", value)
 
 
+def _normalize_output(output: str) -> str:
+    """统一终端行尾供正则匹配；原始日志仍由调用者原样保存。"""
+
+    return output.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def _assert_output(test: TestCase, output: str) -> None:
     """检查拒绝、必需和计数模式，不解释 guest 业务语义。"""
 
+    normalized = _normalize_output(output)
     flags = re.MULTILINE
     for pattern in test.rejected:
-        if re.search(pattern, output, flags):
+        if re.search(pattern, normalized, flags):
             raise TestFailure(f"matched rejected pattern: {pattern}")
     for pattern in test.expected:
-        if not re.search(pattern, output, flags):
+        if not re.search(pattern, normalized, flags):
             raise TestFailure(f"missing expected pattern: {pattern}")
     for expectation in test.counted:
-        count = len(re.findall(expectation.pattern, output, flags))
+        count = len(re.findall(expectation.pattern, normalized, flags))
         if count < expectation.minimum:
             raise TestFailure(
                 f"pattern {expectation.pattern!r} matched {count} times; "

--- a/tests/test_runner_crlf.py
+++ b/tests/test_runner_crlf.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""验证 QEMU CRLF 输出不会破坏 guest-first 协议匹配。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+RUNNER_PATH = Path(__file__).with_name("run.py")
+SPEC = importlib.util.spec_from_file_location("xv6_regression_runner_crlf", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load regression runner from {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class QemuLineEndingTests(unittest.TestCase):
+    """覆盖 pexpect 从 QEMU 收到的 CRLF 与裸 CR。"""
+
+    def test_guest_success_protocol_accepts_crlf(self) -> None:
+        test = RUNNER.TestCase(
+            name="guest",
+            commands=("xv6test --group lab3",),
+            expected=RUNNER.GUEST_SUCCESS,
+        )
+
+        RUNNER._assert_output(
+            test,
+            "XV6TEST summary selected=4 passed=4 failed=0\r\n"
+            "XV6TEST done status=0\r\n",
+        )
+
+    def test_counted_and_rejected_patterns_use_normalized_lines(self) -> None:
+        counted = RUNNER.TestCase(
+            name="frames",
+            commands=("xv6test --group lab4",),
+            expected=RUNNER.GUEST_SUCCESS,
+            counted=(RUNNER.CountExpectation(r"^0x[0-9a-f]+$", 2),),
+        )
+        RUNNER._assert_output(
+            counted,
+            "0x80001234\r0x80005678\rXV6TEST done status=0\r",
+        )
+
+        rejected = RUNNER.TestCase(name="panic", commands=("x",))
+        with self.assertRaisesRegex(RUNNER.TestFailure, "matched rejected pattern"):
+            RUNNER._assert_output(rejected, "panic: broken invariant\r\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 在 `tests/run.py` 匹配输出前将 `CRLF` 与裸 `CR` 统一为 `LF`。
- 原始 QEMU 日志仍原样写入 `test-results/`，只对正则匹配视图做规范化。
- expected、counted 与 rejected 三类模式共享同一规范化文本。

## 基线与依赖

- Base branch：`concept/63-bigfile-boundary`
- Base commit：`6fb611f4bd05f6ccde8ff329a3ad42894eddfb4f`
- 该堆叠基线包含 PR #64 的 `FSSIZE/MAXFILE` 修复，用于让完整 Lab1-Lab10 回归越过 bigfile。

## 添加/修改了什么单元测试（断言类）

新增 `tests/test_runner_crlf.py`：

- CRLF 的 `XV6TEST done status=0` 必须通过；
- 裸 CR 分隔的 backtrace 行仍能计数；
- CRLF 中的 `panic:` 仍必须失败。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
make test-unit
make test-integration CPUS=3
```

修复前，artifact 中已经出现成功协议，但 host runner 报 `missing expected pattern`；修复后同一 atomic suite 可以继续执行后续 guest group。

## 单元自动化测试结果

### 独立 runner 验证

GitHub Actions run `29914341868`：

| 检查项 | 结果 |
|---|---|
| runner 单测 | 通过，包含新增 CRLF 用例 |
| `make clean && make` | 通过 |
| integration | 已越过原来的第一项 CRLF 假失败；随后受旧 `FSSIZE` / 既有测试语义影响 |

### 与 PR #64 的组合验证

GitHub Actions run `29914752508`：

| 范围 | 结果 |
|---|---|
| runner 单测与构建 | 通过 |
| Lab1 | 通过 |
| Lab3-Lab6 | 通过 |
| Lab7 `uthread`、host `ph`、`barrier` | 通过 |
| Lab8 allocator / buffer-cache 行为 | 通过 |
| Lab9 bigfile、symlink | 通过 |
| Lab10 mmap | 通过 |
| focused core | 通过 |
| Lab2 sysinfo | 失败：旧测试假设 `sbrk()` eager allocation；由 #67 / PR #68 单独修复 |
| complete usertests | integration 非零后被 workflow 跳过 |

结论：CRLF 假阴性已修复。当前剩余失败与 runner 无关，是 `sysinfotest` 对 lazy allocation 的过期假设。

## review 主线（先看什么，再看什么）

1. `tests/run.py::_normalize_output()` 是否只影响匹配、不改写原始日志；
2. `_assert_output()` 的三类正则是否全部使用规范化文本；
3. `tests/test_runner_crlf.py` 是否覆盖成功、计数和拒绝路径。

## 边界

- 不修改 guest 测试语义；
- 不修改 suite 编排、timeout 或 workflow；
- 不把终端 CRLF 当成业务输出的一部分；
- PR 保持 Draft，等待堆叠回归全部收敛后再决定合并顺序。

Closes #65
Related to #60
Related to #64
Related to #67
Related to #62