### PR TITLE
test: 让 lazytests 验证当前 PLIC 与真实 OOM

### DIFF
--- a/tests/guest/lazytests.c
+++ b/tests/guest/lazytests.c
@@ -8,26 +8,61 @@
 #include "kernel/memlayout.h"
 #include "kernel/riscv.h"
 
-#define REGION_SZ (1024 * 1024 * 1024)
+#define MAX_SPARSE_REGION (64 * 1024 * 1024)
+#define OOM_CHUNK_SIZE (4 * 1024 * 1024)
+
+/**
+ * 在当前 PLIC 用户地址上限内保留一段足够大的稀疏测试区。
+ *
+ * @param start 接收 sbrk 前的旧 break。
+ * @return 成功时返回页对齐区域大小；可用虚拟空间不足或 sbrk 失败时返回 -1。
+ */
+static int
+reserve_sparse_region(char **start)
+{
+  char *current = sbrk(0);
+  if(current == (char *)-1)
+    return -1;
+
+  uint64 address = (uint64)current;
+  if(address >= PLIC)
+    return -1;
+
+  uint64 room = PLIC - address;
+  uint64 region = MAX_SPARSE_REGION;
+  // sys_sbrk 要求 PGROUNDUP(newsz) 严格小于 PLIC，因此至少保留一页余量。
+  if(region + PGSIZE >= room)
+    region = PGROUNDDOWN(room / 2);
+  if(region < 4 * PGSIZE || region > 0x7fffffff)
+    return -1;
+
+  char *previous = sbrk((int)region);
+  if(previous == (char *)-1)
+    return -1;
+
+  *start = previous;
+  return (int)region;
+}
 
 void
 sparse_memory(char *s)
 {
   char *i, *prev_end, *new_end;
+  int region_size = reserve_sparse_region(&prev_end);
 
-  prev_end = sbrk(REGION_SZ);
-  if (prev_end == (char*)0xffffffffffffffffL) {
-    printf("sbrk() failed\n");
+  if(region_size < 0){
+    printf("unable to reserve sparse region below PLIC\n");
     exit(1);
   }
-  new_end = prev_end + REGION_SZ;
+  new_end = prev_end + region_size;
 
-  for (i = prev_end + PGSIZE; i < new_end; i += 64 * PGSIZE)
+  // 每 64 页只触碰一页，验证 sbrk 保留的其余虚拟页不会立即物化。
+  for(i = prev_end + PGSIZE; i < new_end; i += 64 * PGSIZE)
     *(char **)i = i;
 
-  for (i = prev_end + PGSIZE; i < new_end; i += 64 * PGSIZE) {
-    if (*(char **)i != i) {
-      printf("failed to read value from memory\n");
+  for(i = prev_end + PGSIZE; i < new_end; i += 64 * PGSIZE){
+    if(*(char **)i != i){
+      printf("failed to read value from sparse memory\n");
       exit(1);
     }
   }
@@ -40,31 +75,33 @@ sparse_memory_unmap(char *s)
 {
   int pid;
   char *i, *prev_end, *new_end;
+  int region_size = reserve_sparse_region(&prev_end);
 
-  prev_end = sbrk(REGION_SZ);
-  if (prev_end == (char*)0xffffffffffffffffL) {
-    printf("sbrk() failed\n");
+  if(region_size < 0){
+    printf("unable to reserve sparse unmap region below PLIC\n");
     exit(1);
   }
-  new_end = prev_end + REGION_SZ;
+  new_end = prev_end + region_size;
 
-  for (i = prev_end + PGSIZE; i < new_end; i += PGSIZE * PGSIZE)
+  for(i = prev_end + PGSIZE; i < new_end; i += PGSIZE * PGSIZE)
     *(char **)i = i;
 
-  for (i = prev_end + PGSIZE; i < new_end; i += PGSIZE * PGSIZE) {
+  for(i = prev_end + PGSIZE; i < new_end; i += PGSIZE * PGSIZE){
     pid = fork();
-    if (pid < 0) {
+    if(pid < 0){
       printf("error forking\n");
       exit(1);
-    } else if (pid == 0) {
-      sbrk(-1L * REGION_SZ);
+    } else if(pid == 0){
+      if(sbrk(-region_size) == (char *)-1)
+        exit(1);
+      // 该地址已被 shrink 移出 p->sz，正确行为是 usertrap 以 -1 杀死子进程。
       *(char **)i = i;
       exit(0);
     } else {
       int status;
       wait(&status);
-      if (status == 0) {
-        printf("memory not unmapped\n");
+      if(status != -1){
+        printf("memory not unmapped, child status=%d\n", status);
         exit(1);
       }
     }
@@ -76,36 +113,45 @@ sparse_memory_unmap(char *s)
 void
 oom(char *s)
 {
-  void *m1, *m2;
-  int pid;
-
-  if((pid = fork()) == 0){
-    m1 = 0;
-    while((m2 = malloc(4096*4096)) != 0){
-      *(char**)m2 = m1;
-      m1 = m2;
-    }
-    exit(0);
-  } else {
-    int xstatus;
-    wait(&xstatus);
-    exit(xstatus == 0);
+  int pid = fork();
+  if(pid < 0){
+    printf("oom: fork failed\n");
+    exit(1);
   }
+
+  if(pid == 0){
+    for(;;){
+      char *base = sbrk(OOM_CHUNK_SIZE);
+      if(base == (char *)-1){
+        // 先到虚拟地址上限说明没有真正触发物理 OOM，父进程必须判失败。
+        exit(0);
+      }
+      // volatile 写遍每一页，确保 lazy allocation 真正申请物理页。
+      for(int offset = 0; offset < OOM_CHUNK_SIZE; offset += PGSIZE)
+        *(volatile char *)(base + offset) = 1;
+    }
+  }
+
+  int status;
+  wait(&status);
+  // 当前 page-fault OOM 路径通过 exit(-1) 终止子进程。
+  exit(status == -1 ? 0 : 1);
 }
 
 // run each test in its own process. run returns 1 if child's exit()
 // indicates success.
 int
-run(void f(char *), char *s) {
+run(void f(char *), char *s)
+{
   int pid;
   int xstatus;
 
   printf("running test %s\n", s);
-  if((pid = fork()) < 0) {
+  if((pid = fork()) < 0){
     printf("runtest: fork error\n");
     exit(1);
   }
-  if(pid == 0) {
+  if(pid == 0){
     f(s);
     exit(0);
   } else {
@@ -129,25 +175,24 @@ int
 main(int argc, char *argv[])
 {
   char *n = 0;
-  if(argc > 1) {
+  if(argc > 1)
     n = argv[1];
-  }
 
   struct test {
     void (*f)(char *);
     char *s;
   } tests[] = {
-    { sparse_memory, "lazy alloc"},
-    { sparse_memory_unmap, "lazy unmap"},
-    { oom, "out of memory"},
-    { 0, 0},
+    {sparse_memory, "lazy alloc"},
+    {sparse_memory_unmap, "lazy unmap"},
+    {oom, "out of memory"},
+    {0, 0},
   };
 
   printf("lazytests starting\n");
 
   int fail = 0;
-  for (struct test *t = tests; t->s != 0; t++) {
-    if((n == 0) || strcmp(t->s, n) == 0) {
+  for(struct test *t = tests; t->s != 0; t++){
+    if((n == 0) || strcmp(t->s, n) == 0){
       if(!run(t->f, t->s))
         fail = 1;
     }
@@ -157,6 +202,5 @@ main(int argc, char *argv[])
   else
     printf("SOME TESTS FAILED\n");
 
-  // 统一把汇总结果传播给 xv6test 和宿主机 runner，避免失败用例被误判为通过。
   exit(fail);
 }


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 将固定 `sbrk(1 GiB)` 改为在当前 `PLIC` 用户增长上限内保留最多 64 MiB 的稀疏区域。
- 保留每 64 页触碰一页并读回的 lazy allocation 行为验证。
- unmap 用例要求 shrink 后访问旧地址必须使子进程以 `-1` 被 usertrap 终止，不再把任意非零退出都算通过。
- OOM 用例不再用 `malloc(16 MiB)` 只写首地址；改为每次保留 4 MiB，并以 `volatile` 写遍每一页。
- 如果子进程先到虚拟地址上限而没有发生物理 OOM，测试明确失败。

## 添加/修改了什么单元测试（断言类）

`tests/guest/lazytests.c` 断言：

- 稀疏区域可以在当前 PLIC 边界下合法保留；
- 被触碰的稀疏页可以读回；
- shrink 后旧地址确实不可访问；
- 真正逐页物化后会进入当前 page-fault OOM 路径；
- 三个子测试的退出状态可靠传播给 `xv6test`。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
make clean
make
make test-suite SUITE=lab-vm CPUS=3
make test-integration CPUS=3
```

或在 xv6 shell 中：

```text
xv6test --group lab5
```

预期：

```text
test lazy alloc: OK
test lazy unmap: OK
test out of memory: OK
ALL TESTS PASSED
XV6TEST done status=0
```

## 单元自动化测试结果

- 根因证据来自 run `29916969579`：
  - PR #70 的 backtrace 与 alarm 均通过；
  - lazy alloc / unmap 因 1 GiB 超过 PLIC 上限失败；
  - OOM 因只物化少量页面、先到虚拟上限而失败。
- GitHub Actions：待 Ready 后执行。

## review 主线（先看什么，再看什么）

1. `reserve_sparse_region()` 是否始终给 PLIC 留出一页安全余量；
2. 稀疏测试是否仍只物化少量页面；
3. unmap 是否要求精确的 fault 退出状态；
4. OOM 是否使用 volatile 逐页写入，而非只保留虚拟地址；
5. 确认未修改 `sys_sbrk`、PLIC 限制或 page-fault 策略。

## 边界

- 不解除当前 `p->sz < PLIC` 教学限制；
- 不把一次 OOM 的可分配页数作为稳定性能指标；
- 不修改 workflow 或 suite 编排；
- 测试仅证明当前实现的 reserve、first-touch、shrink 和 OOM 生命周期。

Closes #71
Related to #60
Related to #69
Related to #61