### PR TITLE
fix: 内核 panic 后立即终止 QEMU 回归

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -16,9 +16,12 @@ import pexpect
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RESULT_ROOT = REPO_ROOT / "test-results"
-DEFAULT_REJECTED = (
-    r"panic:",
-    r"kerneltrap",
+QEMU_SHELL_PROMPT = "$ "
+QEMU_FATAL_OUTPUTS = (
+    "panic:",
+    "kerneltrap",
+)
+DEFAULT_REJECTED = QEMU_FATAL_OUTPUTS + (
     r"exec .* failed",
     r"\bFAIL(?:ED)?\b",
 )
@@ -55,6 +58,14 @@ class Suite:
     tests: tuple[TestCase, ...] = ()
     includes: tuple[str, ...] = ()
     description: str = ""
+
+
+@dataclass(frozen=True)
+class QemuCommandResult:
+    """记录一次 guest 命令等待 shell prompt 的输出和失败原因。"""
+
+    output: str
+    failure: str | None = None
 
 
 SUITES: dict[str, Suite] = {
@@ -332,7 +343,7 @@ def _start_qemu(cpus: int) -> pexpect.spawn:
         timeout=120,
     )
     try:
-        child.expect_exact("$ ")
+        child.expect_exact(QEMU_SHELL_PROMPT)
     except (pexpect.TIMEOUT, pexpect.EOF):
         child.terminate(force=True)
         raise
@@ -352,6 +363,57 @@ def _stop_qemu(child: pexpect.spawn) -> None:
         child.terminate(force=True)
 
 
+def _wait_for_qemu_command(child: pexpect.spawn) -> QemuCommandResult:
+    """等待 guest 命令返回 shell，并对已知内核致命输出快速失败。
+
+    Args:
+        child: 已启动并进入 xv6 shell 的 pexpect 子进程；函数会消费本次命令输出。
+
+    Returns:
+        返回已捕获输出和可选失败原因。出现 prompt 时 failure 为 None；出现
+        panic、kerneltrap、EOF 或 timeout 时返回可直接写入 TestFailure 的原因。
+    """
+
+    expectations = (
+        QEMU_SHELL_PROMPT,
+        *QEMU_FATAL_OUTPUTS,
+        pexpect.EOF,
+        pexpect.TIMEOUT,
+    )
+    matched = child.expect_exact(expectations)
+    output = child.before or ""
+
+    if matched == 0:
+        return QemuCommandResult(output=output)
+
+    fatal_end = 1 + len(QEMU_FATAL_OUTPUTS)
+    if matched < fatal_end:
+        fatal = QEMU_FATAL_OUTPUTS[matched - 1]
+        output += child.after or fatal
+
+        # panic 文本本身已经足以判定失败；额外最多等待一秒读取该行余下内容，
+        # 使日志保留 `panic: acquire` 这类真正用于定位根因的信息。
+        tail_match = child.expect_exact(("\n", pexpect.EOF, pexpect.TIMEOUT), timeout=1)
+        output += child.before or ""
+        if tail_match == 0:
+            output += child.after or "\n"
+        return QemuCommandResult(
+            output=output,
+            failure=f"matched fatal output: {fatal}",
+        )
+
+    if matched == fatal_end:
+        return QemuCommandResult(
+            output=output,
+            failure="QEMU exited before returning to the shell",
+        )
+
+    return QemuCommandResult(
+        output=output,
+        failure="QEMU did not return to the shell before timeout",
+    )
+
+
 def _run_qemu_tests(suite: str, tests: Sequence[TestCase], cpus: int) -> None:
     """在一个原子 suite 的 QEMU snapshot 内顺序执行其 guest 命令。"""
 
@@ -360,23 +422,19 @@ def _run_qemu_tests(suite: str, tests: Sequence[TestCase], cpus: int) -> None:
     try:
         for test in tests:
             chunks = [boot_output]
-            try:
-                for command in test.commands:
-                    child.timeout = test.timeout
-                    child.sendline(command)
-                    child.expect_exact("$ ")
-                    chunks.append(f"$ {command}\n{child.before}")
-                output = "\n".join(chunks)
-                log_path = _write_log(suite, test.name, output)
-                _assert_output(test, output)
-                print(f"PASS {test.name} ({log_path.relative_to(REPO_ROOT)})")
-            except (pexpect.TIMEOUT, pexpect.EOF) as exc:
-                chunks.append(child.before or "")
-                output = "\n".join(chunks)
-                log_path = _write_log(suite, test.name, output)
-                raise TestFailure(
-                    f"QEMU did not return to the shell; log: {log_path}"
-                ) from exc
+            for command in test.commands:
+                child.timeout = test.timeout
+                child.sendline(command)
+                result = _wait_for_qemu_command(child)
+                chunks.append(f"$ {command}\n{result.output}")
+                if result.failure is not None:
+                    output = "\n".join(chunks)
+                    log_path = _write_log(suite, test.name, output)
+                    raise TestFailure(f"{result.failure}; log: {log_path}")
+            output = "\n".join(chunks)
+            log_path = _write_log(suite, test.name, output)
+            _assert_output(test, output)
+            print(f"PASS {test.name} ({log_path.relative_to(REPO_ROOT)})")
     finally:
         _stop_qemu(child)
 

--- a/tests/test_qemu_fail_fast.py
+++ b/tests/test_qemu_fail_fast.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证 guest 命令等待逻辑能够快速识别致命输出。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+
+import pexpect
+
+
+RUNNER_PATH = Path(__file__).with_name("run.py")
+SPEC = importlib.util.spec_from_file_location("xv6_qemu_fail_fast_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load regression runner from {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class FakeSpawn:
+    """通过预置匹配事件模拟 `pexpect.spawn.expect_exact`。"""
+
+    def __init__(self, events: Sequence[tuple[object, str, object]]) -> None:
+        """保存按调用顺序返回的匹配事件。
+
+        Args:
+            events: 每项依次表示待匹配对象、`before` 文本和 `after` 值；
+                待匹配对象必须存在于调用方传入的 patterns 中。
+        """
+
+        self._events = list(events)
+        self.before = ""
+        self.after: object = ""
+        self.calls: list[tuple[tuple[object, ...], int | None]] = []
+
+    def expect_exact(
+        self,
+        patterns: Sequence[object],
+        timeout: int | None = None,
+    ) -> int:
+        """消费一个预置事件并返回其在 patterns 中的下标。
+
+        Args:
+            patterns: runner 当前等待的 prompt、fatal pattern 或 pexpect sentinel。
+            timeout: 本次等待预算；测试只记录该值，不进行真实等待。
+
+        Returns:
+            预置匹配对象在 patterns 中的下标。
+        """
+
+        if not self._events:
+            raise AssertionError("unexpected expect_exact call")
+        matched, self.before, self.after = self._events.pop(0)
+        pattern_tuple = tuple(patterns)
+        self.calls.append((pattern_tuple, timeout))
+        return pattern_tuple.index(matched)
+
+
+class QemuFastFailTests(unittest.TestCase):
+    """验证 prompt、fatal、EOF 与 timeout 四类命令结束状态。"""
+
+    def test_prompt_returns_success_output(self) -> None:
+        """shell prompt 应返回捕获输出且不产生失败原因。"""
+
+        child = FakeSpawn(((RUNNER.QEMU_SHELL_PROMPT, "done\r\n", "$ "),))
+
+        result = RUNNER._wait_for_qemu_command(child)
+
+        self.assertEqual("done\r\n", result.output)
+        self.assertIsNone(result.failure)
+        self.assertEqual(1, len(child.calls))
+
+    def test_fatal_outputs_fail_immediately_and_capture_full_line(self) -> None:
+        """panic 与 kerneltrap 均应在一秒行尾补采后立即返回明确失败。"""
+
+        for fatal in RUNNER.QEMU_FATAL_OUTPUTS:
+            with self.subTest(fatal=fatal):
+                child = FakeSpawn(
+                    (
+                        (fatal, "test twochildren: ", fatal),
+                        ("\n", " acquire", "\n"),
+                    )
+                )
+
+                result = RUNNER._wait_for_qemu_command(child)
+
+                self.assertEqual(f"test twochildren: {fatal} acquire\n", result.output)
+                self.assertEqual(f"matched fatal output: {fatal}", result.failure)
+                self.assertEqual(2, len(child.calls))
+                self.assertEqual(1, child.calls[1][1])
+
+    def test_eof_returns_distinct_failure(self) -> None:
+        """QEMU 提前退出应与普通 timeout 使用不同失败原因。"""
+
+        child = FakeSpawn(((pexpect.EOF, "partial output", pexpect.EOF),))
+
+        result = RUNNER._wait_for_qemu_command(child)
+
+        self.assertEqual("partial output", result.output)
+        self.assertEqual("QEMU exited before returning to the shell", result.failure)
+
+    def test_timeout_returns_distinct_failure(self) -> None:
+        """没有 prompt 或 fatal 输出时应保留既有 timeout 语义。"""
+
+        child = FakeSpawn(((pexpect.TIMEOUT, "still running", pexpect.TIMEOUT),))
+
+        result = RUNNER._wait_for_qemu_command(child)
+
+        self.assertEqual("still running", result.output)
+        self.assertEqual(
+            "QEMU did not return to the shell before timeout",
+            result.failure,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #83
- 变更类型：CI / 测试框架修复
- 影响范围：`tests/run.py` 的 QEMU guest 命令等待与失败日志；新增 `tests/test_qemu_fail_fast.py`
- 基线 Commit：`53858c2557492e6bc923afccae34030072ea531f`
- 一句话摘要：当 guest 已输出 `panic:` 或 `kerneltrap` 时立即记录失败并清理 QEMU，不再等待最长 1200 秒的 TestCase timeout。

## 实现了什么

- 将 shell prompt、内核致命输出、EOF 与 timeout 纳入同一次 `pexpect.expect_exact` 等待，返回明确的 `QemuCommandResult`。
- 命中 `panic:` 或 `kerneltrap` 后立即进入失败路径，只额外等待最多 1 秒补采当前行，确保日志保留 `panic: acquire` 等根因文本。
- `_run_qemu_tests` 在 fatal、EOF 或 timeout 时先写入 `test-results/<suite>/<test>.log`，再抛出带具体原因和日志路径的 `TestFailure`。
- 保持现有 suite 组成、TestCase timeout 预算、QEMU snapshot 与 `finally -> _stop_qemu` 清理行为不变。

## 添加/修改了什么单元测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `test_prompt_returns_success_output` | guest 正常返回 `$ ` | `failure is None`，且只消费一次等待事件 |
| `test_fatal_outputs_fail_immediately_and_capture_full_line` | `panic:` 与 `kerneltrap` | 返回 `matched fatal output`，完整保留 fatal 行，并把补采预算限制为 1 秒 |
| `test_eof_returns_distinct_failure` | QEMU 在 prompt 前退出 | 返回 `QEMU exited before returning to the shell` |
| `test_timeout_returns_distinct_failure` | 未出现 prompt 或 fatal output | 保留独立的 timeout 失败原因 |

## 如何通过 CLI 回归观察此 PR 现象

### 前置条件

```bash
git fetch origin
git switch fix/83-qemu-panic-fast-fail
```

### 操作步骤

```bash
python3 -m py_compile tests/run.py tests/test_runner.py tests/test_qemu_fail_fast.py
python3 -m unittest \
  tests.test_qemu_fail_fast.QemuFastFailTests.test_fatal_outputs_fail_immediately_and_capture_full_line \
  -v
python3 -m unittest discover -s tests -p 'test_*.py' -v
```

### 预期现象

```text
test_fatal_outputs_fail_immediately_and_capture_full_line ... ok
...
OK
```

该测试不会真实等待 1200 秒；它断言 runner 在匹配 fatal output 后只允许最多 1 秒补采当前 panic 行，然后立即返回失败结果。

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `python3 -m py_compile tests/run.py tests/test_runner.py tests/test_qemu_fail_fast.py` | 通过 | 三个 Python 文件编译检查无错误 |
| `python3 -m unittest discover -s tests -p 'test_*.py' -v` | 通过 | 基于当前 `main` runner、既有 `test_runner.py` 与仓库布局桩执行，`23/23` 用例通过 |
| fatal focused test | 通过 | `panic:`、`kerneltrap` 两个 subTest 均通过，运行耗时 `0.000s` |
| `python3 tests/run.py --list` | 通过 | 原有 atomic / aggregate suite 列表保持不变 |
| `make clean && make` | 未运行 | 当前执行容器无法解析 `github.com`，无法获得完整仓库与 RISC-V 构建环境 |
| QEMU 集成回归 | 未运行 | Draft PR 保持未就绪；仓库 CI 仅在 PR ready-for-review 时运行 regression job |

## Review 主线

1. `tests/run.py`：`QEMU_SHELL_PROMPT`、`QEMU_FATAL_OUTPUTS`、`QemuCommandResult`
   - 先确认 fatal signal 与既有 rejected pattern 保持一致，未改变 suite timeout。
2. `tests/run.py::_wait_for_qemu_command`
   - 检查 prompt、fatal、EOF、timeout 的索引边界，以及 fatal 行最多 1 秒的补采逻辑。
3. `tests/run.py::_run_qemu_tests`
   - 确认失败前先落日志，异常中包含具体原因和日志路径，且 `finally` 仍统一清理 QEMU。
4. `tests/test_qemu_fail_fast.py`
   - 最后对照 fake `expect_exact` 事件验证四类结果和 fast-fail 不变量。