### PR TITLE
feat: 为内核 backtrace 增加显式测试入口

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -112,6 +112,7 @@ extern uint64 sys_sigreturn(void);
 extern uint64 sys_symlink(void);
 extern uint64 sys_mmap(void);
 extern uint64 sys_munmap(void);
+extern uint64 sys_backtrace(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -142,6 +143,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_symlink]   sys_symlink,
 [SYS_mmap]      sys_mmap,
 [SYS_munmap]    sys_munmap,
+[SYS_backtrace] sys_backtrace,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -27,3 +27,4 @@
 #define SYS_symlink    26
 #define SYS_mmap       27
 #define SYS_munmap     28
+#define SYS_backtrace  29

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -33,6 +33,7 @@ static const char *const syscall_names[] = {
 [SYS_symlink]   = "symlink",
 [SYS_mmap]      = "mmap",
 [SYS_munmap]    = "munmap",
+[SYS_backtrace] = "backtrace",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -164,3 +164,18 @@ sys_sigreturn(void)
     p->in_handler = 0;
     return p->trapframe->a0;
 }
+
+/**
+ * 显式打印当前系统调用路径的内核栈回溯。
+ *
+ * 该入口只用于教学和调试，不接受用户地址，也不修改进程状态。将回溯从
+ * sys_sleep() 分离，避免普通 sleep 调用污染控制台。
+ *
+ * @return 打印完成后返回 0。
+ */
+uint64
+sys_backtrace(void)
+{
+  backtrace();
+  return 0;
+}

--- a/tests/guest/bttest.c
+++ b/tests/guest/bttest.c
@@ -2,9 +2,18 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
+/**
+ * 显式请求内核打印当前系统调用路径的栈回溯。
+ *
+ * 返回地址由内核写入控制台，宿主机 runner 负责检查至少三行完整地址；本测试
+ * 只验证调试系统调用能够正常返回，避免把普通 sleep() 当成隐藏触发器。
+ */
 int
-main(int argc, char *argv[])
+main(void)
 {
-  sleep(1);
+  if(backtrace() < 0){
+    printf("bttest: backtrace syscall failed\n");
+    exit(1);
+  }
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -31,6 +31,7 @@ int sigreturn(void);
 int symlink(char *target, char *path);
 char *mmap(void *addr, int length, int prot, int flags, int fd, int offset);
 int munmap(void *addr, int length);
+int backtrace(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -43,3 +43,4 @@ entry("sigreturn");
 entry("symlink");
 entry("mmap");
 entry("munmap");
+entry("backtrace");


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 新增只读教学调试系统调用：

```c
int backtrace(void);
```

- 调用链明确为：

```text
bttest
→ SYS_backtrace
→ sys_backtrace()
→ kernel/printf.c::backtrace()
→ 控制台返回地址
```

- 不再用普通 `sleep()` 作为隐藏触发器，不污染其他用户程序和测试的控制台输出。
- 将系统调用加入编号、分派表、名称表、用户声明和汇编 stub。

## 基线与依赖

- Base branch：`concept/67-sysinfo-lazy-test`
- Base commit：`73b0f2a33ba71e8855ba99817ceb4a10d05b07db`
- 堆叠基线已包含 PR #64、#66、#68。

## 添加/修改了什么单元测试（断言类）

- `tests/guest/bttest.c` 显式调用 `backtrace()` 并检查返回值。
- 现有 host runner 继续断言 Lab4 日志至少出现三行：

```text
0x<完整返回地址>
```

- guest 退出状态与 host 控制台证据必须同时成立，避免“空测试返回 0”。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
make clean
make
make test-suite SUITE=lab-vm CPUS=3
make test-integration CPUS=3
```

或在 xv6 shell 中：

```text
xv6test --group lab4
```

## 单元自动化测试结果

GitHub Actions run `29916969579`：

| 范围 | 结果 |
|---|---|
| runner 单测 | 通过 |
| `make clean && make` | 通过 |
| `bttest` 系统调用返回 | 通过 |
| 内核回溯地址 | 通过：输出 3 行完整 `0x...` 地址 |
| alarmtest | 通过 |
| Lab1、Lab2、Lab3、Lab7、Lab8、bigfile、symlink、mmap、focused core | 通过 |
| Lab5 lazytests | 失败：旧测试要求 1 GiB 超过当前 PLIC 上限，OOM 又没有逐页物化；由 #71 / PR #72 单独修复 |
| Lab6 COW | `lab-vm` 在 Lab5 失败后未继续执行，尚未获得本轮证据 |
| complete usertests | integration 非零后被 workflow 跳过 |

结论：本 PR 的显式 backtrace 调用链和控制台证据已真实通过；当前剩余失败不属于 backtrace。

## review 主线（先看什么，再看什么）

1. `sys_backtrace()` 是否只调用现有回溯函数且不接受用户地址；
2. 普通 `sys_sleep()` 是否保持无额外输出；
3. 系统调用编号、分派、名称表、stub 是否一致；
4. `bttest` 是否真正触发内核路径；
5. host 至少三帧检查是否继续有效。

## 边界

- 不实现符号解析；
- 不回溯用户栈；
- 不支持跨进程查看；
- 只输出当前系统调用的内核栈；
- `SYS_backtrace=29` 使后续堆叠的 `memsnapshot` 顺延到 30，未合入的 PR #49 也需要在更新主线时重新编号；
- PR 保持 Draft，等待堆叠回归继续收敛。

Closes #69
Related to #60
Related to #67
Related to #71
Related to #61