### PR TITLE
test: 补齐 VMA 配额与跨进程隔离回归

### DIFF
--- a/kernel/vma.c
+++ b/kernel/vma.c
@@ -21,11 +21,21 @@ vma_init(void)
   initlock(&vma_table.lock, "vma_table");
 }
 
+/**
+ * 从全局 VMA 池中分配一个空闲描述符。
+ *
+ * @return 成功时返回由调用方持有的 VMA 指针；池中无空闲项时返回 0。
+ *
+ * `sys_mmap()` 会先在当前进程的 `p->vma[NOFILE]` 中预留槽位，`fork()`
+ * 也只复制父进程已有的 `NOFILE` 个槽位。结合最多 `NPROC` 个进程，合法
+ * 状态下的 VMA 总数不会超过 `NPROC * NOFILE`，因此单个进程最多占用
+ * `NOFILE` 项，不能独占整个全局池。该不变量依赖调用方不绕过进程槽位
+ * 直接申请描述符；返回 0 仍作为资源泄漏或未来模型变化时的防御性失败路径。
+ */
 struct VMA*
 vma_alloc(void)
 {
   acquire(&vma_table.lock);
-  // TODO: 这里的vma_table.areas是每个进程×NOFILE的大小，那么理论上一个进程可以把所有VMA份额全部用掉，是合理的吗？
   for(struct VMA *v = vma_table.areas;
       v < vma_table.areas + NPROC * NOFILE; v++){
     if(!v->used){

--- a/tests/guest/mmaptest.c
+++ b/tests/guest/mmaptest.c
@@ -8,15 +8,24 @@
 
 void mmap_test();
 void fork_test();
+void vma_limit_test();
 char buf[BSIZE];
 
 #define MAP_FAILED ((char *) -1)
 
+/**
+ * 依次运行 mmap 基础行为、fork 继承和 VMA 配额回归。
+ *
+ * @param argc 用户程序参数数量，本测试不使用。
+ * @param argv 用户程序参数数组，本测试不使用。
+ * @return 测试全部通过时以状态 0 退出；任一断言失败时由 err() 以状态 1 退出。
+ */
 int
 main(int argc, char *argv[])
 {
   mmap_test();
   fork_test();
+  vma_limit_test();
   printf("mmaptest: all tests succeeded\n");
   exit(0);
 }
@@ -293,4 +302,137 @@ fork_test(void)
   _v1(p2);
 
   printf("fork_test OK\n");
+}
+
+/**
+ * 使用同一个文件填满当前进程的全部 VMA 槽位。
+ *
+ * @param fd 已打开且可读的文件描述符；函数不会关闭它。
+ * @param mappings 输出数组，成功后每一项保存一个单页映射地址。
+ */
+static void
+map_all_vma_slots(int fd, char **mappings)
+{
+  for(int i = 0; i < NOFILE; i++){
+    mappings[i] = mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0);
+    if(mappings[i] == MAP_FAILED)
+      err("mmap before reaching NOFILE");
+  }
+}
+
+/**
+ * 解除 map_all_vma_slots() 创建的全部映射并归还 VMA 描述符。
+ *
+ * @param mappings 包含 NOFILE 个有效单页映射地址的数组。
+ */
+static void
+unmap_all_vma_slots(char **mappings)
+{
+  for(int i = 0; i < NOFILE; i++){
+    if(munmap(mappings[i], PGSIZE) < 0)
+      err("munmap VMA slot");
+  }
+}
+
+/**
+ * 验证 VMA 配额属于单个进程，并检查 fork 继承与描述符回收。
+ *
+ * 测试先让父进程占满 NOFILE 个槽位，同时让一个未继承这些映射的子进程
+ * 成功 mmap，证明单进程达到上限不会耗尽全局池。随后在满配额状态下 fork，
+ * 验证子进程继承全部 VMA、不能继续 mmap、释放一个槽位后可以重新分配，且
+ * 子进程的释放不影响父进程。最后再次 mmap，确认退出和 munmap 已归还资源。
+ */
+void
+vma_limit_test(void)
+{
+  const char * const f = "mmap.limit";
+  char *mappings[NOFILE];
+  int fd;
+  int pid;
+  int status;
+
+  printf("vma_limit_test starting\n");
+  testname = "vma_limit_test";
+  makefile(f);
+  if((fd = open(f, O_RDONLY)) < 0)
+    err("open quota file");
+
+  // 子进程在父进程填满配额前创建，因此它自己的 VMA 槽位仍为空。
+  int sync_pipe[2];
+  if(pipe(sync_pipe) < 0)
+    err("pipe");
+  if((pid = fork()) < 0)
+    err("fork isolation child");
+  if(pid == 0){
+    char token;
+    close(sync_pipe[1]);
+    if(read(sync_pipe[0], &token, 1) != 1)
+      err("read isolation signal");
+
+    char *child_mapping = mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0);
+    if(child_mapping == MAP_FAILED)
+      err("other process mmap affected by parent quota");
+    if(child_mapping[0] != 'A')
+      err("other process mapping content");
+    if(munmap(child_mapping, PGSIZE) < 0)
+      err("other process munmap");
+
+    close(sync_pipe[0]);
+    close(fd);
+    exit(0);
+  }
+
+  close(sync_pipe[0]);
+  map_all_vma_slots(fd, mappings);
+  if(mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0) != MAP_FAILED)
+    err("mmap should fail after NOFILE VMAs");
+
+  char token = 'x';
+  if(write(sync_pipe[1], &token, 1) != 1)
+    err("write isolation signal");
+  close(sync_pipe[1]);
+
+  status = -1;
+  if(wait(&status) != pid || status != 0)
+    err("independent process VMA isolation");
+  unmap_all_vma_slots(mappings);
+
+  // 满配额 fork 必须仍能复制父进程的 NOFILE 个 VMA；全局池为每个进程
+  // 预留等量容量，因此正常状态下不会在复制中途耗尽。
+  map_all_vma_slots(fd, mappings);
+  if((pid = fork()) < 0)
+    err("fork with full VMA quota");
+  if(pid == 0){
+    if(mappings[0][0] != 'A' || mappings[NOFILE - 1][0] != 'A')
+      err("fork inherited VMA content");
+    if(mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0) != MAP_FAILED)
+      err("child should inherit full VMA quota");
+
+    if(munmap(mappings[0], PGSIZE) < 0)
+      err("child release inherited VMA");
+    char *replacement = mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0);
+    if(replacement == MAP_FAILED || replacement[0] != 'A')
+      err("child reuse released VMA slot");
+    if(munmap(replacement, PGSIZE) < 0)
+      err("child release replacement VMA");
+    close(fd);
+    exit(0);
+  }
+
+  status = -1;
+  if(wait(&status) != pid || status != 0)
+    err("forked VMA quota child");
+  if(mappings[0][0] != 'A' || mappings[NOFILE - 1][0] != 'A')
+    err("child VMA changes affected parent");
+  unmap_all_vma_slots(mappings);
+
+  char *recycled = mmap(0, PGSIZE, PROT_READ, MAP_PRIVATE, fd, 0);
+  if(recycled == MAP_FAILED || recycled[0] != 'A')
+    err("VMA descriptor was not recycled");
+  if(munmap(recycled, PGSIZE) < 0)
+    err("munmap recycled VMA");
+
+  close(fd);
+  unlink(f);
+  printf("vma_limit_test OK\n");
 }

--- a/tests/guest/mmaptest.c
+++ b/tests/guest/mmaptest.c
@@ -14,7 +14,7 @@ char buf[BSIZE];
 #define MAP_FAILED ((char *) -1)
 
 /**
- * 依次运行 mmap 基础行为、fork 继承和 VMA 配额回归。
+ * 依次运行 mmap 基础行为、VMA 配额和 fork 继承回归。
  *
  * @param argc 用户程序参数数量，本测试不使用。
  * @param argv 用户程序参数数组，本测试不使用。
@@ -24,8 +24,8 @@ int
 main(int argc, char *argv[])
 {
   mmap_test();
-  fork_test();
   vma_limit_test();
+  fork_test();
   printf("mmaptest: all tests succeeded\n");
   exit(0);
 }


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Related to #44
- 相关 PR：#87 负责解除 `PLIC` 用户地址上限；本 PR 收敛 #44 的 VMA 资源模型部分
- 基线 Commit：`d800ae0126b9d565e869e1a94ab8473c96458aa6`
- 变更类型：测试 / 设计澄清
- 影响范围：`kernel/vma.c`、`tests/guest/mmaptest.c`
- 一句话摘要：通过 guest 回归证明 VMA 配额属于单个进程，现有全局池无需因“单进程耗尽全部 VMA”而重构。

## 实现了什么

- 删除 `vma_alloc()` 中“单进程可能占满 `NPROC * NOFILE` 全局池”的误导性 TODO，明确记录现有不变量：
  - `sys_mmap()` 先受 `p->vma[NOFILE]` 限制；
  - `fork()` 最多复制父进程已有的 `NOFILE` 个 VMA；
  - 最多 `NPROC` 个进程，因此合法状态下总需求不超过 `NPROC * NOFILE`。
- 保留全局 VMA 池及其锁边界，不为了形式把 VMA 内嵌进 `struct proc`，也不引入树结构或新的地址分配策略。
- 保留 `vma_alloc()` 的资源耗尽返回值作为防御性失败路径；在当前合法调用模型下，已取得空闲进程槽位的 `fork()` 至少还拥有 `NOFILE` 个可用全局 VMA 描述符，因此不会在复制父进程 VMA 时中途耗尽。
- 将配额回归放入现有 `mmaptest`，复用 `lab10-mmap` 的 guest-first 入口，不修改 Python runner 或 GitHub Actions。

## 添加/修改了什么单元测试

| 测试场景 | 前置状态 | 核心断言 |
|---|---|---|
| 单进程配额上限 | 父进程成功建立 `NOFILE` 个 VMA | 第 `NOFILE + 1` 次 `mmap()` 返回 `MAP_FAILED` |
| 跨进程隔离 | 父进程已达到 VMA 上限；子进程在此之前创建且没有继承这些映射 | 子进程仍能 `mmap()`、读取文件内容并 `munmap()` |
| 满配额 fork | 父进程持有 `NOFILE` 个有效 VMA | `fork()` 成功，子进程可读取首尾映射，额外 `mmap()` 失败 |
| 子进程槽位复用 | 子进程解除一个继承的 VMA | 随后一次 `mmap()` 成功且内容正确 |
| 父子生命周期隔离 | 子进程解除和重建自己的 VMA 后退出 | 父进程原有首尾映射仍可读取 |
| 描述符回收 | 父进程解除全部映射，子进程也已退出 | 再次 `mmap()`、读取和 `munmap()` 成功 |

## 如何通过 CLI 回归观察此 PR 现象

### 构建并启动

```bash
make clean
make
make qemu
```

进入 xv6 shell 后执行：

```text
xv6test --run lab10-mmap
```

预期关键输出：

```text
vma_limit_test starting
vma_limit_test OK
XV6TEST ok 1 - lab10-mmap
XV6TEST done status=0
```

也可以从宿主机分别执行多核与单核回归：

```bash
make test-suite SUITE=lab10-mmap CPUS=3
make test-suite SUITE=lab10-mmap CPUS=1
```

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| 完整 diff 检查 | 通过 | 相对基线仅修改 `kernel/vma.c` 与 `tests/guest/mmaptest.c`，未包含 Markdown、runner 或 workflow 变更 |
| GitHub Actions `xv6 CI` Run #171 | 跳过 | PR 保持 Draft，Run ID `29979609319` 的 conclusion 为 `skipped`；这不是测试失败 |
| `make clean && make` | 未运行 | 当前执行环境只有 GitHub connector，无法取得本地 xv6/QEMU 构建环境 |
| `make test-suite SUITE=lab10-mmap CPUS=3` | 未运行 | PR 转为 Ready 后由 CI 执行，或在本地按上方命令验收 |
| `make test-suite SUITE=lab10-mmap CPUS=1` | 未运行 | PR 转为 Ready 后由 CI 执行，或在本地按上方命令验收 |

## Review 主线

1. `kernel/vma.c::vma_alloc()`
   - 先核对 `NPROC * NOFILE` 容量、进程槽位上限和调用方契约是否构成完整不变量。
2. `tests/guest/mmaptest.c::vma_limit_test()`
   - 再检查单进程上限、跨进程隔离、满配额 fork 和资源回收是否都有直接断言。
3. `tests/guest/mmaptest.c::main()`
   - 最后确认配额测试在旧 `fork_test()` 之前运行，避免旧测试保留的映射污染配额前置状态。
4. `tests/guest/xv6test.c` 与 `tests/run.py`
   - 现有 `lab10-mmap` 已通过 `xv6test --group lab10` 执行 `mmaptest`，无需新增注册或宿主机业务输出匹配。