### PR TITLE
chore: 将 bigfile 超时预算同步到 wait_lock 分支

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -151,7 +151,9 @@ SUITES: dict[str, Suite] = {
                 "lab9-bigfile",
                 ("xv6test --run lab9-bigfile",),
                 expected=GUEST_SUCCESS,
-                timeout=420,
+                # 完整边界测试包含 65,803 次写入和读回；共享 CI 主机上
+                # 420 秒会在读回后半段产生假超时，因此保留充足但有限的预算。
+                timeout=900,
             ),
         ),
     ),


### PR DESCRIPTION
## 目的

建立真实分支祖先关系：

```text
#77 test/76-bigfile-timeout-budget
→ #79 concept/78-wait-lock
```

使 #79 及其后继 PR 的 CI 真正包含 `lab9-bigfile timeout=900`，而不只是修改 PR 比较 base。

## 范围

- 只同步 #77 的 `tests/run.py` 变更；
- 不修改 wait_lock 代码；
- 不直接合入 main；
- #77 与 #79 仍按顺序分别合入 main。

Related to #76
Related to #78