### PR TITLE
chore: temporary Git tree probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Print Git tree identifiers
+      - name: Write Git tree identifiers
         run: |
-          echo "BASE_COMMIT=$(git rev-parse origin/main)"
-          echo "BASE_TREE=$(git rev-parse 'origin/main^{tree}')"
-          echo "HEAD_COMMIT=$(git rev-parse HEAD)"
-          echo "HEAD_TREE=$(git rev-parse 'HEAD^{tree}')"
+          {
+            echo "BASE_COMMIT=$(git rev-parse origin/main)"
+            echo "BASE_TREE=$(git rev-parse 'origin/main^{tree}')"
+            echo "HEAD_COMMIT=$(git rev-parse HEAD)"
+            echo "HEAD_TREE=$(git rev-parse 'HEAD^{tree}')"
+          } > tree-identifiers.txt
+
+      - name: Upload identifiers
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-tree-identifiers
+          path: tree-identifiers.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: xv6 CI
+name: xv6 tree probe
 
 on:
   pull_request:
@@ -7,50 +7,18 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: xv6-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  regression:
-    if: github.event.pull_request.draft == false
+  probe:
     runs-on: ubuntu-24.04
-    timeout-minutes: 50
-
     steps:
-      - name: Checkout
+      - name: Checkout full history
         uses: actions/checkout@v4
-
-      - name: Install toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc-riscv64-linux-gnu \
-            binutils-riscv64-linux-gnu \
-            qemu-system-misc \
-            python3-pexpect
-
-      - name: Unit-test regression grader
-        run: |
-          python3 -m py_compile tests/run.py tests/test_runner.py
-          make test-unit
-          python3 tests/run.py --list
-
-      - name: Build xv6
-        run: |
-          make clean
-          make -j2
-
-      - name: Run Lab1-10 QEMU regression
-        run: make test-integration CPUS=3
-
-      - name: Run complete usertests
-        run: make test-usertests CPUS=3
-
-      - name: Upload QEMU logs
-        if: failure()
-        uses: actions/upload-artifact@v4
         with:
-          name: xv6-test-results-${{ github.run_id }}
-          path: test-results/
-          if-no-files-found: ignore
+          fetch-depth: 0
+
+      - name: Print Git tree identifiers
+        run: |
+          echo "BASE_COMMIT=$(git rev-parse origin/main)"
+          echo "BASE_TREE=$(git rev-parse 'origin/main^{tree}')"
+          echo "HEAD_COMMIT=$(git rev-parse HEAD)"
+          echo "HEAD_TREE=$(git rev-parse 'HEAD^{tree}')"


### PR DESCRIPTION
Temporary read-only CI probe used to obtain the latest `main` root tree SHA while resolving PR #87. This PR will be closed without merging.