### PR TITLE
fix: 用 wait_lock 收敛父子进程生命周期

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -20,8 +20,11 @@ struct proc *initproc;
 int nextpid = 1;
 struct spinlock pid_lock;
 
+// Protects parent pointers and the wait/exit/reparent wakeup relationship.
+// wait_lock must be acquired before any p->lock.
+struct spinlock wait_lock;
+
 extern void forkret(void);
-static void wakeup1(struct proc *chan);
 static void freeproc(struct proc *p);
 
 extern char trampoline[]; // trampoline.S
@@ -33,6 +36,7 @@ procinit(void)
   struct proc *p;
 
   initlock(&pid_lock, "nextpid");
+  initlock(&wait_lock, "wait_lock");
   for(p = proc; p < &proc[NPROC]; p++) {
       initlock(&p->lock, "proc");
 
@@ -111,6 +115,7 @@ allocproc(void)
 
 found:
   p->pid = allocpid();
+  p->state = USED;
   p->mask = 0;
   p->handler = 0;
   p->alarm_interval = 0;
@@ -120,6 +125,7 @@ found:
     p->vma[i] = 0;
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
+    freeproc(p);
     release(&p->lock);
     return 0;
   }
@@ -330,7 +336,6 @@ fork(void)
   }
   np->sz = p->sz;
 
-  np->parent = p;
   np->mask = p->mask;
   // copy saved user registers.
   *(np->trapframe) = *(p->trapframe);
@@ -351,35 +356,30 @@ fork(void)
 
   pid = np->pid;
 
-  np->state = RUNNABLE;
+  // parent is protected by wait_lock, whose lock order precedes p->lock.
+  release(&np->lock);
+  acquire(&wait_lock);
+  np->parent = p;
+  release(&wait_lock);
 
+  acquire(&np->lock);
+  np->state = RUNNABLE;
   release(&np->lock);
 
   return pid;
 }
 
 // Pass p's abandoned children to init.
-// Caller must hold p->lock.
+// Caller must hold wait_lock.
 void
 reparent(struct proc *p)
 {
   struct proc *pp;
 
   for(pp = proc; pp < &proc[NPROC]; pp++){
-    // this code uses pp->parent without holding pp->lock.
-    // acquiring the lock first could cause a deadlock
-    // if pp or a child of pp were also in exit()
-    // and about to try to lock p.
     if(pp->parent == p){
-      // pp->parent can't change between the check and the acquire()
-      // because only the parent changes it, and we're the parent.
-      acquire(&pp->lock);
       pp->parent = initproc;
-      // we should wake up init here, but that would require
-      // initproc->lock, which would be a deadlock, since we hold
-      // the lock on one of init's children (pp). this is why
-      // exit() always wakes init (before acquiring any locks).
-      release(&pp->lock);
+      wakeup(initproc);
     }
   }
 }
@@ -410,41 +410,20 @@ exit(int status)
   end_op();
   p->cwd = 0;
 
-  // we might re-parent a child to init. we can't be precise about
-  // waking up init, since we can't acquire its lock once we've
-  // acquired any other proc lock. so wake up init whether that's
-  // necessary or not. init may miss this wakeup, but that seems
-  // harmless.
-  acquire(&initproc->lock);
-  wakeup1(initproc);
-  release(&initproc->lock);
-
-  // grab a copy of p->parent, to ensure that we unlock the same
-  // parent we locked. in case our parent gives us away to init while
-  // we're waiting for the parent lock. we may then race with an
-  // exiting parent, but the result will be a harmless spurious wakeup
-  // to a dead or wrong process; proc structs are never re-allocated
-  // as anything else.
-  acquire(&p->lock);
-  struct proc *original_parent = p->parent;
-  release(&p->lock);
-
-  // we need the parent's lock in order to wake it up from wait().
-  // the parent-then-child rule says we have to lock it first.
-  acquire(&original_parent->lock);
-
-  acquire(&p->lock);
+  acquire(&wait_lock);
 
   // Give any children to init.
   reparent(p);
 
   // Parent might be sleeping in wait().
-  wakeup1(original_parent);
+  wakeup(p->parent);
+
+  acquire(&p->lock);
 
   p->xstate = status;
   p->state = ZOMBIE;
 
-  release(&original_parent->lock);
+  release(&wait_lock);
 
   // Jump into the scheduler, never to return.
   sched();
@@ -460,20 +439,14 @@ wait(uint64 addr)
   int havekids, pid;
   struct proc *p = myproc();
 
-  // hold p->lock for the whole time to avoid lost
-  // wakeups from a child's exit().
-  acquire(&p->lock);
+  acquire(&wait_lock);
 
   for(;;){
     // Scan through table looking for exited children.
     havekids = 0;
     for(np = proc; np < &proc[NPROC]; np++){
-      // this code uses np->parent without holding np->lock.
-      // acquiring the lock first would cause a deadlock,
-      // since np might be an ancestor, and we already hold p->lock.
       if(np->parent == p){
-        // np->parent can't change between the check and the acquire()
-        // because only the parent changes it, and we're the parent.
+        // Make sure the child isn't still in exit() or swtch().
         acquire(&np->lock);
         havekids = 1;
         if(np->state == ZOMBIE){
@@ -482,26 +455,31 @@ wait(uint64 addr)
           if(addr != 0 && copyout(p->pagetable, addr, (char *)&np->xstate,
                                   sizeof(np->xstate)) < 0) {
             release(&np->lock);
-            release(&p->lock);
+            release(&wait_lock);
             return -1;
           }
           freeproc(np);
           release(&np->lock);
-          release(&p->lock);
+          release(&wait_lock);
           return pid;
         }
         release(&np->lock);
       }
     }
 
+    acquire(&p->lock);
+    int killed = p->killed;
+    release(&p->lock);
+
     // No point waiting if we don't have any children.
-    if(!havekids || p->killed){
-      release(&p->lock);
+    if(!havekids || killed){
+      release(&wait_lock);
       return -1;
     }
 
-    // Wait for a child to exit.
-    sleep(p, &p->lock);  //DOC: wait-sleep
+    // Wait for a child to exit. sleep() atomically releases wait_lock and
+    // reacquires it after wakeup, preventing lost child-exit notifications.
+    sleep(p, &wait_lock);  //DOC: wait-sleep
   }
 }
 
@@ -663,18 +641,6 @@ wakeup(void *chan)
   }
 }
 
-// Wake up p if it is sleeping in wait(); used by exit().
-// Caller must hold p->lock.
-static void
-wakeup1(struct proc *p)
-{
-  if(!holding(&p->lock))
-    panic("wakeup1");
-  if(p->chan == p && p->state == SLEEPING) {
-    p->state = RUNNABLE;
-  }
-}
-
 // Kill the process with the given pid.
 // The victim won't exit until it tries to return
 // to user space (see usertrap() in trap.c).
@@ -737,6 +703,7 @@ procdump(void)
 {
   static char *states[] = {
   [UNUSED]    "unused",
+  [USED]      "used  ",
   [SLEEPING]  "sleep ",
   [RUNNABLE]  "runble",
   [RUNNING]   "run   ",

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -35,11 +35,7 @@ extern struct cpu cpus[NCPU];
 // uservec in trampoline.S saves user registers in the trapframe,
 // then initializes registers from the trapframe's
 // kernel_sp, kernel_hartid, kernel_satp, and jumps to kernel_trap.
-// usertrapret() and userret in trampoline.S set up
-// the trapframe's kernel_*, restore user registers from the
-// trapframe, switch to the user page table, and enter user space.
-// the trapframe includes callee-saved user registers like s0-s11 because the
-// return-to-user path via usertrapret() doesn't return through
+// usertrapret() and userret in trampoline.S set up the trapframe,
 // the entire kernel call stack.
 struct trapframe {
   /*   0 */ uint64 kernel_satp;   // kernel page table
@@ -87,7 +83,7 @@ struct user_context {
   uint64 gpr[31];
 };
 
-enum procstate { UNUSED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
+enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 
 // Per-process state
 struct proc {
@@ -95,7 +91,7 @@ struct proc {
 
   // p->lock must be held when using these:
   enum procstate state;        // Process state
-  struct proc *parent;         // Parent process
+  struct proc *parent;         // Parent process; wait_lock protects changes.
   void *chan;                  // If non-zero, sleeping on chan
   int killed;                  // If non-zero, have been killed
   int xstate;                  // Exit status to be returned to parent's wait

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -35,7 +35,11 @@ extern struct cpu cpus[NCPU];
 // uservec in trampoline.S saves user registers in the trapframe,
 // then initializes registers from the trapframe's
 // kernel_sp, kernel_hartid, kernel_satp, and jumps to kernel_trap.
-// usertrapret() and userret in trampoline.S set up the trapframe,
+// usertrapret() and userret in trampoline.S set up
+// the trapframe's kernel_*, restore user registers from the
+// trapframe, switch to the user page table, and enter user space.
+// the trapframe includes callee-saved user registers like s0-s11 because the
+// return-to-user path via usertrapret() doesn't return through
 // the entire kernel call stack.
 struct trapframe {
   /*   0 */ uint64 kernel_satp;   // kernel page table


### PR DESCRIPTION
## 实现了什么（功能清单一览）

- 新增全局 `wait_lock`，在 `procinit()` 初始化。
- 锁序固定为：

```text
wait_lock → p->lock
```

- `fork()` 在 `wait_lock` 下发布 `np->parent`，并增加 `USED` 状态保护尚未 RUNNABLE 的 proc 槽位。
- `reparent()` 由调用者持有 `wait_lock`，不再在遍历中形成不稳定的父锁/子锁组合。
- `exit()` 在 `wait_lock` 下完成 reparent、父进程唤醒和 ZOMBIE 发布。
- `wait()` 在 `wait_lock` 下扫描 parent 关系，并使用具体子进程锁保护状态和回收。
- 删除只适用于旧父锁模型的 `wakeup1()`。

## 失败证据

PR #74 run `29927620572` 的完整 CPUS=3 usertests：

```text
test reparent2: panic: acquire
```

Lab1-Lab10 已全部通过，说明失败集中在高并发 exit/wait/reparent 路径。

## 如何通过 CLI 命令进行回归观察

```bash
make clean
make
make test-integration CPUS=3
make test-usertests CPUS=3
```

必须满足：

- `reparent2: OK`；
- 无 `panic: acquire` 或 `panic: release`；
- Lab1-Lab10 与完整 usertests 全部通过。

## review 主线

1. `wait_lock` 是否总在 `p->lock` 前获取；
2. 所有 parent 发布和修改是否受 `wait_lock` 保护；
3. `exit()` 是否持自身锁进入 `sched()`；
4. `wait()` 是否在释放 wait_lock 前完成子进程回收；
5. 自定义 VMA、kpagetable、COW 和调度切换是否保持原样。

## 来源与边界

同步模型对齐 MIT xv6 当前 `wait_lock` 设计，但保留本仓库的 VMA、每进程内核页表和其他课程实验实现。

Closes #78
Related to #73
Related to #76
Related to #61