### PR TITLE
test: 让 sysinfotest 适配 lazy allocation

### DIFF
--- a/tests/guest/sysinfotest.c
+++ b/tests/guest/sysinfotest.c
@@ -3,94 +3,98 @@
 #include "kernel/sysinfo.h"
 #include "user/user.h"
 
+#define TEST_PAGES 4
 
-void
-sinfo(struct sysinfo *info) {
-  if (sysinfo(info) < 0) {
-    printf("FAIL: sysinfo failed");
-    exit(1);
-  }
-}
-
-//
-// use sbrk() to count how many free physical memory pages there are.
-//
-int
-countfree()
+/**
+ * 调用 sysinfo 并在系统调用失败时终止测试。
+ *
+ * @param info 接收内核统计信息的用户态缓冲区。
+ */
+static void
+sinfo(struct sysinfo *info)
 {
-  uint64 sz0 = (uint64)sbrk(0);
-  struct sysinfo info;
-  int n = 0;
-
-  while(1){
-    if((uint64)sbrk(PGSIZE) == 0xffffffffffffffff){
-      break;
-    }
-    n += PGSIZE;
-  }
-  sinfo(&info);
-  if (info.freemem != 0) {
-    printf("FAIL: there is no free mem, but sysinfo.freemem=%d\n",
-      info.freemem);
-    exit(1);
-  }
-  sbrk(-((uint64)sbrk(0) - sz0));
-  return n;
-}
-
-void
-testmem() {
-  struct sysinfo info;
-  uint64 n = countfree();
-
-  sinfo(&info);
-
-  if (info.freemem!= n) {
-    printf("FAIL: free mem %d (bytes) instead of %d\n", info.freemem, n);
-    exit(1);
-  }
-
-  if((uint64)sbrk(PGSIZE) == 0xffffffffffffffff){
-    printf("sbrk failed");
-    exit(1);
-  }
-
-  sinfo(&info);
-
-  if (info.freemem != n-PGSIZE) {
-    printf("FAIL: free mem %d (bytes) instead of %d\n", n-PGSIZE, info.freemem);
-    exit(1);
-  }
-
-  if((uint64)sbrk(-PGSIZE) == 0xffffffffffffffff){
-    printf("sbrk failed");
-    exit(1);
-  }
-
-  sinfo(&info);
-
-  if (info.freemem != n) {
-    printf("FAIL: free mem %d (bytes) instead of %d\n", n, info.freemem);
+  if(sysinfo(info) < 0){
+    printf("FAIL: sysinfo failed\n");
     exit(1);
   }
 }
 
-void
-testcall() {
+/**
+ * 验证物理空闲页统计反映“首次触页”和“解除映射”，而不是仅反映 sbrk。
+ *
+ * 当前 xv6 使用 lazy allocation：sbrk() 只保留虚拟地址，真正的物理页在
+ * 第一次写入时分配。因此测试固定触碰少量页面，并允许页表页等额外实现开销
+ * 使空闲量下降超过 TEST_PAGES，但要求数据页本身至少被分配并最终归还。
+ */
+static void
+testmem(void)
+{
+  struct sysinfo before;
+  struct sysinfo touched;
+  struct sysinfo released;
+  uint64 bytes = TEST_PAGES * PGSIZE;
+
+  sinfo(&before);
+
+  char *base = sbrk(bytes);
+  if(base == (char *)-1){
+    printf("FAIL: sbrk reserve failed\n");
+    exit(1);
+  }
+
+  // 首次写入触发 lazy allocation，确保统计的是实际物理页而非虚拟保留量。
+  for(int page = 0; page < TEST_PAGES; page++)
+    base[page * PGSIZE] = page;
+
+  sinfo(&touched);
+  if(before.freemem < touched.freemem + bytes){
+    printf("FAIL: touching %d pages reduced free memory from %d to only %d\n",
+           TEST_PAGES, before.freemem, touched.freemem);
+    exit(1);
+  }
+  if((before.freemem - touched.freemem) % PGSIZE != 0){
+    printf("FAIL: free memory changed by a non-page-aligned amount\n");
+    exit(1);
+  }
+
+  if(sbrk(-bytes) == (char *)-1){
+    printf("FAIL: sbrk release failed\n");
+    exit(1);
+  }
+
+  sinfo(&released);
+  if(released.freemem < touched.freemem + bytes){
+    printf("FAIL: released pages did not return to allocator: touched=%d released=%d\n",
+           touched.freemem, released.freemem);
+    exit(1);
+  }
+}
+
+/**
+ * 验证 sysinfo 正常调用和非法用户指针回滚路径。
+ */
+static void
+testcall(void)
+{
   struct sysinfo info;
 
-  if (sysinfo(&info) < 0) {
+  if(sysinfo(&info) < 0){
     printf("FAIL: sysinfo failed\n");
     exit(1);
   }
 
-  if (sysinfo((struct sysinfo *) 0xeaeb0b5b00002f5e) !=  0xffffffffffffffff) {
+  if(sysinfo((struct sysinfo *)0xeaeb0b5b00002f5e) != -1){
     printf("FAIL: sysinfo succeeded with bad argument\n");
     exit(1);
   }
 }
 
-void testproc() {
+/**
+ * 验证 fork 创建和 wait 回收前后的活动进程计数。
+ */
+static void
+testproc(void)
+{
   struct sysinfo info;
   uint64 nproc;
   int status;
@@ -106,22 +110,29 @@ void testproc() {
   }
   if(pid == 0){
     sinfo(&info);
-    if(info.nproc != nproc+1) {
-      printf("sysinfotest: FAIL nproc is %d instead of %d\n", info.nproc, nproc+1);
+    if(info.nproc != nproc + 1){
+      printf("sysinfotest: FAIL nproc is %d instead of %d\n",
+             info.nproc, nproc + 1);
       exit(1);
     }
     exit(0);
   }
+
   wait(&status);
+  if(status != 0){
+    printf("sysinfotest: child failed with status %d\n", status);
+    exit(1);
+  }
+
   sinfo(&info);
-  if(info.nproc != nproc) {
-      printf("sysinfotest: FAIL nproc is %d instead of %d\n", info.nproc, nproc);
-      exit(1);
+  if(info.nproc != nproc){
+    printf("sysinfotest: FAIL nproc is %d instead of %d\n", info.nproc, nproc);
+    exit(1);
   }
 }
 
 int
-main(int argc, char *argv[])
+main(void)
 {
   printf("sysinfotest: start\n");
   testcall();


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 删除通过持续 `sbrk()` 耗尽全部物理内存的旧测试模型。
- 改为固定 4 页：reserve → touch → shrink。
- 明确区分虚拟地址保留和首次触页后的物理页物化。
- 允许页表页等实现开销使空闲量下降超过 4 页，但至少要求 4 个数据页被分配并归还。
- 保留非法指针和活动进程数量测试，并检查 fork 子进程退出状态。

## 基线与依赖

- Base branch：`concept/65-runner-crlf`
- Base commit：`bb00de60a10fb7e97e56339e44d4570905d43d1d`
- 堆叠基线已包含 PR #64 的 bigfile 修复与 PR #66 的 CRLF runner 修复。

## 添加/修改了什么单元测试（断言类）

`tests/guest/sysinfotest.c` 现在断言：

- `sysinfo()` 正常调用成功；
- 非法用户指针返回 `-1`；
- 触碰 4 个 lazy pages 后全局空闲内存至少下降 4 页，且变化按页对齐；
- shrink 后至少归还 4 个数据页；
- fork/wait 前后的 `nproc` 变化正确。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
make clean
make
make test-suite SUITE=lab-basic CPUS=3
make test-integration CPUS=3
```

或在 xv6 shell 中：

```text
xv6test --group lab2
```

预期：

```text
sysinfotest: OK
XV6TEST summary selected=3 passed=3 failed=0
XV6TEST done status=0
```

## 单元自动化测试结果

GitHub Actions run `29915732072`：

| 范围 | 结果 |
|---|---|
| runner 单测 | 通过 |
| `make clean && make` | 通过 |
| Lab2 tracemask | 通过 |
| Lab2 sysinfo | 通过：`sysinfotest: OK` |
| Lab2 trace smoke | 通过 |
| Lab1、Lab3、Lab7、Lab8、bigfile、symlink、mmap、focused core | 通过 |
| Lab4 guest 测试 | 退出状态通过 |
| Lab4 host backtrace 证据 | 失败：`bttest` 未真正触发现有内核 `backtrace()`；由 #69 / PR #70 单独修复 |
| complete usertests | integration 非零后被 workflow 跳过 |

结论：本 PR 的 lazy-aware `sysinfotest` 已在真实 QEMU 中通过；当前剩余失败不属于 sysinfo。

## review 主线（先看什么，再看什么）

1. `testmem()` 是否先触页再读取 `freemem`；
2. 断言是否只要求数据页最低消耗/回收，不把页表额外开销误判为错误；
3. 是否保留 bad-pointer 和 `nproc` 行为验证；
4. 确认未修改内核 `sysinfo` 或 lazy allocation 实现。

## 边界

- 测试只验证当前统计与页面生命周期，不通过一次 OOM 观察定义所有内存分配行为；
- 不恢复 eager allocation；
- 不修改 workflow 或 suite 编排；
- PR 保持 Draft，等待堆叠回归继续收敛。

Closes #67
Related to #60
Related to #64
Related to #66
Related to #69