### PR TITLE
test: 扩大完整 bigfile 边界回归的时间预算

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -151,7 +151,9 @@ SUITES: dict[str, Suite] = {
                 "lab9-bigfile",
                 ("xv6test --run lab9-bigfile",),
                 expected=GUEST_SUCCESS,
-                timeout=420,
+                # 完整边界测试包含 65,803 次写入和读回；共享 CI 主机上
+                # 420 秒会在读回后半段产生假超时，因此保留充足但有限的预算。
+                timeout=900,
             ),
         ),
     ),


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 仅将 `lab9-bigfile` 的超时从 420 秒提高到 900 秒。
- 保留 65,803 块完整写入、首次越界拒绝和 65,803 块完整读回。
- 添加注释说明该预算只针对完整边界测试在共享 CI 主机上的波动。
- 不修改文件系统实现、测试数据量或其他 suite 超时。

## 失败证据

组合 run `29928973772` 中：

- Lab1-Lab8、symlink、mmap、focused core 均完成 `XV6TEST done status=0`；
- `bigfile` 已打印 `wrote 65803 blocks`；
- 日志无 panic、guest FAIL、越界接受或数据不一致；
- 在完整读回结束前未返回 shell，符合 420 秒基础设施超时。

## 如何通过 CLI 命令进行回归观察

```bash
make test-suite SUITE=lab9-bigfile CPUS=3
make test-integration CPUS=3
make test-usertests CPUS=3
```

必须看到：

```text
bigfile done; ok
XV6TEST done status=0
All requested suites passed.
```

## review 主线

1. diff 是否只调整 `lab9-bigfile`；
2. 是否仍执行完整写入和完整读回；
3. 其他 suite 的时间预算是否不变。

Closes #76
Related to #63
Related to #73
Related to #61