### PR TITLE
feat: 增加用户态 VA 访问探针

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,21 @@ $U/_memviz: $U/memviz.o $U/memvizlib.o $(ULIB)
 	$(OBJDUMP) -S $@ > $U/memviz.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/memviz.sym
 
+$U/_varead: $U/varead.o $U/vaaccesslib.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $U/varead.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/varead.sym
+
+$U/_vawrite: $U/vawrite.o $U/vaaccesslib.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $U/vawrite.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/vawrite.sym
+
+$U/_vaprobe: $U/vaprobe.o $U/vaaccesslib.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $U/vaprobe.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/vaprobe.sym
+
 $U/_trace: $U/trace.o $U/tracemask.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $U/trace.asm
@@ -126,6 +141,11 @@ $U/_tracemasktest: $T/tracemasktest.o $U/tracemask.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $T/tracemasktest.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/tracemasktest.sym
+
+$U/_vaaccesstest: $T/vaaccesstest.o $T/testlib.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $T/vaaccesstest.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/vaaccesstest.sym
 
 $U/usys.S: $U/usys.pl
 	perl $U/usys.pl > $U/usys.S
@@ -176,7 +196,11 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_memviz\
+	$U/_varead\
+	$U/_vawrite\
+	$U/_vaprobe\
 	$U/_memviztest\
+	$U/_vaaccesstest\
 	$U/_wc\
 	$U/_zombie\
 	$U/_pingpong\

--- a/kernel/memviz.c
+++ b/kernel/memviz.c
@@ -136,6 +136,59 @@ append_pte_entry(struct memviz_snapshot *snapshot, int space, int role,
 }
 
 /**
+ * fill_pte_path 只读记录一个 VA 在指定页表中的 Sv39 三级链路。
+ *
+ * @param pagetable 被查询页表，不会被修改。
+ * @param va 用户传入的目标虚拟地址；函数内部按页向下对齐。
+ * @param levels 接收 L2、L1、L0 三层 PTE 信息，必须有三个元素。
+ * @param pte_out 接收 leaf PTE；没有有效 leaf 时写入 0。
+ * @param flags_out 接收 leaf flags；没有有效 leaf 时写入 0。
+ * @param pa_out 接收 leaf PA；没有有效 leaf 时写入 0。
+ * @return 找到有效 leaf 映射时返回 1；中途缺页或没有 leaf 时返回 0。
+ */
+static int
+fill_pte_path(pagetable_t pagetable, uint64 va,
+              struct memviz_pte_level levels[3], uint64 *pte_out,
+              uint64 *flags_out, uint64 *pa_out)
+{
+  uint64 aligned = PGROUNDDOWN(va);
+
+  *pte_out = 0;
+  *flags_out = 0;
+  *pa_out = 0;
+
+  if(aligned >= MAXVA)
+    return 0;
+
+  for(int level = 2; level >= 0; level--){
+    struct memviz_pte_level *pte_level = &levels[2 - level];
+    pte_level->level = level;
+    pte_level->index = PX(level, aligned);
+
+    pte_t pte = pagetable[pte_level->index];
+    pte_level->pte = pte;
+    pte_level->flags = PTE_FLAGS(pte);
+    if((pte & PTE_V) == 0)
+      return 0;
+
+    pte_level->present = 1;
+    pte_level->pa = PTE2PA(pte);
+    if(level == 0 || (pte & (PTE_R | PTE_W | PTE_X)) != 0){
+      if((pte & (PTE_R | PTE_W | PTE_X)) == 0)
+        return 0;
+      *pte_out = pte;
+      *flags_out = pte_level->flags;
+      *pa_out = pte_level->pa;
+      return 1;
+    }
+
+    pagetable = (pagetable_t)pte_level->pa;
+  }
+
+  return 0;
+}
+
+/**
  * fill_pagetable_observations 采集从 VA 到 PA 的代表性映射闭环。
  *
  * @param p 当前进程；调用期间页表稳定，函数只读 walk() 查询结果。
@@ -302,5 +355,40 @@ memviz_snapshot(int view, struct memviz_snapshot *snapshot)
 
   // kalloc 负责在锁内完成 freelist 采样，返回前已经释放所有 allocator 锁。
   kalloc_mem_snapshot(snapshot);
+  return 0;
+}
+
+/**
+ * memviz_query_user_va 查询当前进程用户页表中一个 VA 的页表链路。
+ *
+ * @param va 目标用户虚拟地址；允许未映射，函数会返回缺失层级信息。
+ * @param query 输出查询结果，必须是可写内核地址。
+ * @return 参数有效时返回 0；地址超出 Sv39 用户可表达范围或 query 为空时返回 -1。
+ *
+ * 该接口只观察 PTE，不读取或写入 va 指向的数据页；因此不会替代用户态
+ * load/store fault 实验，也不会触发 lazy allocation 或 COW。
+ */
+int
+memviz_query_user_va(uint64 va, struct memviz_va_query *query)
+{
+  if(query == 0 || va >= MAXVA)
+    return -1;
+
+  memset(query, 0, sizeof(*query));
+  query->va = PGROUNDDOWN(va);
+
+  struct proc *p = myproc();
+  query->present = fill_pte_path(p->pagetable, query->va, query->levels,
+                                 &query->pte, &query->flags, &query->pa);
+
+  uint64 kalloc_start = PGROUNDUP((uint64)end);
+  uint64 total = (PHYSTOP - kalloc_start) / PGSIZE;
+  query->kalloc_cell = -1;
+  if(query->present && total > 0 && query->pa >= kalloc_start &&
+     query->pa < PHYSTOP){
+    uint64 page = (query->pa - kalloc_start) / PGSIZE;
+    query->kalloc_cell = (page * MEMVIZ_CELLS) / total;
+  }
+
   return 0;
 }

--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -68,6 +68,18 @@ struct memviz_pte_entry {
   struct memviz_pte_level levels[3];
 };
 
+// 对单个用户虚拟地址执行只读页表查询的结果。
+struct memviz_va_query {
+  uint64 va;
+  int present;
+  int kalloc_cell;
+  int reserved;
+  uint64 pte;
+  uint64 flags;
+  uint64 pa;
+  struct memviz_pte_level levels[3];
+};
+
 // 一个页表页内部的 PTE 槽占用压缩单元。
 struct memviz_pt_usage_cell {
   uint total_entries;
@@ -149,5 +161,6 @@ struct memviz_snapshot {
 // 以下接口只由内核实现调用；用户态仅使用 memsnapshot() 系统调用。
 void kalloc_mem_snapshot(struct memviz_snapshot *snapshot);
 int memviz_snapshot(int view, struct memviz_snapshot *snapshot);
+int memviz_query_user_va(uint64 va, struct memviz_va_query *query);
 
 #endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -114,6 +114,7 @@ extern uint64 sys_mmap(void);
 extern uint64 sys_munmap(void);
 extern uint64 sys_backtrace(void);
 extern uint64 sys_memsnapshot(void);
+extern uint64 sys_vaquery(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -146,6 +147,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_munmap]    sys_munmap,
 [SYS_backtrace] sys_backtrace,
 [SYS_memsnapshot] sys_memsnapshot,
+[SYS_vaquery] sys_vaquery,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -29,3 +29,4 @@
 #define SYS_munmap     28
 #define SYS_backtrace  29
 #define SYS_memsnapshot 30
+#define SYS_vaquery    31

--- a/kernel/sysmemviz.c
+++ b/kernel/sysmemviz.c
@@ -63,3 +63,29 @@ sys_memsnapshot(void)
   release(&memvizsys_lock);
   return 0;
 }
+
+/**
+ * sys_vaquery 将当前进程中一个用户 VA 的页表链路复制到用户空间。
+ *
+ * 参数 0 是目标虚拟地址，参数 1 是 struct memviz_va_query 的用户地址。
+ * 该系统调用只读页表元数据，不读取目标 VA 的内容，也不为目标 VA 分配页。
+ *
+ * @return 成功返回 0；参数、地址范围或 copyout 失败时返回 -1。
+ */
+uint64
+sys_vaquery(void)
+{
+  uint64 va;
+  uint64 address;
+  struct memviz_va_query query;
+
+  if(argaddr(0, &va) < 0 || argaddr(1, &address) < 0)
+    return -1;
+  if(memviz_query_user_va(va, &query) < 0)
+    return -1;
+
+  struct proc *p = myproc();
+  if(copyout(p->pagetable, address, (char *)&query, sizeof(query)) < 0)
+    return -1;
+  return 0;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,7 +99,7 @@ XV6TEST done status=0
 |---|---|---|---|
 | Lab1 utilities | `xv6test --group lab1` | `tests/guest/lab1test.c` | 无 |
 | Lab2 syscall | `xv6test --group lab2` | `tracemasktest.c`、`sysinfotest.c`、`tracesmoke.c` | trace 控制台行 |
-| Lab3 page tables | `xv6test --group lab3` | `usertests.c` 指定用例、`memviztest.c` | 无 |
+| Lab3 page tables | `xv6test --group lab3` | `usertests.c` 指定用例、`memviztest.c`、`vaaccesstest.c` | 无 |
 | Lab4 traps | `xv6test --group lab4` | `bttest.c`、`alarmtest.c` | backtrace 地址行 |
 | Lab5 lazy allocation | `xv6test --group lab5` | `lazytests.c` | 无 |
 | Lab6 COW | `xv6test --group lab6` | `cowtest.c` | 无 |
@@ -108,7 +108,7 @@ XV6TEST done status=0
 | Lab9 file system | `--run lab9-bigfile` / `--run lab9-symlink` | `bigfile.c`、`symlinktest.c` | 分开 QEMU snapshot |
 | Lab10 mmap | `xv6test --group lab10` | `mmaptest.c` | 无 |
 
-`memviztest` 属于 Lab3 地址空间观察回归，验证用户栈、内核栈、物理页计数、分配与释放不变量；普通 `lab-vm` suite 会通过 `xv6test --group lab3` 自动覆盖它。
+`memviztest` 属于 Lab3 地址空间观察回归，验证用户栈、内核栈、物理页计数、分配与释放不变量；`vaaccesstest` 属于 Lab3 用户态 VA 访问回归，验证普通命中、lazy 首次触页、COW 写时复制和非法 VA fault 隔离；普通 `lab-vm` suite 会通过 `xv6test --group lab3` 自动覆盖它们。
 
 `sbrkmuch` 同时属于 Lab3 地址空间增长和 Lab8 allocator 行为，因此按两个稳定测试名注册；这是有意保留的跨 Lab 共享回归。
 

--- a/tests/guest/vaaccesstest.c
+++ b/tests/guest/vaaccesstest.c
@@ -1,0 +1,231 @@
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/memlayout.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+#include "tests/guest/testlib.h"
+
+static char output[4096];
+
+/**
+ * fail 输出稳定失败原因并以非零状态终止测试。
+ *
+ * @param message 失败原因，必须是便于定位的短文本。
+ */
+static void
+fail(char *message)
+{
+  printf("vaaccesstest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * require_contains 断言捕获输出中包含指定协议片段。
+ *
+ * @param text 被检查输出。
+ * @param needle 必须出现的连续子串。
+ */
+static void
+require_contains(char *text, char *needle)
+{
+  if(!xv6_test_contains(text, needle)){
+    printf("vaaccesstest: missing output: %s\n", needle);
+    fail("missing output");
+  }
+}
+
+/**
+ * run_command 执行用户命令并校验退出状态。
+ *
+ * @param argv exec 参数数组，argv[0] 是命令名。
+ * @param expected_status 期望 wait status。
+ * @return 捕获输出缓冲区；下次调用会覆盖。
+ */
+static char *
+run_command(char **argv, int expected_status)
+{
+  int status = 0;
+  if(xv6_test_run_capture(argv, 0, output, sizeof(output), &status) < 0)
+    fail("capture failed");
+  if(status != expected_status){
+    printf("vaaccesstest: command=%s status=%d expected=%d\n",
+           argv[0], status, expected_status);
+    printf("%s\n", output);
+    fail("unexpected status");
+  }
+  return output;
+}
+
+/**
+ * free_pages 读取当前进程可观察的 kalloc 空闲页数量。
+ *
+ * @return 成功时返回 free_pages；系统调用失败时终止测试。
+ */
+static uint64
+free_pages(void)
+{
+  static struct memviz_snapshot snapshot;
+  if(memsnapshot(MEMVIZ_VIEW_USER, &snapshot) < 0)
+    fail("memsnapshot failed");
+  return snapshot.free_pages;
+}
+
+/**
+ * test_mapped_access 验证已映射 ELF 页的读写都走普通命中路径。
+ */
+static void
+test_mapped_access(void)
+{
+  char *read_args[] = {"varead", "image+0", "--expect", "ok", "--snapshot", 0};
+  char *write_args[] = {"vawrite", "image+0", "0x41", "--expect", "ok", 0};
+
+  char *text = run_command(read_args, 0);
+  require_contains(text, "VAACCESS result=ok");
+  require_contains(text, "VAACCESS BEFORE");
+  require_contains(text, "VAACCESS AFTER");
+
+  text = run_command(write_args, 0);
+  require_contains(text, "VAACCESS readback=0x41");
+  require_contains(text, "VAACCESS result=ok");
+
+  printf("vaaccesstest: mapped access OK\n");
+}
+
+/**
+ * test_lazy_access 验证 lazy reserve 与首次触页分离，且命令退出后归还页面。
+ */
+static void
+test_lazy_access(void)
+{
+  char *read_args[] = {"varead", "--lazy", "0", "--snapshot", 0};
+  char *write_args[] = {"vawrite", "--lazy", "2", "0x42", "--snapshot", 0};
+  uint64 before = free_pages();
+
+  char *text = run_command(read_args, 0);
+  require_contains(text, "VAACCESS mode=lazy");
+  require_contains(text, "VAACCESS before mapped=0");
+  require_contains(text, "VAACCESS value=0x00");
+  require_contains(text, "VAACCESS after mapped=1");
+
+  text = run_command(write_args, 0);
+  require_contains(text, "VAACCESS reserved_pages=3");
+  require_contains(text, "VAACCESS before mapped=0");
+  require_contains(text, "VAACCESS readback=0x42");
+  require_contains(text, "VAACCESS after mapped=1");
+
+  if(free_pages() != before)
+    fail("lazy command leaked pages");
+
+  printf("vaaccesstest: lazy access OK\n");
+}
+
+/**
+ * test_cow_access 验证 COW 写前共享 PA、写后 child 私有 PA、父子内容隔离。
+ */
+static void
+test_cow_access(void)
+{
+  char *args[] = {"vawrite", "--cow", "0x43", "--snapshot", 0};
+  uint64 before = free_pages();
+  char *text = run_command(args, 0);
+
+  require_contains(text, "VAACCESS mode=cow");
+  require_contains(text, "VAACCESS child before_pa=");
+  require_contains(text, "VAACCESS readback=0x43");
+  require_contains(text, "VAACCESS parent_value=0x31");
+  require_contains(text, "VAACCESS result=ok");
+  if(free_pages() != before)
+    fail("cow command leaked pages");
+
+  printf("vaaccesstest: cow access OK\n");
+}
+
+/**
+ * test_faults 验证非法访问只杀 worker，supervisor 和后续命令仍可继续。
+ */
+static void
+test_faults(void)
+{
+  char *guard_read[] = {"varead", "guard+0", "--expect", "fault", "--snapshot", 0};
+  char *guard_write[] = {"vawrite", "guard+0", "0x41", "--expect", "fault", 0};
+  char *brk_read[] = {"varead", "brk+4096", "--expect", "fault", 0};
+  char *plic_write[] = {"vawrite", "0x000000000C000000", "0x41",
+                        "--expect", "fault", 0};
+  char *alive[] = {"echo", "shell-alive", 0};
+
+  require_contains(run_command(guard_read, 0), "VAACCESS result=fault");
+  require_contains(run_command(guard_write, 0), "VAACCESS result=fault");
+  require_contains(run_command(brk_read, 0), "VAACCESS result=fault");
+  require_contains(run_command(plic_write, 0), "VAACCESS result=fault");
+  require_contains(run_command(alive, 0), "shell-alive");
+
+  printf("vaaccesstest: fault isolation OK\n");
+}
+
+/**
+ * test_parsing_and_expect 验证地址解析、溢出拒绝和 --expect 状态传播。
+ */
+static void
+test_parsing_and_expect(void)
+{
+  char *decimal[] = {"varead", "0", "--expect", "ok", 0};
+  char *hex[] = {"varead", "0x0", "--expect", "ok", 0};
+  char *bad[] = {"varead", "not-a-va", 0};
+  char *overflow[] = {"varead", "0xffffffffffffffff", 0};
+  char *mismatch[] = {"varead", "image+0", "--expect", "fault", 0};
+
+  require_contains(run_command(decimal, 0), "VAACCESS result=ok");
+  require_contains(run_command(hex, 0), "VAACCESS result=ok");
+  run_command(bad, 2);
+  run_command(overflow, 2);
+  run_command(mismatch, 1);
+
+  printf("vaaccesstest: parsing and expect OK\n");
+}
+
+/**
+ * test_va_zero_follows_real_pagetable 验证 VA 0 不是写死的 NULL page 假设。
+ */
+static void
+test_va_zero_follows_real_pagetable(void)
+{
+  struct memviz_va_query query;
+  if(vaquery(0, &query) < 0)
+    fail("vaquery zero failed");
+
+  if(query.present){
+    char *args[] = {"varead", "image+0", "--expect", "ok", 0};
+    require_contains(run_command(args, 0), "VAACCESS result=ok");
+  } else {
+    char *args[] = {"varead", "0", "--expect", "fault", 0};
+    require_contains(run_command(args, 0), "VAACCESS result=fault");
+  }
+
+  printf("vaaccesstest: va0 real pagetable OK\n");
+}
+
+/**
+ * main 执行用户态 VA 访问探针的 Lab3 回归。
+ *
+ * @param argc 参数数量；测试不接受额外参数。
+ * @param argv 参数数组，仅用于保持 xv6 用户程序签名。
+ * @return 通过 exit() 返回；全部断言成功为 0。
+ */
+int
+main(int argc, char **argv)
+{
+  (void)argv;
+  if(argc != 1)
+    exit(2);
+
+  test_mapped_access();
+  test_lazy_access();
+  test_cow_access();
+  test_faults();
+  test_parsing_and_expect();
+  test_va_zero_follows_real_pagetable();
+
+  printf("vaaccesstest: OK\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -30,6 +30,7 @@ static char *lab3_copyout_argv[] = {"usertests", "copyout", 0};
 static char *lab3_copyinstr_argv[] = {"usertests", "copyinstr1", 0};
 static char *lab3_sbrkmuch_argv[] = {"usertests", "sbrkmuch", 0};
 static char *lab3_memviz_argv[] = {"memviztest", 0};
+static char *lab3_vaaccess_argv[] = {"vaaccesstest", 0};
 
 static char *lab4_backtrace_argv[] = {"bttest", 0};
 static char *lab4_alarm_argv[] = {"alarmtest", 0};
@@ -74,6 +75,7 @@ static struct xv6_test_case tests[] = {
   {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv},
   {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv},
   {"lab3", "lab3-memviz", lab3_memviz_argv},
+  {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
 
   {"lab4", "lab4-backtrace", lab4_backtrace_argv},
   {"lab4", "lab4-alarm", lab4_alarm_argv},

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,6 +39,7 @@ GUEST_SOURCE_NAMES = (
     "lab1test.c",
     "tracesmoke.c",
     "uthreadtest.c",
+    "vaaccesstest.c",
     "testlib.c",
     "xv6test.c",
 )

--- a/user/user.h
+++ b/user/user.h
@@ -2,6 +2,7 @@ struct stat;
 struct rtcdate;
 struct sysinfo;
 struct memviz_snapshot;
+struct memviz_va_query;
 
 // system calls
 int fork(void);
@@ -34,6 +35,7 @@ char *mmap(void *addr, int length, int prot, int flags, int fd, int offset);
 int munmap(void *addr, int length);
 int backtrace(void);
 int memsnapshot(int view, struct memviz_snapshot *snapshot);
+int vaquery(uint64 va, struct memviz_va_query *query);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -45,3 +45,4 @@ entry("mmap");
 entry("munmap");
 entry("backtrace");
 entry("memsnapshot");
+entry("vaquery");

--- a/user/vaaccesslib.c
+++ b/user/vaaccesslib.c
@@ -1,0 +1,899 @@
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/memlayout.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+#include "user/vaaccesslib.h"
+
+struct vaaccess_options {
+  int op;
+  int mode;
+  int expect_fault;
+  int expect_set;
+  int snapshot;
+  char *address_text;
+  uint64 byte_value;
+  int lazy_page;
+};
+
+struct cow_report {
+  uint64 child_before_pa;
+  uint64 child_after_pa;
+  uint64 child_before_flags;
+  uint64 child_after_flags;
+  int readback;
+  int query_ok;
+};
+
+/**
+ * streq 比较两个 NUL 结尾字符串是否完全相同。
+ *
+ * @param a 左侧字符串，必须非空。
+ * @param b 右侧字符串，必须非空。
+ * @return 完全相同时返回 1，否则返回 0。
+ */
+static int
+streq(char *a, char *b)
+{
+  return strcmp(a, b) == 0;
+}
+
+/**
+ * starts_with 判断字符串是否以指定前缀开头。
+ *
+ * @param text 待检查字符串，必须非空。
+ * @param prefix 目标前缀，必须非空。
+ * @return text 以 prefix 开头时返回 1，否则返回 0。
+ */
+static int
+starts_with(char *text, char *prefix)
+{
+  while(*prefix){
+    if(*text != *prefix)
+      return 0;
+    text++;
+    prefix++;
+  }
+  return 1;
+}
+
+/**
+ * hex_digit 将一个十六进制字符转换为数值。
+ *
+ * @param ch 输入字符。
+ * @return 0..15 表示合法十六进制数字；-1 表示非法字符。
+ */
+static int
+hex_digit(char ch)
+{
+  if(ch >= '0' && ch <= '9')
+    return ch - '0';
+  if(ch >= 'a' && ch <= 'f')
+    return ch - 'a' + 10;
+  if(ch >= 'A' && ch <= 'F')
+    return ch - 'A' + 10;
+  return -1;
+}
+
+int
+vaaccess_parse_u64(char *text, uint64 *value)
+{
+  int base = 10;
+  uint64 result = 0;
+
+  if(text == 0 || *text == 0 || value == 0 || *text == '-')
+    return -1;
+  if(text[0] == '0' && (text[1] == 'x' || text[1] == 'X')){
+    base = 16;
+    text += 2;
+    if(*text == 0)
+      return -1;
+  }
+
+  for(; *text; text++){
+    int digit = base == 16 ? hex_digit(*text) :
+      (*text >= '0' && *text <= '9' ? *text - '0' : -1);
+    if(digit < 0 || digit >= base)
+      return -1;
+    if(result > (~(uint64)0 - digit) / base)
+      return -1;
+    result = result * base + digit;
+  }
+
+  *value = result;
+  return 0;
+}
+
+/**
+ * parse_byte 解析写入值并限制在单字节范围内。
+ *
+ * @param text 输入字符串，支持十进制或 0x 十六进制。
+ * @param value 接收 0..255 的解析结果。
+ * @return 成功返回 0；格式错误或超过单字节返回 -1。
+ */
+static int
+parse_byte(char *text, uint64 *value)
+{
+  if(vaaccess_parse_u64(text, value) < 0)
+    return -1;
+  return *value <= 0xff ? 0 : -1;
+}
+
+/**
+ * add_overflow 检查并执行 uint64 加法。
+ *
+ * @param left 左操作数。
+ * @param right 右操作数。
+ * @param out 接收结果。
+ * @return 无溢出返回 0；溢出返回 -1。
+ */
+static int
+add_overflow(uint64 left, uint64 right, uint64 *out)
+{
+  if(left > ~(uint64)0 - right)
+    return -1;
+  *out = left + right;
+  return 0;
+}
+
+/**
+ * print_byte 以稳定的两位十六进制形式打印一个字节。
+ *
+ * @param value 待打印字节，仅低 8 位有效。
+ */
+static void
+print_byte(uint64 value)
+{
+  char *digits = "0123456789abcdef";
+  printf("0x%c%c", digits[(value >> 4) & 0xf], digits[value & 0xf]);
+}
+
+/**
+ * print_flags 输出 leaf PTE 的教学 flags。
+ *
+ * @param flags PTE_FLAGS() 的结果。
+ */
+static void
+print_flags(uint64 flags)
+{
+  printf("%c%c%c%c%c%c",
+         (flags & PTE_V) ? 'V' : '-',
+         (flags & PTE_R) ? 'R' : '-',
+         (flags & PTE_W) ? 'W' : '-',
+         (flags & PTE_X) ? 'X' : '-',
+         (flags & PTE_U) ? 'U' : '-',
+         (flags & PTE_COW) ? 'C' : '-');
+}
+
+/**
+ * snapshot_user 采集当前进程 memviz 用户视图。
+ *
+ * @param snapshot 接收快照，不可为空。
+ * @return 成功返回 0；系统调用失败返回 -1。
+ */
+static int
+snapshot_user(struct memviz_snapshot *snapshot)
+{
+  return memsnapshot(MEMVIZ_VIEW_USER, snapshot);
+}
+
+/**
+ * print_query 输出目标 VA 的单页页表查询摘要。
+ *
+ * @param label 输出阶段标签，例如 before 或 after。
+ * @param va 目标虚拟地址。
+ * @param query 已由 vaquery() 填写的结果。
+ */
+static void
+print_query(char *label, uint64 va, struct memviz_va_query *query)
+{
+  printf("VAACCESS %s va=%p mapped=%d", label, va, query->present);
+  if(query->present){
+    printf(" pte=%p flags=", query->pte);
+    print_flags(query->flags);
+    printf(" pa=%p kalloc_cell=%d", query->pa, query->kalloc_cell);
+  }
+  printf("\n");
+}
+
+/**
+ * print_snapshot_block 输出访问前后的布局和目标 VA 页表路径摘要。
+ *
+ * @param title BEFORE 或 AFTER。
+ * @param va 目标虚拟地址。
+ * @param layout 当前进程用户视图快照。
+ * @param query 当前进程目标 VA 查询结果。
+ */
+static void
+print_snapshot_block(char *title, uint64 va, struct memviz_snapshot *layout,
+                     struct memviz_va_query *query)
+{
+  printf("VAACCESS %s\n", title);
+  printf("VAACCESS layout sz=%p stack=[%p,%p) guard=%p limit=%p free_pages=%d\n",
+         layout->process_size, layout->stack_bottom, layout->stack_top,
+         layout->stack_guard_start, layout->user_limit, (int)layout->free_pages);
+  print_query(title, va, query);
+  for(int i = 0; i < 3; i++){
+    struct memviz_pte_level *level = &query->levels[i];
+    printf("VAACCESS %s L%d[%d] present=%d pte=%p pa=%p flags=",
+           title, level->level, level->index, level->present,
+           level->pte, level->pa);
+    print_flags(level->flags);
+    printf("\n");
+  }
+}
+
+/**
+ * resolve_address 解析相对于当前进程快照的地址表达式。
+ *
+ * @param text 地址表达式，支持绝对数值和 image/guard/stack/heap/brk/limit。
+ * @param layout 当前进程的用户视图快照。
+ * @param va 接收最终绝对 VA。
+ * @param reserved_bytes 接收本函数因 heap+N 临时 sbrk 的字节数。
+ * @return 成功返回 0；格式、溢出、越界或 sbrk 失败返回 -1。
+ */
+static int
+resolve_address(char *text, struct memviz_snapshot *layout, uint64 *va,
+                int *reserved_bytes)
+{
+  uint64 offset;
+  *reserved_bytes = 0;
+
+  if(vaaccess_parse_u64(text, va) == 0)
+    return *va < MAXVA ? 0 : -1;
+
+  if(starts_with(text, "image+")){
+    if(vaaccess_parse_u64(text + 6, &offset) < 0)
+      return -1;
+    return add_overflow(layout->image_start, offset, va) < 0 || *va >= MAXVA ?
+      -1 : 0;
+  }
+  if(starts_with(text, "guard+")){
+    if(vaaccess_parse_u64(text + 6, &offset) < 0)
+      return -1;
+    return add_overflow(layout->stack_guard_start, offset, va) < 0 || *va >= MAXVA ?
+      -1 : 0;
+  }
+  if(starts_with(text, "stack-")){
+    if(vaaccess_parse_u64(text + 6, &offset) < 0 || layout->stack_top < offset)
+      return -1;
+    *va = layout->stack_top - offset;
+    return *va < MAXVA ? 0 : -1;
+  }
+  if(starts_with(text, "brk+")){
+    if(vaaccess_parse_u64(text + 4, &offset) < 0)
+      return -1;
+    return add_overflow(layout->process_size, offset, va) < 0 || *va >= MAXVA ?
+      -1 : 0;
+  }
+  if(starts_with(text, "limit-")){
+    if(vaaccess_parse_u64(text + 6, &offset) < 0 || layout->user_limit < offset)
+      return -1;
+    *va = layout->user_limit - offset;
+    return *va < MAXVA ? 0 : -1;
+  }
+  if(starts_with(text, "heap+")){
+    if(vaaccess_parse_u64(text + 5, &offset) < 0)
+      return -1;
+    uint64 reserve = PGROUNDUP(offset + 1);
+    if(reserve == 0 || reserve > 16 * PGSIZE)
+      return -1;
+    char *base = sbrk((int)reserve);
+    if(base == (char *)-1)
+      return -1;
+    *reserved_bytes = (int)reserve;
+    return add_overflow((uint64)base, offset, va) < 0 || *va >= MAXVA ?
+      -1 : 0;
+  }
+
+  return -1;
+}
+
+/**
+ * resolve_probe_address 解析 vaprobe 会话内地址表达式。
+ *
+ * @param text 地址表达式；heap+N 绑定到 reserve 记录的 heap_base。
+ * @param layout 当前会话进程快照。
+ * @param heap_base 最近一次从 0 页进入 reserve 状态时的旧 break。
+ * @param va 接收最终绝对 VA。
+ * @return 成功返回 0；没有 reserve 却使用 heap+N 或解析失败返回 -1。
+ */
+static int
+resolve_probe_address(char *text, struct memviz_snapshot *layout,
+                      uint64 heap_base, uint64 *va)
+{
+  uint64 offset;
+  int ignored;
+
+  if(starts_with(text, "heap+")){
+    if(heap_base == 0 || vaaccess_parse_u64(text + 5, &offset) < 0)
+      return -1;
+    return add_overflow(heap_base, offset, va) < 0 || *va >= MAXVA ? -1 : 0;
+  }
+  return resolve_address(text, layout, va, &ignored);
+}
+
+/**
+ * parse_expect 解析 --expect 参数。
+ *
+ * @param value ok 或 fault。
+ * @param options 待更新选项。
+ * @return 成功返回 0；未知期望返回 -1。
+ */
+static int
+parse_expect(char *value, struct vaaccess_options *options)
+{
+  if(streq(value, "ok")){
+    options->expect_set = 1;
+    options->expect_fault = 0;
+    return 0;
+  }
+  if(streq(value, "fault")){
+    options->expect_set = 1;
+    options->expect_fault = 1;
+    return 0;
+  }
+  return -1;
+}
+
+/**
+ * worker_access 在当前进程中解析地址并执行真正的 volatile load/store。
+ *
+ * @param options 已解析命令选项。
+ * @return 成功访问返回 0；参数或观测失败返回 2；非法 VA fault 会直接杀死进程。
+ */
+static int
+worker_access(struct vaaccess_options *options)
+{
+  static struct memviz_snapshot before_layout;
+  static struct memviz_snapshot after_layout;
+  struct memviz_va_query before_query;
+  struct memviz_va_query after_query;
+  uint64 va = 0;
+  int reserved_bytes = 0;
+
+  if(snapshot_user(&before_layout) < 0)
+    return 2;
+
+  if(options->mode == VAACCESS_MODE_LAZY){
+    int pages = options->lazy_page + 1;
+    char *base = sbrk(pages * PGSIZE);
+    if(base == (char *)-1)
+      return 2;
+    reserved_bytes = pages * PGSIZE;
+    va = (uint64)base + (uint64)options->lazy_page * PGSIZE;
+    printf("VAACCESS mode=lazy\n");
+    printf("VAACCESS reserved_pages=%d\n", pages);
+    printf("VAACCESS target_page=%d\n", options->lazy_page);
+    if(snapshot_user(&before_layout) < 0)
+      return 2;
+  } else if(resolve_address(options->address_text, &before_layout, &va,
+                            &reserved_bytes) < 0){
+    printf("VAACCESS diagnostic parse-address failed\n");
+    return 2;
+  }
+
+  if(vaquery(va, &before_query) < 0)
+    return 2;
+
+  printf("VAACCESS begin op=%s va=%p",
+         options->op == VAACCESS_READ ? "read" : "write", va);
+  if(options->op == VAACCESS_WRITE){
+    printf(" value=");
+    print_byte(options->byte_value);
+  }
+  printf("\n");
+
+  printf("VAACCESS before mapped=%d free_pages=%d\n",
+         before_query.present, (int)before_layout.free_pages);
+  if(options->snapshot)
+    print_snapshot_block("BEFORE", va, &before_layout, &before_query);
+
+  if(options->op == VAACCESS_READ){
+    volatile unsigned char value = *(volatile unsigned char *)va;
+    printf("VAACCESS value=");
+    print_byte(value);
+    printf("\n");
+  } else {
+    *(volatile unsigned char *)va = (unsigned char)options->byte_value;
+    volatile unsigned char readback = *(volatile unsigned char *)va;
+    printf("VAACCESS readback=");
+    print_byte(readback);
+    printf("\n");
+  }
+
+  if(snapshot_user(&after_layout) < 0 || vaquery(va, &after_query) < 0)
+    return 2;
+  printf("VAACCESS after mapped=%d free_pages=%d\n",
+         after_query.present, (int)after_layout.free_pages);
+  if(options->snapshot)
+    print_snapshot_block("AFTER", va, &after_layout, &after_query);
+
+  if(options->mode == VAACCESS_MODE_LAZY && before_query.present)
+    return 1;
+  if(options->mode == VAACCESS_MODE_LAZY && !after_query.present)
+    return 1;
+
+  if(reserved_bytes > 0 && sbrk(-reserved_bytes) == (char *)-1)
+    return 1;
+  return 0;
+}
+
+/**
+ * run_supervised 在子进程中运行真实访问，并把 wait status 归一化。
+ *
+ * @param options 已解析命令选项。
+ * @return 结果符合 --expect 时返回 0；不符合返回 1；参数错误返回 2。
+ */
+static int
+run_supervised(int argc, char **argv, struct vaaccess_options *options)
+{
+  int pid = fork();
+  int status = 0;
+
+  if(pid < 0){
+    printf("VAACCESS diagnostic fork failed\n");
+    return 1;
+  }
+  if(pid == 0){
+    char *worker_argv[16];
+    if(argc + 1 >= 16)
+      exit(2);
+    worker_argv[0] = argv[0];
+    worker_argv[1] = "--worker";
+    for(int i = 1; i < argc; i++)
+      worker_argv[i + 1] = argv[i];
+    worker_argv[argc + 1] = 0;
+    exec(argv[0], worker_argv);
+    exit(2);
+  }
+
+  if(wait(&status) != pid){
+    printf("VAACCESS diagnostic wait failed\n");
+    return 1;
+  }
+
+  int actual_fault = status == -1;
+  int actual_ok = status == 0;
+  if(actual_fault)
+    printf("VAACCESS result=fault\n");
+  else if(actual_ok)
+    printf("VAACCESS result=ok\n");
+  else {
+    printf("VAACCESS result=error\n");
+    printf("VAACCESS worker_status=%d\n", status);
+    printf("VAACCESS done status=2\n");
+    return 2;
+  }
+
+  if(actual_fault)
+    printf("VAACCESS worker_status=-1\n");
+
+  int expected_fault = options->expect_set ? options->expect_fault : 0;
+  int done = actual_fault == expected_fault ? 0 : 1;
+  printf("VAACCESS done status=%d\n", done);
+  return done;
+}
+
+/**
+ * parse_common_options 解析 read/write 命令共享选项。
+ *
+ * @param argc 参数数量。
+ * @param argv 参数数组。
+ * @param options 接收解析结果。
+ * @return 成功返回 0；参数错误返回 -1。
+ */
+static int
+parse_common_options(int argc, char **argv, struct vaaccess_options *options)
+{
+  int op = options->op;
+  memset(options, 0, sizeof(*options));
+  options->op = op;
+  options->mode = VAACCESS_MODE_DIRECT;
+
+  int i = 1;
+  if(i < argc && streq(argv[i], "--lazy")){
+    uint64 page;
+    if(i + 1 >= argc || vaaccess_parse_u64(argv[i + 1], &page) < 0 ||
+       page > 15)
+      return -1;
+    options->mode = VAACCESS_MODE_LAZY;
+    options->lazy_page = (int)page;
+    i += 2;
+  } else if(options->op == VAACCESS_WRITE && i < argc && streq(argv[i], "--cow")){
+    options->mode = VAACCESS_MODE_COW;
+    i++;
+  } else {
+    if(i >= argc)
+      return -1;
+    options->address_text = argv[i++];
+  }
+
+  if(options->op == VAACCESS_WRITE){
+    if(i >= argc || parse_byte(argv[i], &options->byte_value) < 0)
+      return -1;
+    i++;
+  }
+
+  while(i < argc){
+    if(streq(argv[i], "--snapshot")){
+      options->snapshot = 1;
+      i++;
+    } else if(streq(argv[i], "--expect")){
+      if(i + 1 >= argc || parse_expect(argv[i + 1], options) < 0)
+        return -1;
+      i += 2;
+    } else {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * run_cow 执行明确的 COW 写入实验。
+ *
+ * @param options 写命令选项；byte_value 是 child 写入值。
+ * @return 验证通过返回 0；任一不变量失败返回 1 或 2。
+ */
+static int
+run_cow(struct vaaccess_options *options)
+{
+  static struct memviz_snapshot before;
+  static struct memviz_snapshot after_wait;
+  static struct memviz_snapshot after_shrink;
+  struct memviz_va_query parent_cow;
+  struct cow_report report;
+  int start_pipe[2];
+  int report_pipe[2];
+  char token = 'x';
+  char *base;
+  int pid;
+  int status = 0;
+  unsigned char initial = 0x31;
+
+  memset(&report, 0, sizeof(report));
+  if(snapshot_user(&before) < 0)
+    return 2;
+  base = sbrk(PGSIZE);
+  if(base == (char *)-1)
+    return 2;
+  *(volatile unsigned char *)base = initial;
+
+  if(pipe(start_pipe) < 0 || pipe(report_pipe) < 0)
+    return 2;
+  pid = fork();
+  if(pid < 0)
+    return 2;
+  if(pid == 0){
+    close(start_pipe[1]);
+    close(report_pipe[0]);
+    if(read(start_pipe[0], &token, 1) != 1)
+      exit(2);
+    struct memviz_va_query child_before;
+    struct memviz_va_query child_after;
+    if(vaquery((uint64)base, &child_before) < 0)
+      exit(2);
+    *(volatile unsigned char *)base = (unsigned char)options->byte_value;
+    volatile unsigned char readback = *(volatile unsigned char *)base;
+    if(vaquery((uint64)base, &child_after) < 0)
+      exit(2);
+    report.child_before_pa = child_before.pa;
+    report.child_after_pa = child_after.pa;
+    report.child_before_flags = child_before.flags;
+    report.child_after_flags = child_after.flags;
+    report.readback = readback;
+    report.query_ok = child_before.present && child_after.present;
+    write(report_pipe[1], &report, sizeof(report));
+    exit(0);
+  }
+
+  close(start_pipe[0]);
+  close(report_pipe[1]);
+  if(vaquery((uint64)base, &parent_cow) < 0)
+    return 2;
+  write(start_pipe[1], &token, 1);
+  close(start_pipe[1]);
+  if(read(report_pipe[0], &report, sizeof(report)) != sizeof(report))
+    return 2;
+  close(report_pipe[0]);
+  if(wait(&status) != pid)
+    return 2;
+
+  volatile unsigned char parent_value = *(volatile unsigned char *)base;
+  snapshot_user(&after_wait);
+  int ok = status == 0 && report.query_ok &&
+    report.child_before_pa == parent_cow.pa &&
+    report.child_after_pa != parent_cow.pa &&
+    (parent_cow.flags & PTE_COW) && (report.child_before_flags & PTE_COW) &&
+    (report.child_before_flags & PTE_W) == 0 &&
+    (report.child_after_flags & PTE_W) &&
+    (report.child_after_flags & PTE_COW) == 0 &&
+    report.readback == (int)options->byte_value &&
+    parent_value == initial;
+
+  printf("VAACCESS mode=cow\n");
+  printf("VAACCESS begin op=write va=%p value=", (uint64)base);
+  print_byte(options->byte_value);
+  printf("\n");
+  if(options->snapshot){
+    printf("VAACCESS BEFORE\n");
+    print_query("parent-cow", (uint64)base, &parent_cow);
+    printf("VAACCESS AFTER\n");
+    printf("VAACCESS child before_pa=%p after_pa=%p before_flags=",
+           report.child_before_pa, report.child_after_pa);
+    print_flags(report.child_before_flags);
+    printf(" after_flags=");
+    print_flags(report.child_after_flags);
+    printf("\n");
+    printf("VAACCESS free_pages before=%d after_child=%d\n",
+           (int)before.free_pages, (int)after_wait.free_pages);
+  }
+  printf("VAACCESS readback=");
+  print_byte(report.readback);
+  printf("\n");
+  printf("VAACCESS parent_value=");
+  print_byte(parent_value);
+  printf("\n");
+
+  if(sbrk(-PGSIZE) == (char *)-1)
+    ok = 0;
+  snapshot_user(&after_shrink);
+  if(after_shrink.free_pages != before.free_pages)
+    ok = 0;
+
+  printf("VAACCESS result=%s\n", ok ? "ok" : "error");
+  printf("VAACCESS done status=%d\n", ok ? 0 : 1);
+  return ok ? 0 : 1;
+}
+
+int
+vaaccess_read_main(int argc, char **argv)
+{
+  struct vaaccess_options options;
+  if(argc >= 2 && streq(argv[1], "--worker")){
+    char *worker_argv[16];
+    if(argc > 16)
+      return 2;
+    worker_argv[0] = argv[0];
+    for(int i = 2; i < argc; i++)
+      worker_argv[i - 1] = argv[i];
+    worker_argv[argc - 1] = 0;
+    options.op = VAACCESS_READ;
+    if(parse_common_options(argc - 1, worker_argv, &options) < 0 ||
+       options.mode == VAACCESS_MODE_COW)
+      return 2;
+    options.op = VAACCESS_READ;
+    return worker_access(&options);
+  }
+
+  options.op = VAACCESS_READ;
+  if(parse_common_options(argc, argv, &options) < 0 || options.mode == VAACCESS_MODE_COW){
+    fprintf(2, "usage: varead <address> [--expect ok|fault] [--snapshot]\n");
+    fprintf(2, "       varead --lazy <page-offset> [--expect ok|fault] [--snapshot]\n");
+    return 2;
+  }
+  options.op = VAACCESS_READ;
+  return run_supervised(argc, argv, &options);
+}
+
+int
+vaaccess_write_main(int argc, char **argv)
+{
+  struct vaaccess_options options;
+  if(argc >= 2 && streq(argv[1], "--worker")){
+    char *worker_argv[16];
+    if(argc > 16)
+      return 2;
+    worker_argv[0] = argv[0];
+    for(int i = 2; i < argc; i++)
+      worker_argv[i - 1] = argv[i];
+    worker_argv[argc - 1] = 0;
+    options.op = VAACCESS_WRITE;
+    if(parse_common_options(argc - 1, worker_argv, &options) < 0 ||
+       options.mode == VAACCESS_MODE_COW)
+      return 2;
+    options.op = VAACCESS_WRITE;
+    return worker_access(&options);
+  }
+
+  options.op = VAACCESS_WRITE;
+  if(parse_common_options(argc, argv, &options) < 0){
+    fprintf(2, "usage: vawrite <address> <byte> [--expect ok|fault] [--snapshot]\n");
+    fprintf(2, "       vawrite --lazy <page-offset> <byte> [--expect ok|fault] [--snapshot]\n");
+    fprintf(2, "       vawrite --cow <byte> [--snapshot]\n");
+    return 2;
+  }
+  options.op = VAACCESS_WRITE;
+  if(options.mode == VAACCESS_MODE_COW)
+    return run_cow(&options);
+  return run_supervised(argc, argv, &options);
+}
+
+/**
+ * trim_newline 删除 gets() 留下的换行符。
+ *
+ * @param text 可修改字符串。
+ */
+static void
+trim_newline(char *text)
+{
+  int n = strlen(text);
+  if(n > 0 && text[n - 1] == '\n')
+    text[n - 1] = 0;
+}
+
+/**
+ * split_line 将交互命令切成最多四个参数。
+ *
+ * @param line 可修改命令行；空白会被替换为 NUL。
+ * @param argv 接收参数指针。
+ * @param max 最多接收多少参数。
+ * @return 实际参数数量。
+ */
+static int
+split_line(char *line, char **argv, int max)
+{
+  int argc = 0;
+  char *p = line;
+  while(*p && argc < max){
+    while(*p == ' ' || *p == '\t')
+      p++;
+    if(*p == 0)
+      break;
+    argv[argc++] = p;
+    while(*p && *p != ' ' && *p != '\t')
+      p++;
+    if(*p){
+      *p = 0;
+      p++;
+    }
+  }
+  return argc;
+}
+
+/**
+ * probe_access 在 vaprobe 当前进程中直接执行一次读写。
+ *
+ * @param op VAACCESS_READ 或 VAACCESS_WRITE。
+ * @param address_text vaprobe 地址表达式。
+ * @param byte_value 写操作的目标字节；读操作忽略。
+ * @param heap_base reserve 命令记录的会话 heap 起点。
+ * @return 成功访问返回 0；解析或查询失败返回 -1；非法访问会杀死 vaprobe。
+ */
+static int
+probe_access(int op, char *address_text, uint64 byte_value, uint64 heap_base)
+{
+  struct memviz_va_query before_query;
+  struct memviz_va_query after_query;
+  static struct memviz_snapshot before_layout;
+  static struct memviz_snapshot after_layout;
+  uint64 va;
+
+  if(snapshot_user(&before_layout) < 0 ||
+     resolve_probe_address(address_text, &before_layout, heap_base, &va) < 0 ||
+     vaquery(va, &before_query) < 0)
+    return -1;
+
+  printf("VAACCESS begin op=%s va=%p", op == VAACCESS_READ ? "read" : "write", va);
+  if(op == VAACCESS_WRITE){
+    printf(" value=");
+    print_byte(byte_value);
+  }
+  printf("\n");
+  printf("VAACCESS before mapped=%d free_pages=%d\n",
+         before_query.present, (int)before_layout.free_pages);
+
+  if(op == VAACCESS_READ){
+    volatile unsigned char value = *(volatile unsigned char *)va;
+    printf("VAACCESS value=");
+    print_byte(value);
+    printf("\n");
+  } else {
+    *(volatile unsigned char *)va = (unsigned char)byte_value;
+    volatile unsigned char readback = *(volatile unsigned char *)va;
+    printf("VAACCESS readback=");
+    print_byte(readback);
+    printf("\n");
+  }
+
+  if(snapshot_user(&after_layout) < 0 || vaquery(va, &after_query) < 0)
+    return -1;
+  printf("VAACCESS after mapped=%d free_pages=%d\n",
+         after_query.present, (int)after_layout.free_pages);
+  return 0;
+}
+
+int
+vaaccess_probe_main(int argc, char **argv)
+{
+  char line[128];
+  char *parts[4];
+  int reserved_pages = 0;
+  uint64 heap_base = 0;
+
+  (void)argv;
+  if(argc != 1){
+    fprintf(2, "usage: vaprobe\n");
+    return 2;
+  }
+
+  for(;;){
+    printf("va> ");
+    gets(line, sizeof(line));
+    trim_newline(line);
+    int n = split_line(line, parts, 4);
+    if(n == 0)
+      continue;
+    if(streq(parts[0], "quit"))
+      break;
+    if(streq(parts[0], "help")){
+      printf("commands: help snapshot pte reserve shrink read write cow quit\n");
+    } else if(streq(parts[0], "snapshot")){
+      static struct memviz_snapshot snap;
+      if(snapshot_user(&snap) == 0)
+        printf("VAACCESS snapshot sz=%p stack=[%p,%p) guard=%p free_pages=%d\n",
+               snap.process_size, snap.stack_bottom, snap.stack_top,
+               snap.stack_guard_start, (int)snap.free_pages);
+      else
+        printf("VAACCESS error snapshot\n");
+    } else if(streq(parts[0], "reserve") && n == 2){
+      uint64 pages;
+      char *base;
+      if(vaaccess_parse_u64(parts[1], &pages) == 0 && pages <= 16 &&
+         (base = sbrk((int)pages * PGSIZE)) != (char *)-1){
+        if(reserved_pages == 0)
+          heap_base = (uint64)base;
+        reserved_pages += (int)pages;
+        printf("VAACCESS reserved_pages=%d\n", reserved_pages);
+      } else {
+        printf("VAACCESS error reserve\n");
+      }
+    } else if(streq(parts[0], "shrink") && n == 2){
+      uint64 pages;
+      if(vaaccess_parse_u64(parts[1], &pages) == 0 && pages <= (uint64)reserved_pages &&
+         sbrk(-((int)pages * PGSIZE)) != (char *)-1){
+        reserved_pages -= (int)pages;
+        if(reserved_pages == 0)
+          heap_base = 0;
+        printf("VAACCESS reserved_pages=%d\n", reserved_pages);
+      } else {
+        printf("VAACCESS error shrink\n");
+      }
+    } else if(streq(parts[0], "pte") && n == 2){
+      static struct memviz_snapshot snap;
+      struct memviz_va_query query;
+      uint64 va;
+      if(snapshot_user(&snap) == 0 &&
+         resolve_probe_address(parts[1], &snap, heap_base, &va) == 0 &&
+         vaquery(va, &query) == 0)
+        print_query("pte", va, &query);
+      else
+        printf("VAACCESS error pte\n");
+    } else if(streq(parts[0], "read") && n == 2){
+      if(probe_access(VAACCESS_READ, parts[1], 0, heap_base) < 0)
+        printf("VAACCESS error read\n");
+    } else if(streq(parts[0], "write") && n == 3){
+      uint64 byte_value;
+      if(parse_byte(parts[2], &byte_value) == 0 &&
+         probe_access(VAACCESS_WRITE, parts[1], byte_value, heap_base) == 0){
+      } else {
+        printf("VAACCESS error write\n");
+      }
+    } else if(streq(parts[0], "cow") && n == 2){
+      char *args[] = {"vaprobe-cow", "--cow", parts[1], "--snapshot", 0};
+      struct vaaccess_options opts;
+      opts.op = VAACCESS_WRITE;
+      if(parse_common_options(4, args, &opts) == 0)
+        run_cow(&opts);
+      else
+        printf("VAACCESS error cow\n");
+    } else {
+      printf("VAACCESS error unknown-command\n");
+    }
+  }
+
+  return 0;
+}

--- a/user/vaaccesslib.h
+++ b/user/vaaccesslib.h
@@ -1,0 +1,57 @@
+#ifndef XV6_USER_VAACCESSLIB_H
+#define XV6_USER_VAACCESSLIB_H
+
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/memviz.h"
+
+// 用户态 VA 探针支持的访问操作。
+enum vaaccess_op {
+  VAACCESS_READ = 1,
+  VAACCESS_WRITE = 2,
+};
+
+// 用户态 VA 探针支持的实验模式。
+enum vaaccess_mode {
+  VAACCESS_MODE_DIRECT = 1,
+  VAACCESS_MODE_LAZY = 2,
+  VAACCESS_MODE_COW = 3,
+};
+
+/**
+ * varead 命令入口的共享实现。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组；支持普通地址、--lazy、--expect 和 --snapshot。
+ * @return 进程退出状态；0 表示实际结果符合预期。
+ */
+int vaaccess_read_main(int argc, char **argv);
+
+/**
+ * vawrite 命令入口的共享实现。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组；支持普通地址、--lazy、--cow、--expect 和 --snapshot。
+ * @return 进程退出状态；0 表示实际结果符合预期。
+ */
+int vaaccess_write_main(int argc, char **argv);
+
+/**
+ * vaprobe 交互入口的共享实现。
+ *
+ * @param argc 命令行参数数量；首版不接受额外参数。
+ * @param argv 参数数组，仅用于保持 main 签名一致。
+ * @return 交互会话正常 quit 时返回 0，参数错误返回 2。
+ */
+int vaaccess_probe_main(int argc, char **argv);
+
+/**
+ * vaaccess_parse_u64 解析非负十进制或 0x 十六进制整数。
+ *
+ * @param text 输入字符串，必须完整表示一个非负整数。
+ * @param value 接收解析结果，不可为空。
+ * @return 成功返回 0；空串、负数、非法字符或 uint64 溢出返回 -1。
+ */
+int vaaccess_parse_u64(char *text, uint64 *value);
+
+#endif

--- a/user/vaprobe.c
+++ b/user/vaprobe.c
@@ -1,0 +1,16 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "user/vaaccesslib.h"
+
+/**
+ * vaprobe 在同一进程中交互执行 snapshot、reserve、read、write 和 COW 实验。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组，首版不接受额外参数。
+ * @return 通过 exit() 返回共享入口的状态码。
+ */
+int
+main(int argc, char **argv)
+{
+  exit(vaaccess_probe_main(argc, argv));
+}

--- a/user/varead.c
+++ b/user/varead.c
@@ -1,0 +1,16 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "user/vaaccesslib.h"
+
+/**
+ * varead 从用户态读取一个字节，真实访问由 worker 执行。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组，详见 vaaccess_read_main()。
+ * @return 通过 exit() 返回共享入口的状态码。
+ */
+int
+main(int argc, char **argv)
+{
+  exit(vaaccess_read_main(argc, argv));
+}

--- a/user/vawrite.c
+++ b/user/vawrite.c
@@ -1,0 +1,16 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "user/vaaccesslib.h"
+
+/**
+ * vawrite 从用户态写入一个字节，真实访问由 worker 执行。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组，详见 vaaccess_write_main()。
+ * @return 通过 exit() 返回共享入口的状态码。
+ */
+int
+main(int argc, char **argv)
+{
+  exit(vaaccess_write_main(argc, argv));
+}


### PR DESCRIPTION
## 中心认知与范围

本 PR 回答一个窄问题：用户态一条 load/store 访问指定 VA 时，什么时候直接命中已有映射，什么时候触发 lazy allocation 或 COW，什么时候因为地址范围或权限非法而被内核终止。

实现链路保持为真实 U-mode 访问：

```text
用户指定 VA
→ worker 进程执行 volatile load/store
→ Sv39 地址翻译命中 leaf PTE 或触发 page fault
→ usertrap 中的 lazy / COW / mmap / reject 路径
→ 指令重试成功或 worker 被杀死
→ supervisor / vaprobe 输出 memviz/vaquery 对比
```

本 PR 不新增 `sys_readva` / `sys_writeva`，也不让内核代替用户态读取目标地址。

## 堆叠依赖

- Stacked on PR #62: https://github.com/mental1104/xv6/pull/62
- Base branch: `concept/61-memory-visualization`
- Head branch: `concept/82-va-access-probe`
- 基线 Commit: `origin/concept/61-memory-visualization@30c52e9`
- 本 PR Commit: `795a391`
- 关联 Issue: Closes #82

PR #62 合并后，再执行：

```bash
git fetch origin
git rebase origin/main
```

随后把本 Draft PR 的 base 从 `concept/61-memory-visualization` 改为 `main`，并重新完成构建和回归。

## 实现了什么

- 新增三个用户态入口：
  - `varead <address> [--expect ok|fault] [--snapshot]`
  - `vawrite <address> <byte> [--expect ok|fault] [--snapshot]`
  - `vaprobe`
- `varead/vawrite` 使用 supervisor/worker 结构：
  - supervisor 只负责 fork/exec worker、wait 和结果归一化；
  - worker 执行真实 `volatile unsigned char` load/store；
  - fault 只杀 worker，supervisor 继续输出 `VAACCESS result=fault`。
- worker 采用隐藏 `--worker` exec 模式，避免 fork 后 COW 数据页被 snapshot/copyout 污染普通命中的 free page 观察。
- 新增共享用户态实现 `user/vaaccesslib.c` / `user/vaaccesslib.h`，统一地址表达式解析、snapshot/query 输出、lazy、COW 和 vaprobe 逻辑。
- 支持地址表达式：
  - 绝对十六进制 / 十进制地址；
  - `image+N`、`guard+N`、`stack-N`、`heap+N`、`brk+N`、`limit-N`。
- 支持 lazy 模式：
  - `varead --lazy <page-offset> [--snapshot]`
  - `vawrite --lazy <page-offset> <byte> [--snapshot]`
  - 输出 reserve 页数、目标页、before/after mapped 和 free pages。
- 支持 COW 模式：
  - `vawrite --cow <byte> [--snapshot]`
  - 验证写前 parent/child 同 PA 且 COW、写后 child 私有 PA、child readback 成功、parent 值保持旧值、child 退出后页面回收。
- 新增窄只读 syscall `vaquery(va, out)`：
  - 只查询当前进程用户页表中一个 VA 的 L2/L1/L0、leaf PTE、flags、PA、kalloc cell；
  - 不读取目标 VA 内容；
  - 不触发 lazy allocation 或 COW；
  - 不提供任意内核地址读写能力。

## CLI 使用方式

```text
varead image+0 --expect ok --snapshot
varead guard+0 --expect fault --snapshot
vawrite guard+0 0x41 --expect fault
varead --lazy 0 --snapshot
vawrite --lazy 2 0x41 --snapshot
vawrite --cow 0x42 --snapshot
vaprobe
xv6test --run lab3-vaaccess
echo shell-alive
```

`vaprobe` 支持最小交互命令：

```text
help
snapshot
pte <address>
reserve <pages>
shrink <pages>
read <address>
write <address> <byte>
cow <byte>
quit
```

## lazy allocation 观察

手动验收中：

```text
varead --lazy 0 --snapshot
```

关键现象：

```text
VAACCESS mode=lazy
VAACCESS reserved_pages=1
VAACCESS target_page=0
VAACCESS before mapped=0 free_pages=32404
VAACCESS value=0x00
VAACCESS after mapped=1 free_pages=32403
VAACCESS result=ok
VAACCESS done status=0
```

`vawrite --lazy 2 0x41 --snapshot` 同样显示 target page 在访问前 unmapped，写入后 mapped，且 readback 为 `0x41`。

## COW 观察

手动验收中：

```text
vawrite --cow 0x42 --snapshot
```

关键现象：

```text
VAACCESS mode=cow
VAACCESS parent-cow ... pa=0x0000000087EB4000 ... flags=VR-XUC
VAACCESS child before_pa=0x0000000087EB4000 after_pa=0x0000000087ED3000 before_flags=VR-XUC after_flags=VRWXU-
VAACCESS readback=0x42
VAACCESS parent_value=0x31
VAACCESS result=ok
VAACCESS done status=0
```

这说明写前 parent/child 共享同一 PA，child store fault 后获得私有 PA，COW 标记消失并恢复 writable，parent 内容保持旧值。

## 被内核拒绝的场景

手动验收覆盖：

```text
varead guard+0 --expect fault --snapshot
vawrite guard+0 0x41 --expect fault
varead brk+4096 --expect fault
vawrite 0x000000000C000000 0x41 --expect fault
echo shell-alive
```

关键现象：

```text
VAACCESS result=fault
VAACCESS worker_status=-1
VAACCESS done status=0
shell-alive
```

非法访问只杀 worker，supervisor 和外层 shell 继续运行。

## 添加/修改了什么单元测试

新增 `tests/guest/vaaccesstest.c`，注册为：

```text
xv6test --run lab3-vaaccess
xv6test --group lab3
```

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `test_mapped_access` | 已映射 ELF 页 read/write | `VAACCESS result=ok`、`VAACCESS readback=0x41` 验证普通命中成功 |
| `test_lazy_access` | lazy read/write 首次触页 | `before mapped=0`、`after mapped=1`、read 零、write readback，并比较命令前后 free pages 不泄漏 |
| `test_cow_access` | COW child write | 输出包含 child before/after PA、parent value；测试前后 free pages 相等 |
| `test_faults` | guard、brk 以上未保留地址、PLIC/MMIO | `VAACCESS result=fault` 且后续 `echo shell-alive` 成功 |
| `test_parsing_and_expect` | 十进制/十六进制、非法字符串、溢出、expect mismatch | 成功路径 status 0，解析错误 status 2，expect mismatch status 1 |
| `test_va_zero_follows_real_pagetable` | VA 0 教学反例 | 先 `vaquery(0)`，再按真实 PTE present 状态决定 expect ok/fault，不写死 NULL page 假设 |

`tests/README.md` 和 `tests/test_runner.py` 同步加入 `vaaccesstest.c` 的 Lab3 映射与仓库布局检查。

## 单元自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `git fetch origin` | 通过 | 记录 `origin/main=53858c2557492e6bc923afccae34030072ea531f`、`origin/concept/61-memory-visualization=30c52e9af2ef52a1cc9408ef32bf91d76c1fb2ed` |
| `make clean` | 通过 | 清理构建产物和生成的 `user/xargstest.sh` |
| `make` | 通过 | clean 后内核完整重建成功 |
| `make fs.img` | 通过 | 新增 `varead/vawrite/vaprobe/vaaccesstest` 均编译进镜像 |
| `make test-unit PYTHON=/tmp/xv6-vaaccess-venv/bin/python` | 通过 | `Ran 21 tests ... OK` |
| `make test-suite SUITE=lab-vm CPUS=3 PYTHON=/tmp/xv6-vaaccess-venv/bin/python` | 通过 | Lab3/Lab4/Lab5/Lab6 guest suites 全部 PASS |
| `make test-suite SUITE=lab-vm CPUS=1 PYTHON=/tmp/xv6-vaaccess-venv/bin/python` | 通过 | Lab3/Lab4/Lab5/Lab6 guest suites 全部 PASS |
| unsupported xv6 printf 格式扫描 | 通过 | `rg "%[-0-9]|%u|%lu|%ld" ...` 无命中 |
| `git diff --check` | 通过 | 无空白错误 |

环境说明：系统 Python 缺少 `pexpect`，`pip --user` 被 PEP 668 拒绝，`sudo apt-get` 需要交互密码；本次在 `/tmp/xv6-vaaccess-venv` 中安装 `pexpect` 后用 `PYTHON=/tmp/xv6-vaaccess-venv/bin/python` 执行测试。QEMU 在 sandbox 内无法写 `/var/tmp` 临时文件，因此 QEMU 类验证使用普通系统权限运行。

## review 主线

1. `user/vaaccesslib.c`
   - 先确认真正访问目标 VA 的路径只在 worker/vaprobe 中使用 `volatile` load/store；supervisor 只做 fork/exec/wait 和结果归一化。
2. `kernel/memviz.h`、`kernel/memviz.c`、`kernel/sysmemviz.c`
   - 检查 `vaquery` 是否只是单 VA 页表元数据查询，不读取目标 VA、不触发 lazy/COW、不扩大到任意内核读写。
3. `user/varead.c`、`user/vawrite.c`、`user/vaprobe.c`
   - 确认 CLI 入口、隐藏 `--worker`、lazy reserve/first touch、COW 专用流程和 vaprobe 会话 heap 语义。
4. `Makefile`、`user/user.h`、`user/usys.pl`、`kernel/syscall.*`
   - 确认新增命令、系统调用编号和用户态 stub 的接线范围。
5. `tests/guest/vaaccesstest.c`、`tests/guest/xv6test.c`
   - 对照 Lab3 注册和 guest-first 断言，确认普通命中、lazy、COW、fault、解析、资源回收、VA 0 反例都由 guest 退出状态保护。
6. `tests/README.md`、`tests/test_runner.py`
   - 确认测试目录契约和 Lab3 coverage map 同步。

## 教学边界

- `vaquery` 是观察接口，不是地址访问接口；它不会触发 page fault handler。
- `varead/vawrite --snapshot` 的 before/after 属于 worker 自己的地址空间，不复用 shell 或另一个命令的 memviz 输出。
- `vaprobe` 的直接 read/write 会在同一进程中执行；访问 guard 或非法地址会杀死整个 `vaprobe`，这是保留真实 fault 语义的结果。
- `heap+N` 在普通 CLI 中会为该次实验 reserve 足够空间；在 `vaprobe` 中绑定到本会话 `reserve` 记录的 heap 起点。
- VA 0 不被假定为 NULL page；测试通过 `vaquery(0)` 依据当前 xv6 真实页表决定预期。