### PR TITLE
test: 引入轻量 guest 断言宏

### DIFF
--- a/tests/guest/ASSERTIONS.md
+++ b/tests/guest/ASSERTIONS.md
@@ -1,0 +1,46 @@
+# Lightweight guest assertions
+
+在 xv6 guest 测试中包含：
+
+```c
+#include "tests/guest/test_assert.h"
+```
+
+可用宏：
+
+```c
+EXPECT_EQ(expected, actual);
+EXPECT_NE(expected, actual);
+EXPECT_LT(expected, actual);
+EXPECT_LE(expected, actual);
+EXPECT_GT(expected, actual);
+EXPECT_GE(expected, actual);
+EXPECT_TRUE(condition);
+EXPECT_FALSE(condition);
+EXPECT_NULL(pointer);
+EXPECT_NOT_NULL(pointer);
+EXPECT_STREQ(expected, actual);
+ASSERT_EQ(expected, actual);
+ASSERT_TRUE(condition);
+TEST_EXIT();
+```
+
+`EXPECT_*` 记录错误并继续执行，适合一次报告多个不变量；`ASSERT_*` 在当前断言失败后立即打印汇总并退出。测试主函数最后必须调用 `TEST_EXIT()`，由退出状态交给 `xv6test` 汇总。
+
+示例：
+
+```c
+int
+main(void)
+{
+  int value = 3;
+  char *name = "xv6";
+
+  EXPECT_EQ(3, value);
+  EXPECT_TRUE(value > 0);
+  EXPECT_STREQ("xv6", name);
+  TEST_EXIT();
+}
+```
+
+范围刻意保持最小：没有 fixture、mock、参数化测试、自动注册、动态分配或宿主机依赖。整数/指针比较按 RV64 的 `long` 保存，两侧表达式只求值一次。

--- a/tests/guest/bttest.c
+++ b/tests/guest/bttest.c
@@ -1,6 +1,7 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
 #include "user/user.h"
+#include "tests/guest/test_assert.h"
 
 /**
  * 显式请求内核打印当前系统调用路径的栈回溯。
@@ -11,9 +12,6 @@
 int
 main(void)
 {
-  if(backtrace() < 0){
-    printf("bttest: backtrace syscall failed\n");
-    exit(1);
-  }
-  exit(0);
+  EXPECT_EQ(0, backtrace());
+  TEST_EXIT();
 }

--- a/tests/guest/test_assert.h
+++ b/tests/guest/test_assert.h
@@ -1,0 +1,126 @@
+#ifndef XV6_TEST_ASSERT_H
+#define XV6_TEST_ASSERT_H
+
+#include "kernel/types.h"
+#include "user/user.h"
+
+// 每个 guest 测试程序拥有自己的断言计数；该头文件不引入全局测试注册器。
+static int xv6_expect_checks;
+static int xv6_expect_errors;
+
+/**
+ * 记录整数或指针比较结果。
+ *
+ * 宏在调用本函数前先保存两侧值，确保带副作用的表达式只求值一次。
+ */
+static inline void
+xv6_expect_value(int matched, char *kind, char *expected_expr,
+                  char *actual_expr, uint64 expected, uint64 actual,
+                  char *file, int line)
+{
+  xv6_expect_checks++;
+  if(matched)
+    return;
+
+  xv6_expect_errors++;
+  printf("EXPECT mismatch kind=%s file=%s line=%d expected=%s actual=%s expected_value=%p actual_value=%p\n",
+         kind, file, line, expected_expr, actual_expr, expected, actual);
+}
+
+/**
+ * 记录字符串比较结果；空指针不会传给 strcmp() 或 printf("%s")。
+ */
+static inline void
+xv6_expect_string(int matched, char *expected_expr, char *actual_expr,
+                   char *expected, char *actual, char *file, int line)
+{
+  xv6_expect_checks++;
+  if(matched)
+    return;
+
+  xv6_expect_errors++;
+  printf("EXPECT mismatch kind=STREQ file=%s line=%d expected=%s actual=%s expected_text=%s actual_text=%s\n",
+         file, line, expected_expr, actual_expr,
+         expected == 0 ? "(null)" : expected,
+         actual == 0 ? "(null)" : actual);
+}
+
+#define XV6_EXPECT_BINARY(kind, op, expected, actual) do {                 \
+  long _xv6_expected = (long)(expected);                                   \
+  long _xv6_actual = (long)(actual);                                       \
+  xv6_expect_value(_xv6_expected op _xv6_actual, kind, #expected, #actual, \
+                    (uint64)_xv6_expected, (uint64)_xv6_actual,             \
+                    __FILE__, __LINE__);                                    \
+} while(0)
+
+#define EXPECT_EQ(expected, actual) XV6_EXPECT_BINARY("EQ", ==, expected, actual)
+#define EXPECT_NE(expected, actual) XV6_EXPECT_BINARY("NE", !=, expected, actual)
+#define EXPECT_LT(expected, actual) XV6_EXPECT_BINARY("LT", <, expected, actual)
+#define EXPECT_LE(expected, actual) XV6_EXPECT_BINARY("LE", <=, expected, actual)
+#define EXPECT_GT(expected, actual) XV6_EXPECT_BINARY("GT", >, expected, actual)
+#define EXPECT_GE(expected, actual) XV6_EXPECT_BINARY("GE", >=, expected, actual)
+
+#define EXPECT_TRUE(condition) do {                                        \
+  int _xv6_actual = !!(condition);                                         \
+  xv6_expect_value(_xv6_actual == 1, "TRUE", "true", #condition, 1,      \
+                    (uint64)_xv6_actual, __FILE__, __LINE__);               \
+} while(0)
+
+#define EXPECT_FALSE(condition) do {                                       \
+  int _xv6_actual = !!(condition);                                         \
+  xv6_expect_value(_xv6_actual == 0, "FALSE", "false", #condition, 0,    \
+                    (uint64)_xv6_actual, __FILE__, __LINE__);               \
+} while(0)
+
+#define EXPECT_NULL(value) do {                                            \
+  uint64 _xv6_actual = (uint64)(value);                                    \
+  xv6_expect_value(_xv6_actual == 0, "NULL", "NULL", #value, 0,          \
+                    _xv6_actual, __FILE__, __LINE__);                       \
+} while(0)
+
+#define EXPECT_NOT_NULL(value) do {                                        \
+  uint64 _xv6_actual = (uint64)(value);                                    \
+  xv6_expect_value(_xv6_actual != 0, "NOT_NULL", "non-NULL", #value, 1,  \
+                    _xv6_actual, __FILE__, __LINE__);                       \
+} while(0)
+
+#define EXPECT_STREQ(expected, actual) do {                                \
+  char *_xv6_expected = (expected);                                        \
+  char *_xv6_actual = (actual);                                            \
+  int _xv6_matched = (_xv6_expected == 0 && _xv6_actual == 0) ||           \
+                     (_xv6_expected != 0 && _xv6_actual != 0 &&             \
+                      strcmp(_xv6_expected, _xv6_actual) == 0);             \
+  xv6_expect_string(_xv6_matched, #expected, #actual,                       \
+                     _xv6_expected, _xv6_actual, __FILE__, __LINE__);       \
+} while(0)
+
+#define TEST_CHECKS() (xv6_expect_checks)
+#define TEST_ERRORS() (xv6_expect_errors)
+#define TEST_STATUS() (xv6_expect_errors == 0 ? 0 : 1)
+
+#define TEST_SUMMARY() do {                                                \
+  printf("EXPECT summary checks=%d errors=%d\n",                          \
+         xv6_expect_checks, xv6_expect_errors);                             \
+} while(0)
+
+#define TEST_EXIT() do {                                                   \
+  int _xv6_status = TEST_STATUS();                                         \
+  TEST_SUMMARY();                                                          \
+  exit(_xv6_status);                                                       \
+} while(0)
+
+#define ASSERT_EQ(expected, actual) do {                                   \
+  int _xv6_errors_before = TEST_ERRORS();                                  \
+  EXPECT_EQ(expected, actual);                                             \
+  if(TEST_ERRORS() != _xv6_errors_before)                                  \
+    TEST_EXIT();                                                           \
+} while(0)
+
+#define ASSERT_TRUE(condition) do {                                        \
+  int _xv6_errors_before = TEST_ERRORS();                                  \
+  EXPECT_TRUE(condition);                                                  \
+  if(TEST_ERRORS() != _xv6_errors_before)                                  \
+    TEST_EXIT();                                                           \
+} while(0)
+
+#endif


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 新增 `tests/guest/test_assert.h`，提供 header-only 断言：
  - `EXPECT_EQ / NE / LT / LE / GT / GE`；
  - `EXPECT_TRUE / FALSE`；
  - `EXPECT_NULL / NOT_NULL`；
  - `EXPECT_STREQ`；
  - `ASSERT_EQ / ASSERT_TRUE`；
  - `TEST_CHECKS / TEST_ERRORS / TEST_STATUS / TEST_SUMMARY / TEST_EXIT`。
- 比较表达式只求值一次。
- 失败记录文件、行号、表达式和值，并通过最终退出状态交给 `xv6test`。
- 不引入 fixture、mock、参数化测试、自动注册或第三方框架。
- 新增 `tests/guest/ASSERTIONS.md` 说明适用范围和使用方式。

## 添加/修改了什么单元测试（断言类）

将 `bttest` 改为：

```c
EXPECT_EQ(0, backtrace());
TEST_EXIT();
```

该用例同时验证宏的编译、计数、汇总、退出状态传播，以及原有 backtrace 控制台证据。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
make clean
make
make test-suite SUITE=lab-vm CPUS=3
make test-integration CPUS=3
make test-usertests CPUS=3
```

Lab4 日志应包含：

```text
EXPECT summary checks=1 errors=0
XV6TEST done status=0
```

同时仍需至少三行 `0x...` 内核返回地址。

## 单元自动化测试结果

GitHub Actions run `29932126943`：

| 检查项 | 结果 |
|---|---|
| runner 单测 | 通过 |
| `make clean && make` | 通过 |
| Lab1-Lab10，CPUS=3 | 通过 |
| backtrace 地址与断言汇总 | 通过 |
| 完整 `usertests`，CPUS=3 | 通过 |

此前 run `29927620572` 暴露的 `reparent2: panic: acquire` 已由 PR #79 的 `wait_lock` 修复；PR #79 与 PR #77 均已独立全绿并进入 `main`。

## review 主线（先看什么，再看什么）

1. 宏参数是否只求值一次；
2. `EXPECT_*` 是否继续执行，`ASSERT_*` 是否立即退出；
3. `TEST_EXIT()` 是否仅依据累计错误数返回；
4. header 是否只依赖 xv6 用户态已有 API；
5. `bttest` 原有 backtrace host 证据是否保持。

## 边界

- 不是完整测试框架；
- 不提供 fixture、mock、参数化、自动发现和颜色输出；
- 只面向 `tests/guest`，不进入普通用户程序或内核公共接口。

Closes #73
Related to #60
Related to #72
Related to #77
Related to #79
Related to #62