### PR TITLE
feat: 为 xv6 Shell 增加会话历史与方向键召回

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ $U/_%: $T/%.o $(ULIB)
 	$(OBJDUMP) -S $@ > $T/$*.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/$*.sym
 
-$U/_sh: $U/shentry.o $U/sh.o $U/memvizlib.o $(ULIB)
+$U/_sh: $U/shentry.o $U/sh.o $U/history.o $U/shellinput.o $U/memvizlib.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e sh_entry -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $U/sh.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/sh.sym
@@ -146,6 +146,11 @@ $U/_vaaccesstest: $T/vaaccesstest.o $T/testlib.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $@ > $T/vaaccesstest.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/vaaccesstest.sym
+
+$U/_historytest: $T/historytest.o $U/history.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $T/historytest.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/historytest.sym
 
 $U/usys.S: $U/usys.pl
 	perl $U/usys.pl > $U/usys.S
@@ -227,6 +232,8 @@ UPROGS=\
 	$U/_lab1test\
 	$U/_tracesmoke\
 	$U/_uthreadtest\
+	$U/_historytest\
+	$U/_consolelinetest\
 	$U/_xv6test
 
 UEXTRA = $U/xargstest.sh
@@ -291,6 +298,7 @@ test-grader: test-unit
 # Integration/system tests: boot a fresh QEMU snapshot for every atomic suite
 # and validate xv6 through its user-visible behavior.
 test-integration: $K/kernel fs.img
+	$(PYTHON) tests/shell_history_interactive.py --cpus $(CPUS)
 	$(PYTHON) tests/run.py --suite pr --cpus $(CPUS)
 
 test-labs: test-integration

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -1,12 +1,8 @@
 //
 // Console input and output, to the uart.
-// Reads are line at a time.
-// Implements special input characters:
-//   newline -- end of line
-//   control-h -- backspace
-//   control-u -- kill line
-//   control-d -- end of file
-//   control-p -- print process list
+// Cooked mode reads a line at a time and implements the historical xv6 editing
+// controls. Raw mode is a small teaching interface used only by the interactive
+// shell so user space can receive every input byte and own line editing.
 //
 
 #include <stdarg.h>
@@ -21,6 +17,7 @@
 #include "riscv.h"
 #include "defs.h"
 #include "proc.h"
+#include "console.h"
 
 #define BACKSPACE 0x100
 #define C(x)  ((x)-'@')  // Control-x
@@ -41,16 +38,147 @@ consputc(int c)
   }
 }
 
+/**
+ * 保存 console 输入环形缓冲区及当前最小行规约状态。
+ *
+ * raw_owner 和 raw_file 共同标识唯一允许读取、重复设置和释放 raw mode 的 Shell。
+ * 所有字段均受 cons.lock 保护；raw mode 只改变输入提交与读取语义，不改变输出路径。
+ */
 struct {
   struct spinlock lock;
-  
+
   // input
 #define INPUT_BUF 128
   char buf[INPUT_BUF];
   uint r;  // Read index
   uint w;  // Write index
   uint e;  // Edit index
+  int raw;
+  int raw_owner;
+  struct file *raw_file;
 } cons;
+
+/**
+ * 返回当前进程指定 fd 对应的可读 console 文件对象。
+ *
+ * @param p 当前进程，函数只读取其打开文件表。
+ * @param fd 待校验的文件描述符编号。
+ * @return 校验通过时返回内部 file 指针；非 console、不可读或无效 fd 返回 0。
+ */
+static struct file*
+console_file(struct proc *p, int fd)
+{
+  struct file *file;
+
+  if(fd < 0 || fd >= NOFILE || (file = p->ofile[fd]) == 0)
+    return 0;
+  if(file->type != FD_DEVICE || file->major != CONSOLE || !file->readable)
+    return 0;
+  return file;
+}
+
+/**
+ * 在持有 cons.lock 时恢复 cooked mode 并清空未消费的 raw 字节。
+ *
+ * 调用者必须已经验证 owner，并持有 cons.lock。函数只修改内存和执行 wakeup，
+ * 不进行可能睡眠的文件系统或设备操作。
+ */
+static void
+clear_raw_locked(void)
+{
+  cons.raw = 0;
+  cons.raw_owner = 0;
+  cons.raw_file = 0;
+  // raw 字节没有 cooked 行边界，恢复时统一丢弃，避免污染下一次逐行读取。
+  cons.r = cons.w = cons.e;
+  wakeup(&cons.r);
+}
+
+/**
+ * 在持有 cons.lock 时切换 console 输入模式。
+ *
+ * @param p 发起切换的 Shell 进程。
+ * @param file 本次系统调用校验后的可读 console 文件对象。
+ * @param mode CONSOLE_MODE_COOKED 或 CONSOLE_MODE_RAW。
+ * @return 成功返回 0；owner、文件对象、输入边界或 mode 不满足约束时返回 -1。
+ *
+ * raw claim 只允许从空缓冲区开始，避免把内核已编辑或已提交的一部分 cooked 行
+ * 交给用户态解释。重复设置只有同一 PID 和同一 file 对象可以成功；非 owner 不能
+ * 释放活跃 raw mode。owner 异常退出时由 fileclose() 调用 consolefileclose() 回收。
+ */
+static int
+set_console_mode(struct proc *p, struct file *file, int mode)
+{
+  int result = 0;
+
+  acquire(&cons.lock);
+  if(mode == CONSOLE_MODE_RAW){
+    if(cons.raw){
+      if(cons.raw_owner != p->pid || cons.raw_file != file)
+        result = -1;
+    } else if(cons.r != cons.w || cons.w != cons.e){
+      result = -1;
+    } else {
+      cons.raw = 1;
+      cons.raw_owner = p->pid;
+      cons.raw_file = file;
+    }
+  } else if(mode == CONSOLE_MODE_COOKED){
+    if(cons.raw){
+      if(cons.raw_owner != p->pid || cons.raw_file != file)
+        result = -1;
+      else
+        clear_raw_locked();
+    }
+  } else {
+    result = -1;
+  }
+  release(&cons.lock);
+  return result;
+}
+
+/**
+ * 在 owner 关闭其 console 文件对象时回收 raw mode。
+ *
+ * @param file 正在由 fileclose() 释放引用的文件对象。
+ * @param pid 执行关闭操作的当前进程 PID。
+ *
+ * fileclose() 在进程正常 exit、kill 后退出及用户 trap 异常退出时都会经过此路径。
+ * 非 owner、不同 file 或 cooked mode 均为无操作。该函数不持有 ftable.lock，也不睡眠。
+ */
+void
+consolefileclose(struct file *file, int pid)
+{
+  acquire(&cons.lock);
+  if(cons.raw && cons.raw_owner == pid && cons.raw_file == file)
+    clear_raw_locked();
+  release(&cons.lock);
+}
+
+/**
+ * consolemode 为交互式 xv6 Shell 切换最小 raw/cooked 输入语义。
+ *
+ * 系统调用参数为 `(fd, mode)`。fd 必须是当前进程打开的可读 console；pipe、普通
+ * 文件或其他设备会失败。首版用进程名 `sh` 限制模式所有者，这是 xv6 单 console
+ * 教学约束，不等价于 POSIX controlling terminal、session 或前台进程组。
+ *
+ * @return 成功返回 0；参数、fd、调用者或所有权不满足约束时返回 -1。
+ */
+uint64
+sys_consolemode(void)
+{
+  struct proc *p = myproc();
+  struct file *file;
+  int fd;
+  int mode;
+
+  if(argint(0, &fd) < 0 || argint(1, &mode) < 0)
+    return -1;
+  if((file = console_file(p, fd)) == 0 ||
+     strncmp(p->name, "sh", sizeof(p->name)) != 0)
+    return -1;
+  return set_console_mode(p, file, mode);
+}
 
 //
 // user write()s to the console go here.
@@ -72,26 +200,40 @@ consolewrite(int user_src, uint64 src, int n)
   return i;
 }
 
-//
-// user read()s from the console go here.
-// copy (up to) a whole input line to dst.
-// user_dist indicates whether dst is a user
-// or kernel address.
-//
+/**
+ * 从 console 读取 cooked 行或 raw 字节。
+ *
+ * @param user_dst 非零表示 dst 是用户地址，零表示内核地址。
+ * @param dst 输出地址。
+ * @param n 最大读取字节数。
+ * @return 已复制字节数；进程被杀死、copyout 失败或 raw mode 非 owner 读取返回 -1。
+ *
+ * cooked mode 保留原 xv6 Ctrl-D 和换行返回语义。raw mode 只允许 owner 读取，并
+ * 立即返回当前可用字节；Shell 每次请求一个字节，从而在用户态维护 Escape 状态机。
+ */
 int
 consoleread(int user_dst, uint64 dst, int n)
 {
   uint target;
   int c;
   char cbuf;
+  int pid = myproc()->pid;
 
   target = n;
   acquire(&cons.lock);
+  if(cons.raw && cons.raw_owner != pid){
+    release(&cons.lock);
+    return -1;
+  }
+
   while(n > 0){
-    // wait until interrupt handler has put some
-    // input into cons.buffer.
+    // wait until interrupt handler has put some input into cons.buffer.
     while(cons.r == cons.w){
       if(myproc()->killed){
+        release(&cons.lock);
+        return -1;
+      }
+      if(cons.raw && cons.raw_owner != pid){
         release(&cons.lock);
         return -1;
       }
@@ -100,7 +242,7 @@ consoleread(int user_dst, uint64 dst, int n)
 
     c = cons.buf[cons.r++ % INPUT_BUF];
 
-    if(c == C('D')){  // end-of-file
+    if(!cons.raw && c == C('D')){  // end-of-file
       if(n < target){
         // Save ^D for next time, to make sure
         // caller gets a 0-byte result.
@@ -111,15 +253,20 @@ consoleread(int user_dst, uint64 dst, int n)
 
     // copy the input byte to the user-space buffer.
     cbuf = c;
-    if(either_copyout(user_dst, dst, &cbuf, 1) == -1)
-      break;
+    if(either_copyout(user_dst, dst, &cbuf, 1) == -1){
+      release(&cons.lock);
+      return -1;
+    }
 
     dst++;
     --n;
 
-    if(c == '\n'){
-      // a whole line has arrived, return to
-      // the user-level read().
+    if(cons.raw){
+      // raw caller通常只请求一个字节；若请求更多，则一次返回当前已到达的连续字节。
+      if(cons.r == cons.w)
+        break;
+    } else if(c == '\n'){
+      // a whole line has arrived, return to the user-level read().
       break;
     }
   }
@@ -128,21 +275,37 @@ consoleread(int user_dst, uint64 dst, int n)
   return target - n;
 }
 
-//
-// the console input interrupt handler.
-// uartintr() calls this for input character.
-// do erase/kill processing, append to cons.buf,
-// wake up consoleread() if a whole line has arrived.
-//
+/**
+ * 接收 UART 输入并按当前模式提交到 console 环形缓冲区。
+ *
+ * @param c UART 提供的输入字节。
+ *
+ * Ctrl-P 始终保留为内核 procdump 控制键。raw mode 不回显、不转换 CR，也不解释
+ * Backspace、Ctrl-U 或 Ctrl-D，并在每个字节到达时唤醒 owner。cooked mode 保持
+ * 原 xv6 的逐行提交与内核编辑行为。
+ */
 void
 consoleintr(int c)
 {
   acquire(&cons.lock);
 
-  switch(c){
-  case C('P'):  // Print process list.
+  if(c == C('P')){
     procdump();
-    break;
+    release(&cons.lock);
+    return;
+  }
+
+  if(cons.raw){
+    if(c != 0 && cons.e-cons.r < INPUT_BUF){
+      cons.buf[cons.e++ % INPUT_BUF] = c;
+      cons.w = cons.e;
+      wakeup(&cons.r);
+    }
+    release(&cons.lock);
+    return;
+  }
+
+  switch(c){
   case C('U'):  // Kill line.
     while(cons.e != cons.w &&
           cons.buf[(cons.e-1) % INPUT_BUF] != '\n'){
@@ -176,7 +339,7 @@ consoleintr(int c)
     }
     break;
   }
-  
+
   release(&cons.lock);
 }
 

--- a/kernel/console.h
+++ b/kernel/console.h
@@ -1,0 +1,9 @@
+#ifndef XV6_CONSOLE_H
+#define XV6_CONSOLE_H
+
+/** 保持现有逐行读取、内核回显和行编辑语义。 */
+#define CONSOLE_MODE_COOKED 0
+/** 将 console 输入逐字节交给当前交互式 Shell，由用户态负责回显和编辑。 */
+#define CONSOLE_MODE_RAW 1
+
+#endif

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -25,6 +25,7 @@ void            bunpin(struct buf*);
 void            consoleinit(void);
 void            consoleintr(int);
 void            consputc(int);
+void            consolefileclose(struct file*, int);
 
 // exec.c
 int             exec(char*, char**);

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -61,6 +61,11 @@ fileclose(struct file *f)
 {
   struct file ff;
 
+  // raw console ownership belongs to the current PID plus this file object.
+  // Run the non-sleeping cleanup before ftable may invalidate the final reference.
+  if(f->type == FD_DEVICE && f->major == CONSOLE)
+    consolefileclose(f, myproc()->pid);
+
   acquire(&ftable.lock);
   if(f->ref < 1)
     panic("fileclose");
@@ -179,4 +184,3 @@ filewrite(struct file *f, uint64 addr, int n)
 
   return ret;
 }
-

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -116,6 +116,7 @@ extern uint64 sys_backtrace(void);
 extern uint64 sys_memsnapshot(void);
 extern uint64 sys_vaquery(void);
 extern uint64 sys_waitpid(void);
+extern uint64 sys_consolemode(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -150,6 +151,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_memsnapshot] sys_memsnapshot,
 [SYS_vaquery] sys_vaquery,
 [SYS_waitpid] sys_waitpid,
+[SYS_consolemode] sys_consolemode,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -31,3 +31,4 @@
 #define SYS_memsnapshot 30
 #define SYS_vaquery    31
 #define SYS_waitpid    32
+#define SYS_consolemode 33

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -37,6 +37,7 @@ static const char *const syscall_names[] = {
 [SYS_memsnapshot] = "memsnapshot",
 [SYS_vaquery]    = "vaquery",
 [SYS_waitpid]    = "waitpid",
+[SYS_consolemode] = "consolemode",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/tests/guest/consolelinetest.c
+++ b/tests/guest/consolelinetest.c
@@ -1,0 +1,27 @@
+#include "kernel/types.h"
+#include "user/user.h"
+
+/**
+ * 验证外部用户程序启动后 console 已恢复 cooked 行规约。
+ *
+ * 程序先输出 ready，宿主机再输入 `ab<Backspace>c<Enter>`；内核应完成退格编辑
+ * 后一次返回 `ac\n`。握手避免测试输入仍停留在父 Shell 的 raw 缓冲区。
+ *
+ * @return 通过 exit status 返回；成功为 0，读取错误或行规约不符为 1。
+ */
+int
+main(void)
+{
+  char buffer[8] = {0};
+  int count;
+
+  printf("consolelinetest: ready\n");
+  count = read(0, buffer, sizeof(buffer));
+  if(count != 3 || buffer[0] != 'a' || buffer[1] != 'c' || buffer[2] != '\n'){
+    printf("consolelinetest: count=%d bytes=%d,%d,%d\n",
+           count, buffer[0], buffer[1], buffer[2]);
+    exit(1);
+  }
+  printf("consolelinetest: OK\n");
+  exit(0);
+}

--- a/tests/guest/historytest.c
+++ b/tests/guest/historytest.c
@@ -1,0 +1,119 @@
+#include "kernel/types.h"
+#include "user/history.h"
+#include "user/user.h"
+
+/**
+ * 在断言失败时打印稳定诊断并终止测试。
+ *
+ * @param condition 非零表示断言成立。
+ * @param message 失败时输出的场景说明。
+ */
+static void
+check(int condition, char *message)
+{
+  if(condition)
+    return;
+  printf("historytest: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 生成 cmdNN 形式的固定测试命令。
+ *
+ * @param value 1 到 99 之间的编号。
+ * @param command 输出缓冲区，至少需要 6 字节。
+ */
+static void
+make_command(int value, char *command)
+{
+  command[0] = 'c';
+  command[1] = 'm';
+  command[2] = 'd';
+  command[3] = '0' + value / 10;
+  command[4] = '0' + value % 10;
+  command[5] = 0;
+}
+
+/**
+ * 验证过滤、连续去重、环形覆盖和单调编号。
+ */
+static void
+test_history_ring(void)
+{
+  struct shell_history history;
+  const struct shell_history_entry *entry;
+  char command[6];
+
+  shell_history_init(&history);
+  check(shell_history_add(&history, "   \t\n") == 0, "blank command recorded");
+  check(shell_history_add(&history, "echo one\n") == 1, "first command rejected");
+  check(shell_history_count(&history) == 1, "first command count");
+  entry = shell_history_at(&history, 0);
+  check(entry != 0 && entry->number == 1, "first command number");
+  check(strcmp(entry->command, "echo one") == 0, "line ending not trimmed");
+  check(shell_history_add(&history, "echo one") == 0, "consecutive duplicate recorded");
+  check(shell_history_add(&history, "echo two") == 1, "second command rejected");
+  check(shell_history_add(&history, "echo one") == 1, "non-consecutive duplicate rejected");
+
+  shell_history_init(&history);
+  for(int value = 1; value <= 33; value++){
+    make_command(value, command);
+    check(shell_history_add(&history, command) == 1, "ring insertion failed");
+  }
+  check(shell_history_count(&history) == SHELL_HISTORY_CAPACITY, "ring capacity");
+  entry = shell_history_at(&history, 0);
+  check(entry != 0 && entry->number == 2, "oldest number after overwrite");
+  check(strcmp(entry->command, "cmd02") == 0, "oldest command after overwrite");
+  entry = shell_history_at(&history, SHELL_HISTORY_CAPACITY - 1);
+  check(entry != 0 && entry->number == 33, "newest number after overwrite");
+  check(strcmp(entry->command, "cmd33") == 0, "newest command after overwrite");
+}
+
+/**
+ * 验证上下方向浏览边界以及越过最新项后的 draft 恢复。
+ */
+static void
+test_history_cursor(void)
+{
+  struct shell_history history;
+  struct shell_history_cursor cursor;
+  char replacement[SHELL_HISTORY_COMMAND_SIZE];
+
+  shell_history_init(&history);
+  shell_history_cursor_reset(&cursor);
+  check(shell_history_cursor_up(&history, &cursor, "draft",
+                                replacement, sizeof(replacement)) == 0,
+        "empty history moved cursor");
+  shell_history_add(&history, "one");
+  shell_history_add(&history, "two");
+
+  check(shell_history_cursor_up(&history, &cursor, "draft",
+                                replacement, sizeof(replacement)) == 1,
+        "first up failed");
+  check(strcmp(replacement, "two") == 0, "first up not newest");
+  shell_history_cursor_up(&history, &cursor, replacement,
+                          replacement, sizeof(replacement));
+  check(strcmp(replacement, "one") == 0, "second up not oldest");
+  shell_history_cursor_up(&history, &cursor, replacement,
+                          replacement, sizeof(replacement));
+  check(strcmp(replacement, "one") == 0, "up crossed oldest boundary");
+  shell_history_cursor_down(&history, &cursor, replacement, sizeof(replacement));
+  check(strcmp(replacement, "two") == 0, "down not newer");
+  shell_history_cursor_down(&history, &cursor, replacement, sizeof(replacement));
+  check(strcmp(replacement, "draft") == 0, "down did not restore draft");
+  check(cursor.active == 0, "cursor stayed active after draft restore");
+}
+
+/**
+ * 执行全部纯历史逻辑断言。
+ *
+ * @return 通过 exit status 返回；成功为 0，任一断言失败为 1。
+ */
+int
+main(void)
+{
+  test_history_ring();
+  test_history_cursor();
+  printf("historytest: OK\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -51,6 +51,7 @@ static char *core_sbrkbugs_argv[] = {"usertests", "sbrkbugs", 0};
 static char *core_forkforkfork_argv[] = {"usertests", "forkforkfork", 0};
 static char *core_linkunlink_argv[] = {"usertests", "linkunlink", 0};
 static char *core_openiput_argv[] = {"usertests", "openiput", 0};
+static char *core_history_argv[] = {"historytest", 0};
 
 static char *legacy_forktest_argv[] = {"forktest", 0};
 static char *legacy_stressfs_argv[] = {"stressfs", 0};
@@ -98,6 +99,7 @@ static struct xv6_test_case tests[] = {
   {"core", "core-forkforkfork", core_forkforkfork_argv},
   {"core", "core-linkunlink", core_linkunlink_argv},
   {"core", "core-openiput", core_openiput_argv},
+  {"core", "core-shell-history", core_history_argv},
 
   {"legacy", "legacy-forktest", legacy_forktest_argv},
   {"legacy", "legacy-stressfs", legacy_stressfs_argv},

--- a/tests/shell_history_interactive.py
+++ b/tests/shell_history_interactive.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""通过真实 QEMU 串口输入验证 xv6 Shell 行编辑与会话历史。"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import TextIO
+
+import pexpect
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULT_ROOT = REPO_ROOT / "test-results"
+TRANSCRIPT_PATH = RESULT_ROOT / "shell-history-interactive.log"
+PROMPT = "$ "
+
+
+class ShellHistoryFailure(RuntimeError):
+    """表示交互式 Shell 行为与验收契约不一致。"""
+
+
+def start_qemu(cpus: int, transcript: TextIO) -> pexpect.spawn:
+    """启动独立 snapshot QEMU 并等待首个 Shell 提示符。
+
+    Args:
+        cpus: QEMU 虚拟 CPU 数量，必须至少为 1。
+        transcript: 持续接收 QEMU 串口输出的文本文件。
+
+    Returns:
+        已进入 xv6 Shell 的 pexpect 子进程，调用者负责关闭。
+    """
+
+    command = f"make -s --no-print-directory qemu CPUS={cpus} QEMUEXTRA=-snapshot"
+    child = pexpect.spawn(
+        "/bin/bash",
+        ["-lc", command],
+        cwd=str(REPO_ROOT),
+        encoding="utf-8",
+        codec_errors="replace",
+        timeout=120,
+    )
+    child.logfile_read = transcript
+    child.expect_exact(PROMPT)
+    return child
+
+
+def stop_qemu(child: pexpect.spawn) -> None:
+    """通过 QEMU monitor 快捷键退出实例，失败时强制终止。
+
+    Args:
+        child: start_qemu() 返回的活动子进程。
+    """
+
+    if not child.isalive():
+        return
+    child.sendcontrol("a")
+    child.send("x")
+    try:
+        child.expect(pexpect.EOF, timeout=5)
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        child.terminate(force=True)
+
+
+def submit(child: pexpect.spawn, text: str, timeout: int = 30) -> str:
+    """向当前提示符提交一条命令并返回下一提示符前的原始输出。
+
+    Args:
+        child: 已处于 Shell 提示符的 QEMU 子进程。
+        text: 不含 Enter 的命令文本。
+        timeout: 等待下一提示符的秒数。
+
+    Returns:
+        从命令输入到下一提示符之间捕获的原始终端输出。
+    """
+
+    child.timeout = timeout
+    child.send(text)
+    child.send("\r")
+    child.expect_exact(PROMPT)
+    return child.before or ""
+
+
+def require(pattern: str, output: str, message: str) -> None:
+    """要求正则模式出现在输出中，否则抛出带上下文的失败。
+
+    Args:
+        pattern: 使用 MULTILINE 与 DOTALL 匹配的正则表达式。
+        output: 待检查的终端输出。
+        message: 失败时说明被破坏的行为。
+    """
+
+    if re.search(pattern, output, re.MULTILINE | re.DOTALL) is None:
+        raise ShellHistoryFailure(f"{message}; pattern={pattern!r}; output={output!r}")
+
+
+def run_checks(child: pexpect.spawn) -> None:
+    """执行历史、方向键、编辑边界及兼容性验收。
+
+    Args:
+        child: 已进入全新登录 Shell 的 QEMU 子进程。
+    """
+
+    output = submit(child, "echo first")
+    require(r"\bfirst\b", output, "首条普通命令未执行")
+
+    child.send("echo draft")
+    child.send("\x1b[A")
+    child.send("\x1b[B")
+    child.send("\r")
+    child.expect_exact(PROMPT)
+    require(r"\bdraft\b", child.before or "", "下键未恢复进入浏览前的 draft")
+
+    output = submit(child, "history")
+    require(r"1 echo first", output, "history 缺少第一条命令")
+    require(r"2 echo draft", output, "history 缺少 draft 命令")
+    require(r"3 history", output, "history 未包含自身")
+
+    child.send("echo 123456789")
+    child.send("\x1b[A")
+    child.send("\r")
+    child.expect_exact(PROMPT)
+    require(r"3 history", child.before or "", "长草稿替换为短历史项后执行内容错误")
+
+    child.send("echo ax")
+    child.send("\x7f")
+    child.send("b\r")
+    child.expect_exact(PROMPT)
+    require(r"\bab\b", child.before or "", "Backspace 未删除一个字符")
+
+    child.send("echo wrong")
+    child.sendcontrol("u")
+    child.send("echo cleared\r")
+    child.expect_exact(PROMPT)
+    require(r"\bcleared\b", child.before or "", "Ctrl-U 未清空整行")
+
+    child.send("echo esc")
+    child.send("\x1b[Z")
+    child.send("ape\r")
+    child.expect_exact(PROMPT)
+    require(r"\bescape\b", child.before or "", "未知 Escape 序列破坏后续输入")
+
+    child.send("x" * 120)
+    child.sendcontrol("u")
+    child.send("echo max-ok\r")
+    child.expect_exact(PROMPT)
+    require(r"\bmax-ok\b", child.before or "", "缓冲区满后 Ctrl-U 或 Enter 失效")
+
+    child.send("consolelinetest\r")
+    child.expect_exact("consolelinetest: ready")
+    child.send("ab\x7fc\r")
+    child.expect_exact("consolelinetest: OK")
+    child.expect_exact(PROMPT)
+
+    # PR #49 的 jobctl 用 pipe 驱动子 Shell，同时覆盖非 console stdin fallback。
+    output = submit(child, "usertests jobctl", timeout=120)
+    require(r"ALL TESTS PASSED", output, "PR #49 pipe-driven jobctl 回归失败")
+
+    child.send("echo ctrl-d")
+    child.sendcontrol("d")
+    child.expect_exact(PROMPT)
+    require(r"\bctrl-d\b", child.before or "", "非空行 Ctrl-D 未提交当前输入")
+
+    child.sendcontrol("p")
+    child.send("echo ctrlp-ok\r")
+    child.expect_exact(PROMPT)
+    require(r"\bsh\b.*\bctrlp-ok\b", child.before or "", "Ctrl-P 未保留或 Shell 未继续读取")
+
+    child.sendcontrol("d")
+    child.expect_exact("init: starting sh")
+    child.expect_exact(PROMPT)
+
+
+def parse_args() -> argparse.Namespace:
+    """解析 QEMU CPU 数量。"""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cpus", type=int, default=3, help="QEMU CPU count")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """运行全部交互检查，并通过进程退出状态报告结果。"""
+
+    args = parse_args()
+    if args.cpus < 1:
+        raise SystemExit("--cpus must be at least 1")
+
+    RESULT_ROOT.mkdir(parents=True, exist_ok=True)
+    with TRANSCRIPT_PATH.open("w", encoding="utf-8", errors="replace") as transcript:
+        child = start_qemu(args.cpus, transcript)
+        try:
+            run_checks(child)
+        except Exception as exc:
+            transcript.write(f"\nHOST FAILURE: {exc!r}\n")
+            transcript.flush()
+            raise
+        finally:
+            stop_qemu(child)
+    print(f"PASS shell-history-interactive ({TRANSCRIPT_PATH.relative_to(REPO_ROOT)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/user/history.c
+++ b/user/history.c
@@ -1,0 +1,231 @@
+#include "kernel/types.h"
+#include "user/history.h"
+#include "user/user.h"
+
+/**
+ * 判断字符是否属于 Shell 历史过滤使用的空白集合。
+ *
+ * @param c 待检查的单字节字符。
+ * @return 空格、制表、垂直制表或行尾字符返回 1，否则返回 0。
+ */
+static int
+history_space(char c)
+{
+  return c == ' ' || c == '\t' || c == '\v' || c == '\r' || c == '\n';
+}
+
+/**
+ * 将命令复制到固定容量缓冲区，并去除末尾 CR/LF。
+ *
+ * @param dst 输出缓冲区，必须至少提供 dst_size 个字节。
+ * @param dst_size 输出容量，必须大于 0。
+ * @param src 输入命令；超长部分会被截断以保证 NUL 结尾。
+ * @return 复制后命令长度，不包含结尾 NUL。
+ */
+static int
+history_copy_command(char *dst, int dst_size, const char *src)
+{
+  int length = 0;
+
+  while(src[length] != 0 && length + 1 < dst_size){
+    dst[length] = src[length];
+    length++;
+  }
+  while(length > 0 && (dst[length - 1] == '\r' || dst[length - 1] == '\n'))
+    length--;
+  dst[length] = 0;
+  return length;
+}
+
+/**
+ * 判断命令是否只包含历史规则认可的空白字符。
+ *
+ * @param command 已保证 NUL 结尾的命令文本。
+ * @return 空命令或纯空白命令返回 1，否则返回 0。
+ */
+static int
+history_blank(const char *command)
+{
+  for(; *command != 0; command++)
+    if(!history_space(*command))
+      return 0;
+  return 1;
+}
+
+/**
+ * 初始化一份空的会话历史。
+ *
+ * @param history 待初始化的历史对象，调用者持有其存储。
+ */
+void
+shell_history_init(struct shell_history *history)
+{
+  memset(history, 0, sizeof(*history));
+  history->next_number = 1;
+}
+
+/**
+ * 按从旧到新的逻辑下标读取历史记录。
+ *
+ * @param history 只读历史对象。
+ * @param index 逻辑下标，0 表示当前最旧记录。
+ * @return 下标有效时返回内部只读记录指针；越界时返回 0，所有权仍归 history。
+ */
+const struct shell_history_entry *
+shell_history_at(const struct shell_history *history, int index)
+{
+  if(index < 0 || index >= history->count)
+    return 0;
+  return &history->entries[(history->start + index) % SHELL_HISTORY_CAPACITY];
+}
+
+/**
+ * 返回当前有效历史记录数量。
+ *
+ * @param history 只读历史对象。
+ * @return 0 到 SHELL_HISTORY_CAPACITY 之间的记录数。
+ */
+int
+shell_history_count(const struct shell_history *history)
+{
+  return history->count;
+}
+
+/**
+ * 将一条有效命令追加到环形历史表。
+ *
+ * @param history 待修改的会话历史。
+ * @param command 原始命令；函数会去除末尾 CR/LF，并过滤空白与连续重复。
+ * @return 实际新增记录返回 1；被过滤或与上一条完全相同返回 0。
+ */
+int
+shell_history_add(struct shell_history *history, const char *command)
+{
+  char normalized[SHELL_HISTORY_COMMAND_SIZE];
+  const struct shell_history_entry *latest;
+  struct shell_history_entry *entry;
+  int index;
+
+  history_copy_command(normalized, sizeof(normalized), command);
+  if(history_blank(normalized))
+    return 0;
+
+  latest = shell_history_at(history, history->count - 1);
+  if(latest != 0 && strcmp(latest->command, normalized) == 0)
+    return 0;
+
+  if(history->count < SHELL_HISTORY_CAPACITY){
+    index = (history->start + history->count) % SHELL_HISTORY_CAPACITY;
+    history->count++;
+  } else {
+    index = history->start;
+    history->start = (history->start + 1) % SHELL_HISTORY_CAPACITY;
+  }
+
+  entry = &history->entries[index];
+  entry->number = history->next_number++;
+  history_copy_command(entry->command, sizeof(entry->command), normalized);
+  return 1;
+}
+
+/**
+ * 重置方向键浏览状态，并清空旧草稿。
+ *
+ * @param cursor 待重置的浏览游标。
+ */
+void
+shell_history_cursor_reset(struct shell_history_cursor *cursor)
+{
+  memset(cursor, 0, sizeof(*cursor));
+  cursor->position = -1;
+}
+
+/**
+ * 将文本复制到方向键替换缓冲区。
+ *
+ * @param dst 输出缓冲区。
+ * @param dst_size 输出容量，必须大于 0。
+ * @param src 待显示文本。
+ */
+static void
+history_copy_replacement(char *dst, int dst_size, const char *src)
+{
+  history_copy_command(dst, dst_size, src);
+}
+
+/**
+ * 向更旧的命令移动，并在首次进入浏览时保存当前草稿。
+ *
+ * @param history 只读会话历史。
+ * @param cursor 会被更新的浏览状态。
+ * @param current 首次按上键时当前尚未提交的输入。
+ * @param replacement 输出应替换到命令行的文本。
+ * @param replacement_size 输出容量，必须大于 0。
+ * @return 有历史可展示时返回 1；空历史时返回 0。
+ */
+int
+shell_history_cursor_up(const struct shell_history *history,
+                        struct shell_history_cursor *cursor,
+                        const char *current,
+                        char *replacement,
+                        int replacement_size)
+{
+  const struct shell_history_entry *entry;
+
+  if(history->count == 0)
+    return 0;
+  if(!cursor->active){
+    history_copy_command(cursor->draft, sizeof(cursor->draft), current);
+    cursor->active = 1;
+    cursor->position = history->count - 1;
+  } else if(cursor->position > 0){
+    cursor->position--;
+  }
+
+  entry = shell_history_at(history, cursor->position);
+  history_copy_replacement(replacement, replacement_size, entry->command);
+  return 1;
+}
+
+/**
+ * 向更新的命令移动，越过最新项时恢复进入浏览前保存的草稿。
+ *
+ * @param history 只读会话历史。
+ * @param cursor 会被更新的浏览状态。
+ * @param replacement 输出应替换到命令行的文本。
+ * @param replacement_size 输出容量，必须大于 0。
+ * @return 当前处于历史浏览时返回 1；未浏览时返回 0。
+ */
+int
+shell_history_cursor_down(const struct shell_history *history,
+                          struct shell_history_cursor *cursor,
+                          char *replacement,
+                          int replacement_size)
+{
+  const struct shell_history_entry *entry;
+
+  if(!cursor->active)
+    return 0;
+  if(cursor->position + 1 < history->count){
+    cursor->position++;
+    entry = shell_history_at(history, cursor->position);
+    history_copy_replacement(replacement, replacement_size, entry->command);
+  } else {
+    history_copy_replacement(replacement, replacement_size, cursor->draft);
+    cursor->active = 0;
+    cursor->position = -1;
+  }
+  return 1;
+}
+
+/**
+ * 标记用户已经编辑召回结果，后续上键会把当前文本视为新的草稿。
+ *
+ * @param cursor 待退出浏览状态的游标；保存的旧草稿不再参与当前编辑。
+ */
+void
+shell_history_cursor_edit(struct shell_history_cursor *cursor)
+{
+  cursor->active = 0;
+  cursor->position = -1;
+}

--- a/user/history.h
+++ b/user/history.h
@@ -1,0 +1,55 @@
+#ifndef XV6_USER_HISTORY_H
+#define XV6_USER_HISTORY_H
+
+#define SHELL_HISTORY_CAPACITY 32
+#define SHELL_HISTORY_COMMAND_SIZE 100
+
+/**
+ * 保存一条 Shell 会话历史记录。
+ *
+ * number 是不会因环形覆盖而回退的展示编号；command 保存去除行尾后的原始命令。
+ */
+struct shell_history_entry {
+  int number;
+  char command[SHELL_HISTORY_COMMAND_SIZE];
+};
+
+/**
+ * 保存当前 Shell 进程拥有的固定容量历史表。
+ *
+ * start 指向最旧记录，count 表示有效记录数，next_number 是下一条记录的展示编号。
+ */
+struct shell_history {
+  struct shell_history_entry entries[SHELL_HISTORY_CAPACITY];
+  int start;
+  int count;
+  int next_number;
+};
+
+/**
+ * 保存一次方向键浏览的游标与进入浏览前的未提交草稿。
+ */
+struct shell_history_cursor {
+  int active;
+  int position;
+  char draft[SHELL_HISTORY_COMMAND_SIZE];
+};
+
+void shell_history_init(struct shell_history *history);
+int shell_history_add(struct shell_history *history, const char *command);
+int shell_history_count(const struct shell_history *history);
+const struct shell_history_entry *shell_history_at(const struct shell_history *history,
+                                                   int index);
+void shell_history_cursor_reset(struct shell_history_cursor *cursor);
+int shell_history_cursor_up(const struct shell_history *history,
+                            struct shell_history_cursor *cursor,
+                            const char *current,
+                            char *replacement,
+                            int replacement_size);
+int shell_history_cursor_down(const struct shell_history *history,
+                              struct shell_history_cursor *cursor,
+                              char *replacement,
+                              int replacement_size);
+void shell_history_cursor_edit(struct shell_history_cursor *cursor);
+
+#endif

--- a/user/sh.c
+++ b/user/sh.c
@@ -2,6 +2,8 @@
 
 #include "kernel/types.h"
 #include "user/user.h"
+#include "user/history.h"
+#include "user/shellinput.h"
 #include "kernel/fcntl.h"
 #include "kernel/wait.h"
 
@@ -27,6 +29,7 @@ struct job {
 
 static struct job jobs[MAXJOBS];
 static int nextjid = 1;
+static struct shell_history command_history;
 
 struct cmd {
   int type;
@@ -217,6 +220,20 @@ showjobs(void)
       printf("[%d] %d Running %s\n", job->jid, job->pid, job->command);
 }
 
+/**
+ * 按从旧到新的顺序输出当前 Shell 进程拥有的会话历史。
+ *
+ * history 命令在进入内置命令分派前已写入 command_history，因此输出包含自身。
+ */
+static void
+showhistory(void)
+{
+  for(int i = 0; i < shell_history_count(&command_history); i++){
+    const struct shell_history_entry *entry = shell_history_at(&command_history, i);
+    printf("%d %s\n", entry->number, entry->command);
+  }
+}
+
 static int
 parsejid(char *s)
 {
@@ -266,9 +283,19 @@ startswith(char *s, char *prefix)
   return *prefix == 0;
 }
 
+/**
+ * 在 Shell 父进程内分派需要持久状态或影响当前 Shell 的内置命令。
+ *
+ * @param buf 已去除行尾的完整命令。
+ * @return 命中内置命令并完成处理时返回 1，否则返回 0。
+ */
 static int
 runbuiltin(char *buf)
 {
+  if(strcmp(buf, "history") == 0){
+    showhistory();
+    return 1;
+  }
   if(strcmp(buf, "jobs") == 0){
     showjobs();
     return 1;
@@ -363,15 +390,19 @@ runcmd(struct cmd *cmd)
   exit(0);
 }
 
+/**
+ * 输出提示符并读取一条命令。
+ *
+ * @param buf 命令缓冲区。
+ * @param nbuf 缓冲区容量。
+ * @return 成功提交一行返回 0；EOF、空行 Ctrl-D 或读取失败返回 -1。
+ */
 int
 getcmd(char *buf, int nbuf)
 {
   fprintf(2, "$ ");
   memset(buf, 0, nbuf);
-  gets(buf, nbuf);
-  if(buf[0] == 0) // EOF
-    return -1;
-  return 0;
+  return shell_readline(buf, nbuf, &command_history);
 }
 
 int
@@ -379,6 +410,8 @@ main(void)
 {
   static char buf[100];
   int fd;
+
+  shell_history_init(&command_history);
 
   // Ensure that three file descriptors are open.
   while((fd = open("console", O_RDWR)) >= 0){
@@ -398,6 +431,8 @@ main(void)
       buf[len-1] = 0;
     if(buf[0] == 0)
       continue;
+    // 历史先于内置命令分派更新，保证 `history` 输出包含当前这一条命令。
+    shell_history_add(&command_history, buf);
     if(runbuiltin(buf))
       continue;
     runline(parsecmd(buf));

--- a/user/shellinput.c
+++ b/user/shellinput.c
@@ -1,0 +1,222 @@
+#include "kernel/types.h"
+#include "kernel/console.h"
+#include "user/history.h"
+#include "user/shellinput.h"
+#include "user/user.h"
+
+#define ESCAPE 0x1b
+#define CTRL_D 0x04
+#define CTRL_U 0x15
+
+enum escape_state {
+  ESCAPE_NONE,
+  ESCAPE_STARTED,
+  ESCAPE_CSI,
+};
+
+/**
+ * 将一段文本完整写入指定文件描述符。
+ *
+ * @param fd 目标文件描述符；Shell 编辑回显使用 stderr 对应的 console。
+ * @param text NUL 结尾文本。
+ */
+static void
+write_text(int fd, const char *text)
+{
+  write(fd, text, strlen(text));
+}
+
+/**
+ * 擦除当前命令行中由 Shell 用户态回显的全部字符。
+ *
+ * @param length 当前可见字符数。
+ */
+static void
+erase_line(int length)
+{
+  while(length-- > 0)
+    write_text(2, "\b \b");
+}
+
+/**
+ * 用历史命令或草稿替换当前行，并保持缓冲区与终端显示一致。
+ *
+ * @param buf Shell 命令缓冲区。
+ * @param max 缓冲区容量。
+ * @param length 输入输出参数，调用前为旧长度，返回时为新长度。
+ * @param replacement 待显示的新文本。
+ */
+static void
+replace_line(char *buf, int max, int *length, const char *replacement)
+{
+  int new_length = 0;
+
+  erase_line(*length);
+  while(replacement[new_length] != 0 && new_length + 1 < max){
+    buf[new_length] = replacement[new_length];
+    new_length++;
+  }
+  buf[new_length] = 0;
+  write(2, buf, new_length);
+  *length = new_length;
+}
+
+/**
+ * 在方向键状态机中处理一个字节。
+ *
+ * @param state 当前 Escape 解析状态，会被更新。
+ * @param c 本次输入字节。
+ * @param history 当前 Shell 会话历史，只读。
+ * @param buf 当前命令缓冲区。
+ * @param max 缓冲区容量。
+ * @param length 当前命令长度，会在召回时更新。
+ * @param cursor 当前历史浏览游标。
+ * @return 字节已被 Escape 状态机消费时返回 1；应继续普通字符处理时返回 0。
+ */
+static int
+handle_escape(enum escape_state *state, char c,
+              const struct shell_history *history,
+              char *buf, int max, int *length,
+              struct shell_history_cursor *cursor)
+{
+  char replacement[SHELL_HISTORY_COMMAND_SIZE];
+
+  if(*state == ESCAPE_NONE){
+    if((unsigned char)c == ESCAPE){
+      *state = ESCAPE_STARTED;
+      return 1;
+    }
+    return 0;
+  }
+
+  if(*state == ESCAPE_STARTED){
+    if(c == '['){
+      *state = ESCAPE_CSI;
+      return 1;
+    }
+    // 非 CSI 序列只丢弃 ESC；当前字节重新按普通输入处理，避免吞掉可见字符。
+    *state = ESCAPE_NONE;
+    return 0;
+  }
+
+  *state = ESCAPE_NONE;
+  if(c == 'A'){
+    if(shell_history_cursor_up(history, cursor, buf,
+                               replacement, sizeof(replacement)))
+      replace_line(buf, max, length, replacement);
+  } else if(c == 'B'){
+    if(shell_history_cursor_down(history, cursor,
+                                 replacement, sizeof(replacement)))
+      replace_line(buf, max, length, replacement);
+  }
+  // 其他 CSI 尾字节被安全忽略；状态在本次输入后立即复位，不额外阻塞等待。
+  return 1;
+}
+
+/**
+ * 将已编辑命令转换为原 sh.c 期待的带换行输入。
+ *
+ * @param buf 命令缓冲区。
+ * @param max 缓冲区容量。
+ * @param length 当前有效字符数。
+ */
+static void
+terminate_line(char *buf, int max, int length)
+{
+  if(length + 1 < max)
+    buf[length++] = '\n';
+  buf[length] = 0;
+}
+
+/**
+ * 从 stdin 读取一条 Shell 命令，并在交互式 console 上提供最小行编辑。
+ *
+ * @param buf 输出命令缓冲区。
+ * @param max 缓冲区容量，必须大于 1。
+ * @param history 当前 Shell 会话历史，只读，用于方向键召回。
+ * @return 成功提交一行返回 0；空行 Ctrl-D、读取失败或 EOF 返回 -1。
+ *
+ * stdin 不是 console 或存在尚未消费的 cooked 输入时，raw claim 会失败并回退到
+ * 原 gets()。raw mode 只覆盖当前提示符读取，正常结束路径恢复 cooked mode；Shell
+ * 异常退出时由 fileclose() 按 owner PID 与 console file 对象回收 raw mode。
+ */
+int
+shell_readline(char *buf, int max, const struct shell_history *history)
+{
+  struct shell_history_cursor cursor;
+  enum escape_state escape = ESCAPE_NONE;
+  int length = 0;
+
+  shell_history_cursor_reset(&cursor);
+  if(max < 2){
+    if(max > 0)
+      buf[0] = 0;
+    return -1;
+  }
+
+  consolemode(0, CONSOLE_MODE_COOKED);
+  if(consolemode(0, CONSOLE_MODE_RAW) < 0){
+    gets(buf, max);
+    return buf[0] == 0 ? -1 : 0;
+  }
+
+  memset(buf, 0, max);
+  for(;;){
+    char c;
+    int count = read(0, &c, 1);
+
+    if(count != 1){
+      consolemode(0, CONSOLE_MODE_COOKED);
+      buf[0] = 0;
+      return -1;
+    }
+    if(handle_escape(&escape, c, history, buf, max, &length, &cursor))
+      continue;
+
+    if(c == '\r' || c == '\n'){
+      write_text(2, "\n");
+      consolemode(0, CONSOLE_MODE_COOKED);
+      terminate_line(buf, max, length);
+      return 0;
+    }
+    if((unsigned char)c == CTRL_D){
+      consolemode(0, CONSOLE_MODE_COOKED);
+      if(length == 0){
+        buf[0] = 0;
+        return -1;
+      }
+      // 非空行 Ctrl-D 按“立即提交当前输入”处理，避免静默丢弃已经编辑的命令。
+      write_text(2, "\n");
+      terminate_line(buf, max, length);
+      return 0;
+    }
+    if((unsigned char)c == CTRL_U){
+      erase_line(length);
+      length = 0;
+      buf[0] = 0;
+      shell_history_cursor_edit(&cursor);
+      escape = ESCAPE_NONE;
+      continue;
+    }
+    if(c == '\b' || (unsigned char)c == 0x7f){
+      if(length > 0){
+        length--;
+        buf[length] = 0;
+        write_text(2, "\b \b");
+        shell_history_cursor_edit(&cursor);
+      }
+      escape = ESCAPE_NONE;
+      continue;
+    }
+    if(c >= 0x20 && c <= 0x7e){
+      if(length + 1 < max){
+        buf[length++] = c;
+        buf[length] = 0;
+        write(2, &c, 1);
+        shell_history_cursor_edit(&cursor);
+      }
+      continue;
+    }
+    // 其余控制字节不修改缓冲区，也不会改变历史游标边界。
+  }
+}

--- a/user/shellinput.h
+++ b/user/shellinput.h
@@ -1,0 +1,16 @@
+#ifndef XV6_USER_SHELLINPUT_H
+#define XV6_USER_SHELLINPUT_H
+
+struct shell_history;
+
+/**
+ * 从 stdin 读取一条 Shell 命令，并在交互式 console 上提供最小行编辑。
+ *
+ * @param buf 输出命令缓冲区。
+ * @param max 缓冲区容量，必须大于 1。
+ * @param history 当前 Shell 会话历史，只读，用于方向键召回。
+ * @return 成功提交一行返回 0；空行 Ctrl-D、读取失败或 EOF 返回 -1。
+ */
+int shell_readline(char *buf, int max, const struct shell_history *history);
+
+#endif

--- a/user/user.h
+++ b/user/user.h
@@ -37,6 +37,7 @@ int munmap(void *addr, int length);
 int backtrace(void);
 int memsnapshot(int view, struct memviz_snapshot *snapshot);
 int vaquery(uint64 va, struct memviz_va_query *query);
+int consolemode(int fd, int mode);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -47,3 +47,4 @@ entry("munmap");
 entry("backtrace");
 entry("memsnapshot");
 entry("vaquery");
+entry("consolemode");


### PR DESCRIPTION
Closes #81

PR #49 已合入主线；本 PR 已重建到最新 `main@d800ae0126b9d565e869e1a94ab8473c96458aa6`，仅保留 Issue #81 的 Shell 历史与最小行编辑改动。

## 实现了什么（功能清单一览）

- 增加 Shell 进程内 32 项环形会话历史：过滤空白、连续完全重复去重、编号单调递增，容量满后覆盖最旧项。
- 将 `history` 接入父 Shell 内置命令分派路径；命令在分派前入表，因此输出包含当前 `history` 自身。
- 增加用户态逐字符行编辑：`↑` / `↓` 召回、越过最新项恢复未提交 draft、Backspace、`Ctrl-U`、Enter、`Ctrl-D`、未知 Escape 序列和满缓冲区边界。
- 新增 `consolemode(fd, mode)` 教学系统调用：只接受当前进程打开的可读 console fd，raw mode 不由内核回显或编辑，并逐字节唤醒 owner。
- raw mode owner 由 Shell PID 与具体 console `struct file *` 共同约束；非 owner 不能读取、重复设置或释放。
- owner 正常退出、被 kill 或异常退出时，`fileclose()` 自动恢复 cooked mode，避免 console 永久无回显。
- stdin 为 pipe / 文件时，`consolemode` 校验失败并回退原 `gets()` 行读取，保持非交互 Shell 和 PR #49 jobctl 测试兼容。
- 外部程序运行前恢复 cooked mode；保留既有 `jobs`、`fg`、`waitpid` 和 `Ctrl-P` 内核诊断行为。

## 添加/修改了什么单元测试（断言类）

- `tests/guest/historytest.c`
  - 空白过滤与行尾裁剪。
  - 连续重复去重、非连续重复保留。
  - 第 33 条覆盖最旧项，编号仍单调递增。
  - `↑` / `↓` 边界与 draft 恢复。
- `tests/guest/consolelinetest.c`
  - 通过 ready 握手后输入 `ab<Backspace>c<Enter>`，断言外部程序获得 cooked 行 `ac\n`。
- `tests/guest/xv6test.c`
  - 注册 `core-shell-history`，纳入现有 PR/core guest 回归。
- `tests/shell_history_interactive.py`
  - 通过真实 QEMU 串口发送 `ESC [ A` / `ESC [ B`。
  - 验证召回、draft、长短行重绘、Backspace、`Ctrl-U`、`Ctrl-D`、未知 ESC、满缓冲区、cooked 恢复、pipe-driven jobctl 与 `Ctrl-P`。
  - 失败时保存完整 transcript 到 `test-results/shell-history-interactive.log`。

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
git fetch origin
git checkout concept/81-shell-history-readline
git pull --ff-only
make clean
make -j2
make test-unit
make test-integration CPUS=3
make test-usertests CPUS=3
make qemu
```

QEMU 出现 `$ ` 后可依次输入：

```text
echo first
history
```

随后输入一段未提交草稿，按 `↑` 再按 `↓`，应恢复草稿；还可观察 Backspace、`Ctrl-U`、非空行 `Ctrl-D` 和 `Ctrl-P`。

## 单元自动化测试结果

提交前验证：

- `historytest` 通过宿主机兼容桩实际编译运行，输出 `historytest: OK`。
- `user/history.c`、`user/shellinput.c`、`user/sh.c`、guest 测试与 `kernel/console.c` 已完成 `-Wall -Werror -fsyntax-only` 检查。
- `tests/shell_history_interactive.py` 已通过 `python3 -m py_compile`。
- `user/usys.pl` 已通过 `perl -c`。
- GitHub Actions 最终 RISC-V 构建、多核 QEMU 回归与完整 `usertests`：正在以重建后的 `main` 基线执行，完成后回填准确结果。

## review 主线（先看什么，再看什么）

1. `kernel/console.c`、`kernel/file.c`、`kernel/console.h`：确认 fd 校验、owner 生命周期、`cons.lock` 边界和异常退出恢复。
2. `user/history.c`：确认环形表、编号与历史游标不变量。
3. `user/shellinput.c`：确认字节状态机、重绘、控制键和非 console fallback。
4. `user/sh.c`：确认历史写入时机及 `history` 接入既有父 Shell 内置命令分派。
5. `tests/guest/historytest.c` 与 `tests/shell_history_interactive.py`：核对 Issue #81 的纯逻辑和真实串口验收覆盖。

## 基线与教学边界

- 最新主线基线：`d800ae0126b9d565e869e1a94ab8473c96458aa6`。
- 系统调用编号：`consolemode=33`，接续主线 `waitpid=32`。
- 用进程名 `sh`、owner PID 和 console file 对象约束 raw mode，是 xv6 单 console 教学简化，不等价于 POSIX `termios`、controlling terminal、session 或前台进程组。
- 历史只属于当前 Shell 进程，不持久化、不跨会话共享，也不实现完整 readline、左右光标、补全或历史展开。