### PR TITLE
feat: 为 xv6 ls 增加 -alh 与 Linux 风格输出

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ UPROGS=\
 	$U/_uthreadtest\
 	$U/_historytest\
 	$U/_consolelinetest\
+	$U/_lstest\
 	$U/_xv6test\
 	$U/_schedtest\
 	$U/_schedtracetest

--- a/tests/guest/lstest.c
+++ b/tests/guest/lstest.c
@@ -5,7 +5,7 @@
 
 #define OUTPUT_SIZE 1024
 
-// 捕获缓冲区放在 BSS，避免占满 xv6 的单页用户栈。
+// 1024 字节足以覆盖专项输出；放在 BSS 避免占满 xv6 的单页用户栈。
 static char output[OUTPUT_SIZE];
 
 /**

--- a/tests/guest/lstest.c
+++ b/tests/guest/lstest.c
@@ -1,0 +1,236 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define OUTPUT_SIZE 1024
+
+// 捕获缓冲区放在 BSS，避免占满 xv6 的单页用户栈。
+static char output[OUTPUT_SIZE];
+
+/**
+ * 在断言失败时打印稳定诊断并终止测试。
+ *
+ * @param condition 非零表示断言成立。
+ * @param message 失败时输出的场景说明。
+ */
+static void
+check(int condition, char *message)
+{
+  if(condition)
+    return;
+  printf("lstest: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 判断完整输出中是否包含指定连续文本。
+ *
+ * @param text 待搜索输出。
+ * @param pattern 需要出现的子串。
+ * @return 找到返回 1，否则返回 0。
+ */
+static int
+contains(char *text, char *pattern)
+{
+  int i;
+  int j;
+
+  if(pattern[0] == 0)
+    return 1;
+  for(i = 0; text[i] != 0; i++){
+    for(j = 0; pattern[j] != 0 && text[i + j] == pattern[j]; j++)
+      ;
+    if(pattern[j] == 0)
+      return 1;
+  }
+  return 0;
+}
+
+/**
+ * 判断输出中是否存在内容完全相同的一整行。
+ *
+ * @param text 多行输出。
+ * @param expected 目标行，不包含换行符。
+ * @return 找到完整行返回 1，否则返回 0。
+ */
+static int
+has_line(char *text, char *expected)
+{
+  int start;
+  int end;
+  int expected_length;
+
+  expected_length = strlen(expected);
+  start = 0;
+  while(text[start] != 0){
+    end = start;
+    while(text[end] != 0 && text[end] != '\n')
+      end++;
+    if(end - start == expected_length && memcmp(text + start, expected, expected_length) == 0)
+      return 1;
+    start = text[end] == '\n' ? end + 1 : end;
+  }
+  return 0;
+}
+
+/**
+ * 在子进程中执行 ls，并同时捕获 stdout 与 stderr。
+ *
+ * @param argv 传给 exec("ls") 的空指针结尾参数数组。
+ * @param output 输出缓冲区。
+ * @param capacity output 容量，必须大于 1。
+ * @return ls 的退出状态；基础设施失败时直接终止测试。
+ */
+static int
+run_ls(char **argv, char *output, int capacity)
+{
+  int pipefd[2];
+  int pid;
+  int status;
+  int total;
+  int count;
+
+  check(pipe(pipefd) == 0, "pipe failed");
+  pid = fork();
+  check(pid >= 0, "fork failed");
+  if(pid == 0){
+    close(pipefd[0]);
+    close(1);
+    check(dup(pipefd[1]) == 1, "redirect stdout failed");
+    close(2);
+    check(dup(pipefd[1]) == 2, "redirect stderr failed");
+    close(pipefd[1]);
+    exec("ls", argv);
+    exit(127);
+  }
+
+  close(pipefd[1]);
+  total = 0;
+  while(total < capacity - 1){
+    count = read(pipefd[0], output + total, capacity - total - 1);
+    if(count <= 0)
+      break;
+    total += count;
+  }
+  output[total] = 0;
+  close(pipefd[0]);
+  check(wait(&status) == pid, "wait returned wrong child");
+  return status;
+}
+
+/** 创建 ls 选项测试使用的目录、隐藏文件、普通文件和符号链接。 */
+static void
+create_fixture(void)
+{
+  char block[512];
+  int fd;
+  int i;
+
+  unlink("lstmp/link");
+  unlink("lstmp/.hidden");
+  unlink("lstmp/visible");
+  unlink("lstmp/subdir");
+  unlink("lstmp");
+  unlink("-lsdash");
+
+  check(mkdir("lstmp") == 0, "mkdir fixture failed");
+  check(mkdir("lstmp/subdir") == 0, "mkdir subdir failed");
+  memset(block, 'x', sizeof(block));
+  fd = open("lstmp/visible", O_CREATE | O_RDWR | O_TRUNC);
+  check(fd >= 0, "open visible failed");
+  for(i = 0; i < 3; i++)
+    check(write(fd, block, sizeof(block)) == sizeof(block), "write visible failed");
+  close(fd);
+
+  fd = open("lstmp/.hidden", O_CREATE | O_WRONLY | O_TRUNC);
+  check(fd >= 0, "open hidden failed");
+  check(write(fd, "h", 1) == 1, "write hidden failed");
+  close(fd);
+  check(symlink("visible", "lstmp/link") == 0, "create symlink failed");
+
+  fd = open("-lsdash", O_CREATE | O_WRONLY | O_TRUNC);
+  check(fd >= 0, "open dash path failed");
+  close(fd);
+}
+
+/** 删除 fixture，确保重复执行不会因残留目录项失败。 */
+static void
+remove_fixture(void)
+{
+  unlink("lstmp/link");
+  unlink("lstmp/.hidden");
+  unlink("lstmp/visible");
+  unlink("lstmp/subdir");
+  unlink("lstmp");
+  unlink("-lsdash");
+}
+
+/** 验证默认隐藏、-a、-l、-h、组合选项、-- 和错误状态传播。 */
+static void
+test_ls_options(void)
+{
+  char *default_argv[] = {"ls", "lstmp", 0};
+  char *all_argv[] = {"ls", "-a", "lstmp", 0};
+  char *long_argv[] = {"ls", "-l", "lstmp", 0};
+  char *human_argv[] = {"ls", "-lh", "lstmp", 0};
+  char *combined_argv[] = {"ls", "-alh", "lstmp", 0};
+  char *dash_argv[] = {"ls", "--", "-lsdash", 0};
+  char *help_argv[] = {"ls", "--help", 0};
+  char *invalid_argv[] = {"ls", "-z", 0};
+  char *multi_argv[] = {"ls", "missing-ls", "lstmp/visible", 0};
+
+  check(run_ls(default_argv, output, sizeof(output)) == 0, "default ls status");
+  check(has_line(output, "visible"), "default ls missing visible");
+  check(has_line(output, "subdir"), "default ls missing directory");
+  check(has_line(output, "link"), "default ls missing symlink");
+  check(!has_line(output, "."), "default ls exposed dot");
+  check(!has_line(output, ".."), "default ls exposed dotdot");
+  check(!has_line(output, ".hidden"), "default ls exposed hidden file");
+
+  check(run_ls(all_argv, output, sizeof(output)) == 0, "ls -a status");
+  check(has_line(output, "."), "ls -a missing dot");
+  check(has_line(output, ".."), "ls -a missing dotdot");
+  check(has_line(output, ".hidden"), "ls -a missing hidden file");
+
+  check(run_ls(long_argv, output, sizeof(output)) == 0, "ls -l status");
+  check(contains(output, "1536 visible"), "ls -l missing byte size");
+  check(contains(output, "d "), "ls -l missing directory type");
+  check(contains(output, "l "), "ls -l missing symlink type");
+
+  check(run_ls(human_argv, output, sizeof(output)) == 0, "ls -lh status");
+  check(contains(output, "1.5K visible"), "ls -lh missing human size");
+
+  check(run_ls(combined_argv, output, sizeof(output)) == 0, "ls -alh status");
+  check(contains(output, ".hidden"), "ls -alh missing hidden file");
+  check(contains(output, "1.5K visible"), "ls -alh lost human size");
+
+  check(run_ls(dash_argv, output, sizeof(output)) == 0, "ls -- status");
+  check(has_line(output, "-lsdash"), "ls -- did not preserve dash path");
+
+  check(run_ls(help_argv, output, sizeof(output)) == 0, "ls --help status");
+  check(contains(output, "Usage: ls [-alh]"), "ls --help missing usage");
+
+  check(run_ls(invalid_argv, output, sizeof(output)) == 2, "invalid option status");
+  check(contains(output, "invalid option"), "invalid option diagnostic");
+  check(contains(output, "Usage: ls"), "invalid option usage");
+
+  check(run_ls(multi_argv, output, sizeof(output)) == 1, "multi-path failure status");
+  check(contains(output, "cannot access 'missing-ls'"), "missing path diagnostic");
+  check(has_line(output, "visible"), "multi-path stopped before valid path");
+}
+
+/**
+ * 创建 fixture、执行全部断言并清理。
+ *
+ * @return 通过 exit status 返回；成功为 0，任一断言失败为 1。
+ */
+int
+main(void)
+{
+  create_fixture();
+  test_ls_options();
+  remove_fixture();
+  printf("lstest: OK\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -54,6 +54,7 @@ static char *core_linkunlink_argv[] = {"usertests", "linkunlink", 0};
 static char *core_openiput_argv[] = {"usertests", "openiput", 0};
 static char *core_schedtrace_argv[] = {"schedtracetest", 0};
 static char *core_history_argv[] = {"historytest", 0};
+static char *core_ls_options_argv[] = {"lstest", 0};
 
 static char *legacy_forktest_argv[] = {"forktest", 0};
 static char *legacy_stressfs_argv[] = {"stressfs", 0};
@@ -104,6 +105,7 @@ static struct xv6_test_case tests[] = {
   {"core", "core-openiput", core_openiput_argv},
   {"core", "core-schedtrace", core_schedtrace_argv},
   {"core", "core-shell-history", core_history_argv},
+  {"core", "core-ls-options", core_ls_options_argv},
 
   {"legacy", "legacy-forktest", legacy_forktest_argv},
   {"legacy", "legacy-stressfs", legacy_stressfs_argv},

--- a/user/ls.c
+++ b/user/ls.c
@@ -1,82 +1,475 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "kernel/fcntl.h"
 #include "user/user.h"
 #include "kernel/fs.h"
 
-/** Return the final path component padded to DIRSIZ for aligned output. */
-char*
-fmtname(char *path)
+#define LS_PATH_SIZE 512
+#define LS_SIZE_SIZE 32
+
+/** 保存一次 ls 调用启用的展示选项。 */
+struct ls_options {
+  int show_all;
+  int long_format;
+  int human_readable;
+  int show_help;
+};
+
+/**
+ * 输出当前实现支持的命令行形式和长格式字段。
+ */
+static void
+usage(void)
 {
-  static char buf[DIRSIZ+1];
-  char *p;
-
-  for(p = path + strlen(path); p >= path && *p != '/'; p--)
-    ;
-  p++;
-
-  if(strlen(p) >= DIRSIZ)
-    return p;
-  memmove(buf, p, strlen(p));
-  memset(buf + strlen(p), ' ', DIRSIZ - strlen(p));
-  buf[DIRSIZ] = 0;
-  return buf;
+  printf("Usage: ls [-alh] [--help] [--] [FILE ...]\n");
+  printf("  -a  show entries starting with .\n");
+  printf("  -l  long format: TYPE NLINK INODE SIZE NAME\n");
+  printf("  -h  human-readable sizes with -l\n");
 }
 
-/** List one file or directory and print 64-bit sizes without truncation. */
-void
-ls(char *path)
+/**
+ * 解析 -a、-l、-h、--help 和 --，并定位首个路径参数。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 命令行参数数组。
+ * @param options 输出选项集合，调用前无需初始化。
+ * @param first_path 输出首个路径参数下标；没有路径时等于 argc。
+ * @return 参数合法时返回 0；遇到未知选项时返回 -1，并已输出诊断。
+ */
+static int
+parse_options(int argc, char **argv, struct ls_options *options, int *first_path)
 {
-  char buf[512], *p;
-  int fd;
-  struct dirent de;
-  struct stat st;
+  int i;
+  int j;
 
-  if((fd = open(path, 0)) < 0){
-    fprintf(2, "ls: cannot open %s\n", path);
-    return;
-  }
-  if(fstat(fd, &st) < 0){
-    fprintf(2, "ls: cannot stat %s\n", path);
-    close(fd);
-    return;
-  }
-
-  switch(st.type){
-  case T_FILE:
-    printf("%s %d %d %l\n", fmtname(path), st.type, st.ino, st.size);
-    break;
-  case T_DIR:
-    if(strlen(path) + 1 + DIRSIZ + 1 > sizeof buf){
-      printf("ls: path too long\n");
+  memset(options, 0, sizeof(*options));
+  for(i = 1; i < argc; i++){
+    if(strcmp(argv[i], "--") == 0){
+      i++;
       break;
     }
-    strcpy(buf, path);
-    p = buf + strlen(buf);
-    *p++ = '/';
-    while(read(fd, &de, sizeof(de)) == sizeof(de)){
-      if(de.inum == 0)
-        continue;
-      memmove(p, de.name, DIRSIZ);
-      p[DIRSIZ] = 0;
-      if(stat(buf, &st) < 0){
-        printf("ls: cannot stat %s\n", buf);
-        continue;
-      }
-      printf("%s %d %d %l\n", fmtname(buf), st.type, st.ino, st.size);
+    if(strcmp(argv[i], "--help") == 0){
+      options->show_help = 1;
+      i++;
+      break;
     }
-    break;
+    if(argv[i][0] != '-' || argv[i][1] == 0)
+      break;
+    if(argv[i][1] == '-'){
+      fprintf(2, "ls: unrecognized option '%s'\n", argv[i]);
+      usage();
+      return -1;
+    }
+
+    for(j = 1; argv[i][j] != 0; j++){
+      switch(argv[i][j]){
+      case 'a':
+        options->show_all = 1;
+        break;
+      case 'l':
+        options->long_format = 1;
+        break;
+      case 'h':
+        options->human_readable = 1;
+        break;
+      default:
+        fprintf(2, "ls: invalid option -- '%c'\n", argv[i][j]);
+        usage();
+        return -1;
+      }
+    }
   }
-  close(fd);
+
+  *first_path = i;
+  return 0;
 }
 
+/**
+ * 从路径中提取用于显示的最后一个名称组件。
+ *
+ * @param path 输入路径，不会被修改。
+ * @param name 输出缓冲区，至少需要 DIRSIZ + 2 字节；过长名称按完整路径
+ *             现有上限截断到 DIRSIZ 字节。
+ * @return name 缓冲区首地址。
+ */
+static char*
+display_name(char *path, char *name)
+{
+  char *start;
+  char *end;
+  int length;
+
+  end = path + strlen(path);
+  while(end > path + 1 && end[-1] == '/')
+    end--;
+  start = end;
+  while(start > path && start[-1] != '/')
+    start--;
+
+  length = end - start;
+  if(length == 0 && path[0] == '/'){
+    name[0] = '/';
+    name[1] = 0;
+    return name;
+  }
+  if(length > DIRSIZ)
+    length = DIRSIZ;
+  memmove(name, start, length);
+  name[length] = 0;
+  return name;
+}
+
+/**
+ * 将固定宽度 dirent 名称转换为以 NUL 结尾的用户态字符串。
+ *
+ * @param entry_name 磁盘目录项中的 DIRSIZ 字节名称。
+ * @param name 输出缓冲区，至少需要 DIRSIZ + 1 字节。
+ */
+static void
+copy_dirent_name(char *entry_name, char *name)
+{
+  int length;
+
+  for(length = 0; length < DIRSIZ && entry_name[length] != 0; length++)
+    name[length] = entry_name[length];
+  name[length] = 0;
+}
+
+/**
+ * 判断名称是否属于默认应隐藏的点条目。
+ *
+ * @param name 以 NUL 结尾的单个名称组件。
+ * @return 名称以 '.' 开头时返回 1，否则返回 0。
+ */
+static int
+is_hidden(char *name)
+{
+  return name[0] == '.';
+}
+
+/**
+ * 将 xv6 inode 类型映射为简短且可读的类型字符。
+ *
+ * @param type struct stat 中的 T_* 类型。
+ * @return 目录、普通文件、设备、符号链接分别返回 d、-、c、l；未知类型返回 ?。
+ */
+static char
+file_type(short type)
+{
+  switch(type){
+  case T_DIR:
+    return 'd';
+  case T_FILE:
+    return '-';
+  case T_DEVICE:
+    return 'c';
+  case T_SYMLINK:
+    return 'l';
+  default:
+    return '?';
+  }
+}
+
+/**
+ * 将无符号整数转换为十进制字符串。
+ *
+ * @param value 待格式化数值。
+ * @param buffer 输出缓冲区，至少需要 21 字节。
+ */
+static void
+format_uint64(uint64 value, char *buffer)
+{
+  char reverse[21];
+  int length;
+  int i;
+
+  length = 0;
+  do {
+    reverse[length++] = '0' + value % 10;
+    value /= 10;
+  } while(value != 0);
+
+  for(i = 0; i < length; i++)
+    buffer[i] = reverse[length - i - 1];
+  buffer[length] = 0;
+}
+
+/**
+ * 使用 1024 进制单位格式化文件大小，不依赖浮点运行时。
+ *
+ * @param size 原始字节数。
+ * @param buffer 输出缓冲区，至少需要 LS_SIZE_SIZE 字节。
+ */
+static void
+format_human_size(uint64 size, char *buffer)
+{
+  static char units[] = "KMGT";
+  uint64 divisor;
+  uint64 whole;
+  uint64 decimal;
+  int unit;
+  int length;
+
+  if(size < 1024){
+    format_uint64(size, buffer);
+    return;
+  }
+
+  divisor = 1024;
+  unit = 0;
+  while(unit < 3 && size >= divisor * 1024){
+    divisor *= 1024;
+    unit++;
+  }
+
+  whole = size / divisor;
+  decimal = ((size % divisor) * 10 + divisor / 2) / divisor;
+  if(decimal == 10){
+    whole++;
+    decimal = 0;
+  }
+
+  format_uint64(whole, buffer);
+  length = strlen(buffer);
+  if(whole < 10 && decimal != 0){
+    buffer[length++] = '.';
+    buffer[length++] = '0' + decimal;
+  }
+  buffer[length++] = units[unit];
+  buffer[length] = 0;
+}
+
+/**
+ * 按当前选项格式化文件大小。
+ *
+ * @param size 原始字节数。
+ * @param human_readable 非零时使用 K/M/G/T 单位，否则输出字节数。
+ * @param buffer 输出缓冲区，至少需要 LS_SIZE_SIZE 字节。
+ */
+static void
+format_size(uint64 size, int human_readable, char *buffer)
+{
+  if(human_readable)
+    format_human_size(size, buffer);
+  else
+    format_uint64(size, buffer);
+}
+
+/**
+ * 在字段内容前输出空格，使其至少达到指定宽度。
+ *
+ * @param text 待输出字符串。
+ * @param width 最小字段宽度，小于字符串长度时不截断。
+ */
+static void
+print_right_aligned(char *text, int width)
+{
+  int padding;
+
+  padding = width - strlen(text);
+  while(padding-- > 0)
+    printf(" ");
+  printf("%s", text);
+}
+
+/**
+ * 输出一个目录项或文件参数。
+ *
+ * @param name 只用于展示的名称，不包含父目录前缀。
+ * @param st 通过 O_NOFOLLOW 获取的真实 xv6 元数据。
+ * @param options 当前展示选项。
+ */
+static void
+print_entry(char *name, struct stat *st, struct ls_options *options)
+{
+  char nlink[LS_SIZE_SIZE];
+  char inode[LS_SIZE_SIZE];
+  char size[LS_SIZE_SIZE];
+
+  if(!options->long_format){
+    printf("%s\n", name);
+    return;
+  }
+
+  format_uint64(st->nlink, nlink);
+  format_uint64(st->ino, inode);
+  format_size(st->size, options->human_readable, size);
+  printf("%c ", file_type(st->type));
+  print_right_aligned(nlink, 3);
+  printf(" ");
+  print_right_aligned(inode, 5);
+  printf(" ");
+  print_right_aligned(size, 6);
+  printf(" %s\n", name);
+}
+
+/**
+ * 优先读取路径本身的 stat，在当前内核拒绝给目录附加 O_NOFOLLOW 时回退。
+ *
+ * xv6 的 can_open_inode_locked() 会把 O_NOFOLLOW 误当成目录写入模式，因此真实
+ * 目录第一次打开会失败。符号链接本身可以用 O_NOFOLLOW 打开，只有失败后才以
+ * O_RDONLY 重试；这样既保留符号链接类型，也不需要为了 ls 修改内核 open 语义。
+ *
+ * @param path 待读取路径。
+ * @param st 输出元数据。
+ * @return 成功返回 0；两种打开方式或 fstat 均失败时返回 -1，临时 fd 已关闭。
+ */
+static int
+stat_no_follow(char *path, struct stat *st)
+{
+  int fd;
+
+  fd = open(path, O_RDONLY | O_NOFOLLOW);
+  if(fd < 0)
+    fd = open(path, O_RDONLY);
+  if(fd < 0)
+    return -1;
+  if(fstat(fd, st) < 0){
+    close(fd);
+    return -1;
+  }
+  close(fd);
+  return 0;
+}
+
+/**
+ * 安全拼接目录路径和单个 dirent 名称。
+ *
+ * @param directory 父目录路径。
+ * @param name 单个名称组件。
+ * @param path 输出完整路径。
+ * @param capacity path 缓冲区容量。
+ * @return 拼接成功返回 0；超出容量返回 -1，path 内容不可使用。
+ */
+static int
+join_path(char *directory, char *name, char *path, int capacity)
+{
+  int directory_length;
+  int name_length;
+  int need_slash;
+  int length;
+
+  directory_length = strlen(directory);
+  name_length = strlen(name);
+  need_slash = directory_length > 0 && directory[directory_length - 1] != '/';
+  length = directory_length + need_slash + name_length + 1;
+  if(length > capacity)
+    return -1;
+
+  memmove(path, directory, directory_length);
+  length = directory_length;
+  if(need_slash)
+    path[length++] = '/';
+  memmove(path + length, name, name_length);
+  path[length + name_length] = 0;
+  return 0;
+}
+
+/**
+ * 遍历并输出一个真实目录，不跟随目录中的符号链接。
+ *
+ * @param path 目录路径。
+ * @param options 当前展示选项。
+ * @return 全部条目成功时返回 0；任一条目路径过长或 stat 失败时返回 1。
+ */
+static int
+list_directory(char *path, struct ls_options *options)
+{
+  char full_path[LS_PATH_SIZE];
+  char name[DIRSIZ + 1];
+  int fd;
+  int failed;
+  struct dirent entry;
+  struct stat st;
+
+  fd = open(path, O_RDONLY);
+  if(fd < 0){
+    fprintf(2, "ls: cannot open '%s'\n", path);
+    return 1;
+  }
+
+  failed = 0;
+  while(read(fd, &entry, sizeof(entry)) == sizeof(entry)){
+    if(entry.inum == 0)
+      continue;
+    copy_dirent_name(entry.name, name);
+    if(!options->show_all && is_hidden(name))
+      continue;
+    if(join_path(path, name, full_path, sizeof(full_path)) < 0){
+      fprintf(2, "ls: path too long: '%s/%s'\n", path, name);
+      failed = 1;
+      continue;
+    }
+    if(stat_no_follow(full_path, &st) < 0){
+      fprintf(2, "ls: cannot stat '%s'\n", full_path);
+      failed = 1;
+      continue;
+    }
+    print_entry(name, &st, options);
+  }
+  close(fd);
+  return failed;
+}
+
+/**
+ * 输出一个文件或目录参数。
+ *
+ * @param path 用户提供的路径。
+ * @param options 当前展示选项。
+ * @return 成功返回 0；路径不可访问或目录遍历出现错误时返回 1。
+ */
+static int
+list_path(char *path, struct ls_options *options)
+{
+  char name[DIRSIZ + 2];
+  struct stat st;
+
+  if(stat_no_follow(path, &st) < 0){
+    fprintf(2, "ls: cannot access '%s'\n", path);
+    return 1;
+  }
+  if(st.type == T_DIR)
+    return list_directory(path, options);
+
+  print_entry(display_name(path, name), &st, options);
+  return 0;
+}
+
+/**
+ * 解析命令行并依次处理全部路径。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 命令行参数数组。
+ * @return 通过 exit status 返回：成功为 0，路径错误为 1，参数错误为 2。
+ */
 int
 main(int argc, char *argv[])
 {
-  if(argc < 2){
-    ls(".");
+  struct ls_options options;
+  int first_path;
+  int failed;
+  int path_count;
+  int i;
+
+  if(parse_options(argc, argv, &options, &first_path) < 0)
+    exit(2);
+  if(options.show_help){
+    usage();
     exit(0);
   }
-  for(int i = 1; i < argc; i++)
-    ls(argv[i]);
-  exit(0);
+  if(first_path == argc)
+    exit(list_path(".", &options));
+
+  failed = 0;
+  path_count = argc - first_path;
+  for(i = first_path; i < argc; i++){
+    if(path_count > 1){
+      if(i > first_path)
+        printf("\n");
+      printf("%s:\n", argv[i]);
+    }
+    if(list_path(argv[i], &options) != 0)
+      failed = 1;
+  }
+  exit(failed);
 }


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #90
- 最新基线 Commit：`7e54eec12ded9f560c135a5725562849cbd5d4ac`
- 当前 Head：`c3c2579f8d86182f0bb3945bbeaf2a6c6350b543`
- 分支：`concept/90-linux-style-ls`
- 变更类型：功能 / 测试 / 冲突解决
- 影响范围：`user/ls.c`、`tests/guest/lstest.c`、`tests/guest/xv6test.c`、`Makefile`
- 状态：Ready for review，未经批准不合并

## 实现了什么（功能清单一览）

- 默认 `ls` 仅输出名称，并隐藏 `.`、`..` 与其他点文件。
- 支持 `-a`、`-l`、`-h` 及 `-alh`、`-lah` 等组合短选项。
- 支持 `--help` 和 `--`，可通过 `ls -- -name` 访问以 `-` 开头的路径。
- `-l` 输出 xv6 原生长格式：

```text
TYPE NLINK INODE SIZE NAME
```

- `-h` 使用整数运算按 1024 进制输出 `K/M/G/T`，例如 `1536 -> 1.5K`。
- 文件类型以 `d / - / c / l / ?` 表示目录、普通文件、设备、符号链接和未知类型。
- 多路径输出带路径标题；单个路径失败后继续处理其余路径，并在最终退出状态中反映错误。
- 未知选项返回状态 `2`；路径错误返回状态 `1`。
- 不修改 inode 格式、系统调用或 shell。

## 合并冲突处理

本次将 PR 分支重新建立在最新 `main@7e54eec` 上，并按语义重新应用原有四文件改动。

保留的最新主线能力包括：

- #95 的 4 GiB 单文件支持、`uint64 stat.size`、`_largefile`、`fs-large.img` 与 `largefiletest`；
- 调度器主线的 `schedviz`、`schedtest`、`schedtracetest`、调度策略编译参数与相关构建目标；
- #98 的 changed-file CI 选择器与新工作流。

冲突处理结果：

- `user/ls.c` 保留 Linux 风格 `-alh`，并使用 64 位大小格式化，避免大文件截断；
- `Makefile` 仅在最新主线 UPROGS 中补回 `_lstest`；
- `tests/guest/xv6test.c` 在最新的 scheduler/core registry 上补回 `core-ls-options`；
- `tests/guest/lstest.c` 保持纯 C guest 断言，1024 字节捕获缓冲区位于 BSS，避免占满单页用户栈。

Git 对比结果：

```text
status=ahead
behind_by=0
merge_base=7e54eec12ded9f560c135a5725562849cbd5d4ac
changed_files=4
```

GitHub 当前判定：`mergeable=true`。

## 添加/修改了什么单元测试（断言类）

新增纯 C guest 测试 `tests/guest/lstest.c`，使用 `pipe + fork + dup + exec` 捕获 `ls` 的 stdout、stderr 与退出状态。

| 场景 | 核心断言 |
|---|---|
| 默认目录列表 | 显示普通文件、目录和符号链接；隐藏点条目 |
| `-a` | 显示 `.`、`..` 和 `.hidden` |
| `-l` | 显示字节大小与真实文件类型 |
| `-lh` | 1536 字节显示为 `1.5K` |
| `-alh` | 隐藏文件与人类可读大小同时生效 |
| `-- -lsdash` | 以 `-` 开头的文件名按路径处理 |
| `--help` | 返回 0 并输出 usage |
| `-z` | 返回 2，并输出诊断与 usage |
| 多路径错误 | 缺失路径报错，但继续处理后续有效路径，最终返回 1 |

专项入口：

```text
xv6test --run core-ls-options
```

## 如何通过 CLI 命令进行回归观察此 PR 现象

```bash
git fetch origin
git switch concept/90-linux-style-ls
make clean
make
make qemu
```

进入 xv6 shell：

```text
ls
ls -a
ls -l
ls -lh
ls -alh
ls --help
xv6test --run core-ls-options
```

预期专项测试结束协议：

```text
lstest: OK
XV6TEST ok 1 - core-ls-options
XV6TEST summary selected=1 passed=1 failed=0
XV6TEST done status=0
```

## 单元自动化测试结果

已有真实 QEMU 证据：[`xv6 CI #215`](https://github.com/mental1104/xv6/actions/runs/29990407804)

| 检查项 | 结果 | 说明 |
|---|---|---|
| regression runner 单元测试 | ✅ 通过 | CI #215 |
| `make clean && make -j2` | ✅ 通过 | CI #215 |
| `usertests-core` | ✅ 通过 | 6/6，包括 `core-ls-options` |
| `lstest` | ✅ 通过 | 日志包含 `lstest: OK` |
| 旧工作流全套 QEMU | ❌ 基线故障 | 停在 #95 已存在的 `lab8-bigwrite`；#95 CI #211 与本 PR #215 的 lab8 日志 SHA-256 完全一致 |
| 最新 #98 CI 计划 | ✅ 映射确认 | 当前四文件变更精确选择 `usertests-core`，不再运行无关 `lab8-locks` |
| 最新 head Actions | 未触发 | GitHub 连接器写入与 API reopen 未生成 Actions 事件，不伪造最新 run |
| `CPUS=1` | 未执行 | 不宣称已验证 |

## Review 主线（先看什么，再看什么）

1. `user/ls.c::parse_options()`、`main()`：参数组合、`--` 和退出状态。
2. `user/ls.c::format_human_size()`、`print_entry()`：64 位大小与人类可读格式。
3. `user/ls.c::stat_no_follow()`、`list_directory()`：符号链接、路径边界和 fd 生命周期。
4. `tests/guest/lstest.c`：用户可见行为断言与 BSS 缓冲区约束。
5. `tests/guest/xv6test.c`、`Makefile`：在最新 largefile、scheduler 与 CI 主线上只补回 ls 测试入口。