### PR TITLE
[Concept Lab] 支持 4 GiB 单文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ initcode
 initcode.out
 kernelmemfs
 mkfs
+mkfs/mkfs-large
 kernel/kernel
 user/usys.S
 .gdbinit

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ U=user
 T=tests/guest
 H=tests/host
 
+FSIMG ?= fs.img
+LARGE_FSSIZE ?= 4250000
+
 OBJS = \
   $K/entry.o \
   $K/start.o \
@@ -187,6 +190,9 @@ $U/xargstest.sh: $T/xargstest.sh
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 	gcc -Werror -Wall -I. -o mkfs/mkfs mkfs/mkfs.c
 
+mkfs/mkfs-large: mkfs/mkfs_large.c $K/fs.h $K/param.h
+	gcc -Werror -Wall -I. -DFSSIZE=$(LARGE_FSSIZE) -o $@ $<
+
 .PRECIOUS: %.o
 
 UPROGS=\
@@ -227,6 +233,7 @@ UPROGS=\
 	$U/_lazytests\
 	$U/_cowtest\
 	$U/_bigfile\
+	$U/_largefile\
 	$U/_symlinktest\
 	$U/_mmaptest\
 	$U/_lab1test\
@@ -241,14 +248,17 @@ UEXTRA = $U/xargstest.sh
 fs.img: mkfs/mkfs README $(UEXTRA) $(UPROGS)
 	mkfs/mkfs fs.img README $(UEXTRA) $(UPROGS)
 
+fs-large.img: mkfs/mkfs-large README $(UEXTRA) $(UPROGS)
+	mkfs/mkfs-large $@ README $(UEXTRA) $(UPROGS)
+
 -include kernel/*.d user/*.d tests/guest/*.d
 
 clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 		*/*.o */*.d */*.asm */*.sym \
 		$T/*.o $T/*.d $T/*.asm $T/*.sym \
-		$U/initcode $U/initcode.out $K/kernel fs.img \
-		mkfs/mkfs .gdbinit $U/usys.S $(UPROGS) $(UEXTRA) ph barrier
+		$U/initcode $U/initcode.out $K/kernel fs.img fs-large.img \
+		mkfs/mkfs mkfs/mkfs-large .gdbinit $U/usys.S $(UPROGS) $(UEXTRA) ph barrier
 
 GDBPORT = $(shell expr `id -u` % 5000 + 25000)
 QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
@@ -259,17 +269,17 @@ CPUS := 3
 endif
 
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic
-QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0
+QEMUOPTS += -drive file=$(FSIMG),if=none,format=raw,id=x0
 QEMUOPTS += -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 QEMUOPTS += $(QEMUEXTRA)
 
-qemu: $K/kernel fs.img
+qemu: $K/kernel $(FSIMG)
 	$(QEMU) $(QEMUOPTS)
 
 .gdbinit: .gdbinit.tmpl-riscv
 	sed "s/:1234/:$(GDBPORT)/" < $^ > $@
 
-qemu-gdb: $K/kernel .gdbinit fs.img
+qemu-gdb: $K/kernel .gdbinit $(FSIMG)
 	@echo "*** Now run 'gdb' in another window." 1>&2
 	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)
 
@@ -313,5 +323,10 @@ test-suite: $K/kernel fs.img
 	@test -n "$(SUITE)" || (echo "usage: make test-suite SUITE=<suite> [CPUS=<n>]"; exit 2)
 	$(PYTHON) tests/run.py --suite $(SUITE) --cpus $(CPUS)
 
+# Explicitly opt into the sparse 4.25-million-block image. This target is kept
+# out of test/pr/full because it performs a real sequential 4-GiB write/read.
+largefiletest: $K/kernel fs-large.img
+	FSIMG=fs-large.img $(PYTHON) tests/run_largefile.py --suite largefs-4gib --cpus $(CPUS)
+
 .PHONY: clean qemu qemu-gdb gdb ph barrier test test-unit test-grader \
-	test-integration test-labs test-usertests test-full test-suite
+	test-integration test-labs test-usertests test-full test-suite largefiletest

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -54,9 +54,9 @@ void            iupdate(struct inode*);
 int             namecmp(const char*, const char*);
 struct inode*   namei(char*);
 struct inode*   nameiparent(char*, char*);
-int             readi(struct inode*, int, uint64, uint, uint);
+int             readi(struct inode*, int, uint64, uint64, uint);
 void            stati(struct inode*, struct stat*);
-int             writei(struct inode*, int, uint64, uint, uint);
+int             writei(struct inode*, int, uint64, uint64, uint);
 void            itrunc(struct inode*);
 
 // ramdisk.c
@@ -189,7 +189,7 @@ void            vmwalk(pagetable_t pagetable, int depth);
 void            vmprint(pagetable_t pagetable);
 void            kvmmapkern(pagetable_t pagetable, uint64 va, uint64 pa, uint64 sz, int perm);
 pagetable_t     kvmcreate();
-void            kvmfree(pagetable_t kpagetale) ;
+void            kvmfree(pagetable_t kpagetale);
 void            u2kvmcopy(pagetable_t, pagetable_t, uint64, uint64);
 void            u2kvmunmap(pagetable_t, uint64, uint64);
 int             uvmlazyalloc(struct proc*, uint64);
@@ -207,6 +207,7 @@ void            virtio_disk_intr(void);
 
 uint64          free_proc(void);
 uint64          free_mem(void);
+
 // vma.c
 void            vma_init(void);
 struct VMA*     vma_alloc(void);

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -1,14 +1,14 @@
 //
-// Support functions for system calls that involve file descriptors.
+// File descriptors
 //
 
 #include "types.h"
 #include "riscv.h"
 #include "defs.h"
 #include "param.h"
-#include "fs.h"
 #include "spinlock.h"
 #include "sleeplock.h"
+#include "fs.h"
 #include "file.h"
 #include "stat.h"
 #include "proc.h"
@@ -19,20 +19,19 @@ struct {
   struct file file[NFILE];
 } ftable;
 
+/** 初始化全局打开文件表。 */
 void
 fileinit(void)
 {
   initlock(&ftable.lock, "ftable");
 }
 
-// Allocate a file structure.
+/** 分配一个带引用的文件表项。 */
 struct file*
 filealloc(void)
 {
-  struct file *f;
-
   acquire(&ftable.lock);
-  for(f = ftable.file; f < ftable.file + NFILE; f++){
+  for(struct file *f = ftable.file; f < ftable.file + NFILE; f++){
     if(f->ref == 0){
       f->ref = 1;
       release(&ftable.lock);
@@ -43,7 +42,7 @@ filealloc(void)
   return 0;
 }
 
-// Increment ref count for file f.
+/** 复制一个打开文件引用。 */
 struct file*
 filedup(struct file *f)
 {
@@ -55,14 +54,13 @@ filedup(struct file *f)
   return f;
 }
 
-// Close file f.  (Decrement ref count, close when reaches 0.)
+/** 释放打开文件引用，并在最后一个引用关闭时释放底层对象。 */
 void
 fileclose(struct file *f)
 {
   struct file ff;
 
-  // raw console ownership belongs to the current PID plus this file object.
-  // Run the non-sleeping cleanup before ftable may invalidate the final reference.
+  // raw console 所有权同时绑定 PID 与 file 对象；必须在 ftable 失效前回收。
   if(f->type == FD_DEVICE && f->major == CONSOLE)
     consolefileclose(f, myproc()->pid);
 
@@ -87,33 +85,31 @@ fileclose(struct file *f)
   }
 }
 
-// Get metadata about file f.
-// addr is a user virtual address, pointing to a struct stat.
+/** 把 inode 元数据复制到用户态 stat。 */
 int
 filestat(struct file *f, uint64 addr)
 {
   struct proc *p = myproc();
   struct stat st;
-  
+
   if(f->type == FD_INODE || f->type == FD_DEVICE){
     ilock(f->ip);
     stati(f->ip, &st);
     iunlock(f->ip);
-    if(copyout(p->pagetable, addr, (char *)&st, sizeof(st)) < 0)
+    if(copyout(p->pagetable, addr, (char*)&st, sizeof(st)) < 0)
       return -1;
     return 0;
   }
   return -1;
 }
 
-// Read from file f.
-// addr is a user virtual address.
+/** 从文件读取并推进 64 位打开文件偏移。 */
 int
 fileread(struct file *f, uint64 addr, int n)
 {
   int r = 0;
 
-  if(f->readable == 0)
+  if(!f->readable)
     return -1;
 
   if(f->type == FD_PIPE){
@@ -130,18 +126,21 @@ fileread(struct file *f, uint64 addr, int n)
   } else {
     panic("fileread");
   }
-
   return r;
 }
 
-// Write to file f.
-// addr is a user virtual address.
+/**
+ * 写入文件并推进 64 位打开文件偏移。
+ *
+ * 每个分片都小于日志预留上限。磁盘满时允许返回短写：已经完成的字节被提交
+ * 并返回给用户，而不是因为 short write 触发 panic。
+ */
 int
 filewrite(struct file *f, uint64 addr, int n)
 {
   int r, ret = 0;
 
-  if(f->writable == 0)
+  if(!f->writable)
     return -1;
 
   if(f->type == FD_PIPE){
@@ -151,14 +150,9 @@ filewrite(struct file *f, uint64 addr, int n)
       return -1;
     ret = devsw[f->major].write(1, addr, n);
   } else if(f->type == FD_INODE){
-    // write a few blocks at a time to avoid exceeding
-    // the maximum log transaction size, including
-    // i-node, indirect block, allocation blocks,
-    // and 2 blocks of slop for non-aligned writes.
-    // this really belongs lower down, since writei()
-    // might be writing a device like the console.
-    int max = ((MAXOPBLOCKS-1-1-2) / 2) * BSIZE;
+    int max = ((MAXOPBLOCKS - 1 - 1 - 2) / 2) * BSIZE;
     int i = 0;
+
     while(i < n){
       int n1 = n - i;
       if(n1 > max)
@@ -166,18 +160,25 @@ filewrite(struct file *f, uint64 addr, int n)
 
       begin_op();
       ilock(f->ip);
-      if ((r = writei(f->ip, 1, addr + i, f->off, n1)) > 0)
+      r = writei(f->ip, 1, addr + i, f->off, n1);
+      if(r > 0)
         f->off += r;
       iunlock(f->ip);
       end_op();
 
-      if(r < 0)
+      if(r <= 0)
         break;
-      if(r != n1)
-        panic("short filewrite");
       i += r;
+      if(r != n1)
+        break;
     }
-    ret = (i == n ? n : -1);
+
+    if(i == n)
+      ret = n;
+    else if(i > 0)
+      ret = i;
+    else
+      ret = -1;
   } else {
     panic("filewrite");
   }

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -5,13 +5,13 @@ struct file {
   char writable;
   struct pipe *pipe; // FD_PIPE
   struct inode *ip;  // FD_INODE and FD_DEVICE
-  uint off;          // FD_INODE
+  uint64 off;        // FD_INODE
   short major;       // FD_DEVICE
 };
 
 #define major(dev)  ((dev) >> 16 & 0xFFFF)
 #define minor(dev)  ((dev) & 0xFFFF)
-#define	mkdev(m,n)  ((uint)((m)<<16| (n)))
+#define mkdev(m,n)  ((uint)((m)<<16| (n)))
 
 // in-memory copy of an inode
 struct inode {
@@ -25,8 +25,8 @@ struct inode {
   short major;
   short minor;
   short nlink;
-  uint size;
-  uint addrs[NDIRECT+2];
+  uint64 size;
+  uint addrs[NDIRECT+NINDIRECT_LEVELS];
 };
 
 // map major device number to device functions.

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -1,13 +1,9 @@
-// File system implementation.  Five layers:
+// File system implementation. Five layers:
 //   + Blocks: allocator for raw disk blocks.
 //   + Log: crash recovery for multi-step updates.
 //   + Files: inode allocator, reading, writing, metadata.
-//   + Directories: inode with special contents (list of other inodes!)
+//   + Directories: inode with special contents (list of other inodes).
 //   + Names: paths like /usr/rtm/xv6/fs.c for convenient naming.
-//
-// This file contains the low-level file system manipulation
-// routines.  The (higher-level) system call implementations
-// are in sysfile.c.
 
 #include "types.h"
 #include "riscv.h"
@@ -22,70 +18,137 @@
 #include "file.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
-// there should be one superblock per disk device, but we run with
-// only one device
-struct superblock sb; 
 
-// Read the super block.
+typedef char dinode_must_remain_64_bytes[(sizeof(struct dinode) == 64) ? 1 : -1];
+
+// There should be one superblock per disk device, but xv6 uses one device.
+struct superblock sb;
+
+// Protects the allocation cursor only. Bitmap contents remain synchronized by
+// the buffer cache sleeplock for each bitmap block.
+static struct spinlock balloc_lock;
+static uint balloc_cursor;
+
+/**
+ * Read the file-system superblock from device dev.
+ *
+ * @param dev Disk device number.
+ * @param out Destination superblock.
+ */
 static void
-readsb(int dev, struct superblock *sb)
+readsb(int dev, struct superblock *out)
 {
-  struct buf *bp;
-
-  bp = bread(dev, 1);
-  memmove(sb, bp->data, sizeof(*sb));
+  struct buf *bp = bread(dev, 1);
+  memmove(out, bp->data, sizeof(*out));
   brelse(bp);
 }
 
-// Init fs
+/**
+ * Initialize the file system and recover its write-ahead log.
+ *
+ * @param dev Root file-system device.
+ */
 void
-fsinit(int dev) {
+fsinit(int dev)
+{
   readsb(dev, &sb);
   if(sb.magic != FSMAGIC)
     panic("invalid file system");
+
+  initlock(&balloc_lock, "balloc");
+  balloc_cursor = sb.size - sb.nblocks;
   initlog(dev, &sb);
 }
 
-// Zero a block.
+/**
+ * Zero an allocated block inside the caller's log transaction.
+ *
+ * @param dev Disk device number.
+ * @param bno Block number to clear.
+ */
 static void
 bzero(int dev, int bno)
 {
-  struct buf *bp;
-
-  bp = bread(dev, bno);
+  struct buf *bp = bread(dev, bno);
   memset(bp->data, 0, BSIZE);
   log_write(bp);
   brelse(bp);
 }
 
-// Blocks.
+/**
+ * Search one half-open data-block range for a free bitmap entry.
+ *
+ * @param dev Disk device number.
+ * @param start First candidate block.
+ * @param end One-past-last candidate block.
+ * @return Allocated block number, or zero when the range is full.
+ */
+static uint
+balloc_range(uint dev, uint start, uint end)
+{
+  for(uint b = start; b < end;){
+    uint bitmap_base = b - b % BPB;
+    struct buf *bp = bread(dev, BBLOCK(b, sb));
+    uint first_bit = b - bitmap_base;
 
-// Allocate a zeroed disk block.
+    for(uint bi = first_bit; bi < BPB && bitmap_base + bi < end; bi++){
+      int mask = 1 << (bi % 8);
+      if((bp->data[bi / 8] & mask) == 0){
+        uint allocated = bitmap_base + bi;
+        bp->data[bi / 8] |= mask;
+        log_write(bp);
+        brelse(bp);
+        bzero(dev, allocated);
+        return allocated;
+      }
+    }
+
+    brelse(bp);
+    b = bitmap_base + BPB;
+  }
+  return 0;
+}
+
+/**
+ * Allocate and zero one disk block.
+ *
+ * A short-lived cursor keeps sequential allocation linear instead of rescanning
+ * all preceding bitmap bits for every block. Concurrent callers may start from
+ * the same hint, but the bitmap buffer sleeplock still makes the allocation
+ * decision atomic. Disk exhaustion returns zero instead of panicking.
+ *
+ * @param dev Disk device number.
+ * @return Allocated block number, or zero when the device is full.
+ */
 static uint
 balloc(uint dev)
 {
-  int b, bi, m;
-  struct buf *bp;
+  uint data_start = sb.size - sb.nblocks;
 
-  bp = 0;
-  for(b = 0; b < sb.size; b += BPB){
-    bp = bread(dev, BBLOCK(b, sb));
-    for(bi = 0; bi < BPB && b + bi < sb.size; bi++){
-      m = 1 << (bi % 8);
-      if((bp->data[bi/8] & m) == 0){  // Is block free?
-        bp->data[bi/8] |= m;  // Mark block in use.
-        log_write(bp);
-        brelse(bp);
-        bzero(dev, b + bi);
-        return b + bi;
-      }
-    }
-    brelse(bp);
-  }
-  panic("balloc: out of blocks");
+  acquire(&balloc_lock);
+  uint start = balloc_cursor;
+  release(&balloc_lock);
+
+  uint allocated = balloc_range(dev, start, sb.size);
+  if(allocated == 0 && start > data_start)
+    allocated = balloc_range(dev, data_start, start);
+  if(allocated == 0)
+    return 0;
+
+  acquire(&balloc_lock);
+  balloc_cursor = allocated + 1;
+  if(balloc_cursor >= sb.size)
+    balloc_cursor = data_start;
+  release(&balloc_lock);
+  return allocated;
 }
 
-// Free a disk block.
+/**
+ * Return one allocated block to the free bitmap.
+ *
+ * @param dev Disk device number.
+ * @param b Allocated block number.
+ */
 static void
 bfree(int dev, uint b)
 {
@@ -104,108 +167,41 @@ bfree(int dev, uint b)
 
 // Inodes.
 //
-// An inode describes a single unnamed file.
-// The inode disk structure holds metadata: the file's type,
-// its size, the number of links referring to it, and the
-// list of blocks holding the file's content.
-//
-// The inodes are laid out sequentially on disk at
-// sb.startinode. Each inode has a number, indicating its
-// position on the disk.
-//
-// The kernel keeps a cache of in-use inodes in memory
-// to provide a place for synchronizing access
-// to inodes used by multiple processes. The cached
-// inodes include book-keeping information that is
-// not stored on disk: ip->ref and ip->valid.
-//
-// An inode and its in-memory representation go through a
-// sequence of states before they can be used by the
-// rest of the file system code.
-//
-// * Allocation: an inode is allocated if its type (on disk)
-//   is non-zero. ialloc() allocates, and iput() frees if
-//   the reference and link counts have fallen to zero.
-//
-// * Referencing in cache: an entry in the inode cache
-//   is free if ip->ref is zero. Otherwise ip->ref tracks
-//   the number of in-memory pointers to the entry (open
-//   files and current directories). iget() finds or
-//   creates a cache entry and increments its ref; iput()
-//   decrements ref.
-//
-// * Valid: the information (type, size, &c) in an inode
-//   cache entry is only correct when ip->valid is 1.
-//   ilock() reads the inode from
-//   the disk and sets ip->valid, while iput() clears
-//   ip->valid if ip->ref has fallen to zero.
-//
-// * Locked: file system code may only examine and modify
-//   the information in an inode and its content if it
-//   has first locked the inode.
-//
-// Thus a typical sequence is:
-//   ip = iget(dev, inum)
-//   ilock(ip)
-//   ... examine and modify ip->xxx ...
-//   iunlock(ip)
-//   iput(ip)
-//
-// ilock() is separate from iget() so that system calls can
-// get a long-term reference to an inode (as for an open file)
-// and only lock it for short periods (e.g., in read()).
-// The separation also helps avoid deadlock and races during
-// pathname lookup. iget() increments ip->ref so that the inode
-// stays cached and pointers to it remain valid.
-//
-// Many internal file system functions expect the caller to
-// have locked the inodes involved; this lets callers create
-// multi-step atomic operations.
-//
-// The icache.lock spin-lock protects the allocation of icache
-// entries. Since ip->ref indicates whether an entry is free,
-// and ip->dev and ip->inum indicate which i-node an entry
-// holds, one must hold icache.lock while using any of those fields.
-//
-// An ip->lock sleep-lock protects all ip-> fields other than ref,
-// dev, and inum.  One must hold ip->lock in order to
-// read or write that inode's ip->valid, ip->size, ip->type, &c.
-
+// The icache spinlock protects cache identity and reference counts. Each inode
+// sleeplock protects the on-disk fields mirrored below ref/dev/inum.
 struct {
   struct spinlock lock;
   struct inode inode[NINODE];
 } icache;
 
+/** Initialize inode-cache locks. */
 void
-iinit()
+iinit(void)
 {
-  int i = 0;
-  
   initlock(&icache.lock, "icache");
-  for(i = 0; i < NINODE; i++) {
+  for(int i = 0; i < NINODE; i++)
     initsleeplock(&icache.inode[i].lock, "inode");
-  }
 }
 
 static struct inode* iget(uint dev, uint inum);
 
-// Allocate an inode on device dev.
-// Mark it as allocated by  giving it type type.
-// Returns an unlocked but allocated and referenced inode.
+/**
+ * Allocate an on-disk inode and return an unlocked cache reference.
+ *
+ * @param dev Disk device number.
+ * @param type Initial inode type.
+ * @return Referenced inode; panics only when the fixed inode table is full.
+ */
 struct inode*
 ialloc(uint dev, short type)
 {
-  int inum;
-  struct buf *bp;
-  struct dinode *dip;
-
-  for(inum = 1; inum < sb.ninodes; inum++){
-    bp = bread(dev, IBLOCK(inum, sb));
-    dip = (struct dinode*)bp->data + inum%IPB;
-    if(dip->type == 0){  // a free inode
+  for(int inum = 1; inum < sb.ninodes; inum++){
+    struct buf *bp = bread(dev, IBLOCK(inum, sb));
+    struct dinode *dip = (struct dinode*)bp->data + inum % IPB;
+    if(dip->type == 0){
       memset(dip, 0, sizeof(*dip));
       dip->type = type;
-      log_write(bp);   // mark it allocated on the disk
+      log_write(bp);
       brelse(bp);
       return iget(dev, inum);
     }
@@ -214,18 +210,17 @@ ialloc(uint dev, short type)
   panic("ialloc: no inodes");
 }
 
-// Copy a modified in-memory inode to disk.
-// Must be called after every change to an ip->xxx field
-// that lives on disk, since i-node cache is write-through.
-// Caller must hold ip->lock.
+/**
+ * Write all persistent fields of a locked in-memory inode to disk.
+ *
+ * @param ip Locked inode to persist.
+ */
 void
 iupdate(struct inode *ip)
 {
-  struct buf *bp;
-  struct dinode *dip;
+  struct buf *bp = bread(ip->dev, IBLOCK(ip->inum, sb));
+  struct dinode *dip = (struct dinode*)bp->data + ip->inum % IPB;
 
-  bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-  dip = (struct dinode*)bp->data + ip->inum%IPB;
   dip->type = ip->type;
   dip->major = ip->major;
   dip->minor = ip->minor;
@@ -236,29 +231,22 @@ iupdate(struct inode *ip)
   brelse(bp);
 }
 
-// Find the inode with number inum on device dev
-// and return the in-memory copy. Does not lock
-// the inode and does not read it from disk.
+/** Find or create an inode-cache reference without locking the inode. */
 static struct inode*
 iget(uint dev, uint inum)
 {
-  struct inode *ip, *empty;
+  struct inode *ip, *empty = 0;
 
   acquire(&icache.lock);
-
-  // Is the inode already cached?
-  empty = 0;
   for(ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++){
     if(ip->ref > 0 && ip->dev == dev && ip->inum == inum){
       ip->ref++;
       release(&icache.lock);
       return ip;
     }
-    if(empty == 0 && ip->ref == 0)    // Remember empty slot.
+    if(empty == 0 && ip->ref == 0)
       empty = ip;
   }
-
-  // Recycle an inode cache entry.
   if(empty == 0)
     panic("iget: no inodes");
 
@@ -268,12 +256,10 @@ iget(uint dev, uint inum)
   ip->ref = 1;
   ip->valid = 0;
   release(&icache.lock);
-
   return ip;
 }
 
-// Increment reference count for ip.
-// Returns ip to enable ip = idup(ip1) idiom.
+/** Increment an inode reference count. */
 struct inode*
 idup(struct inode *ip)
 {
@@ -283,22 +269,21 @@ idup(struct inode *ip)
   return ip;
 }
 
-// Lock the given inode.
-// Reads the inode from disk if necessary.
+/**
+ * Lock an inode and lazily populate its persistent fields.
+ *
+ * @param ip Referenced inode to lock.
+ */
 void
 ilock(struct inode *ip)
 {
-  struct buf *bp;
-  struct dinode *dip;
-
   if(ip == 0 || ip->ref < 1)
     panic("ilock");
 
   acquiresleep(&ip->lock);
-
   if(ip->valid == 0){
-    bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-    dip = (struct dinode*)bp->data + ip->inum%IPB;
+    struct buf *bp = bread(ip->dev, IBLOCK(ip->inum, sb));
+    struct dinode *dip = (struct dinode*)bp->data + ip->inum % IPB;
     ip->type = dip->type;
     ip->major = dip->major;
     ip->minor = dip->minor;
@@ -312,35 +297,30 @@ ilock(struct inode *ip)
   }
 }
 
-// Unlock the given inode.
+/** Unlock a referenced inode. */
 void
 iunlock(struct inode *ip)
 {
   if(ip == 0 || !holdingsleep(&ip->lock) || ip->ref < 1)
     panic("iunlock");
-
   releasesleep(&ip->lock);
 }
 
-// Drop a reference to an in-memory inode.
-// If that was the last reference, the inode cache entry can
-// be recycled.
-// If that was the last reference and the inode has no links
-// to it, free the inode (and its content) on disk.
-// All calls to iput() must be inside a transaction in
-// case it has to free the inode.
+/**
+ * Drop an inode reference and reclaim an unlinked final inode.
+ *
+ * The caller must be inside a log transaction. A large inode can touch hundreds
+ * of bitmap blocks while truncating; log.c therefore supports a multi-block
+ * commit header and param.h provides enough pinned buffers for the transaction.
+ *
+ * @param ip Referenced inode to release.
+ */
 void
 iput(struct inode *ip)
 {
   acquire(&icache.lock);
-
   if(ip->ref == 1 && ip->valid && ip->nlink == 0){
-    // inode has no links and no other references: truncate and free.
-
-    // ip->ref == 1 means no other process can have ip locked,
-    // so this acquiresleep() won't block (or deadlock).
     acquiresleep(&ip->lock);
-
     release(&icache.lock);
 
     itrunc(ip);
@@ -349,15 +329,13 @@ iput(struct inode *ip)
     ip->valid = 0;
 
     releasesleep(&ip->lock);
-
     acquire(&icache.lock);
   }
-
   ip->ref--;
   release(&icache.lock);
 }
 
-// Common idiom: unlock, then put.
+/** Unlock an inode and drop the caller's reference. */
 void
 iunlockput(struct inode *ip)
 {
@@ -365,51 +343,74 @@ iunlockput(struct inode *ip)
   iput(ip);
 }
 
-// 每个 inode 先保存直接块地址，随后每个槽位分别保存一棵
-// 深度为 1、2 ... 的间接索引树根块。
-#define NINDIRECT_LEVELS 2
-
 static const uint64 indirect_capacity[NINDIRECT_LEVELS] = {
   NINDIRECT,
   NDOUBLEINDIRECT,
+  NTRIPLEINDIRECT,
 };
 
-// 沿指定深度的间接索引树逐层定位数据块；缺失的索引块或数据块按需分配。
+/**
+ * Walk one indirect tree and optionally allocate missing nodes.
+ *
+ * @param ip Locked inode that owns the root.
+ * @param addr Root index-block address.
+ * @param bn Block number relative to this tree.
+ * @param depth Tree depth: 1, 2, or 3.
+ * @param alloc Non-zero to allocate missing index/data blocks.
+ * @return Data block address, or zero for a missing block/allocation failure.
+ */
 static uint
-bmap_indirect(struct inode *ip, uint addr, uint64 bn, int depth)
+bmap_indirect(struct inode *ip, uint addr, uint64 bn, int depth, int alloc)
 {
   uint64 divisor = 1;
 
-  // divisor 表示当前层一个入口能够覆盖的叶子数据块数量。
   for(int level = 1; level < depth; level++)
     divisor *= NINDIRECT;
 
   for(int level = depth; level > 0; level--){
+    if(addr == 0)
+      return 0;
+
     struct buf *bp = bread(ip->dev, addr);
     uint *entries = (uint*)bp->data;
     uint index = bn / divisor;
-
     bn %= divisor;
+
     if(entries[index] == 0){
-      entries[index] = balloc(ip->dev);
+      if(!alloc){
+        brelse(bp);
+        return 0;
+      }
+      uint allocated = balloc(ip->dev);
+      if(allocated == 0){
+        brelse(bp);
+        return 0;
+      }
+      entries[index] = allocated;
       log_write(bp);
     }
+
     addr = entries[index];
     brelse(bp);
-
     if(level > 1)
       divisor /= NINDIRECT;
   }
-
   return addr;
 }
 
-// 返回 inode 中第 bn 个逻辑数据块对应的磁盘块号；不存在时按需分配。
+/**
+ * Resolve an inode-relative data-block number.
+ *
+ * @param ip Locked inode.
+ * @param bn Zero-based data-block number in the file.
+ * @param alloc Non-zero to allocate missing blocks.
+ * @return Disk block number, or zero when absent/full/out of range.
+ */
 static uint
-bmap(struct inode *ip, uint bn)
+bmap(struct inode *ip, uint64 bn, int alloc)
 {
   if(bn < NDIRECT){
-    if(ip->addrs[bn] == 0)
+    if(ip->addrs[bn] == 0 && alloc)
       ip->addrs[bn] = balloc(ip->dev);
     return ip->addrs[bn];
   }
@@ -417,17 +418,21 @@ bmap(struct inode *ip, uint bn)
   uint64 indirect_bn = bn - NDIRECT;
   for(int depth = 1; depth <= NINDIRECT_LEVELS; depth++){
     uint64 capacity = indirect_capacity[depth - 1];
-
     if(indirect_bn < capacity){
       uint root_index = NDIRECT + depth - 1;
-      if(ip->addrs[root_index] == 0)
+      if(ip->addrs[root_index] == 0){
+        if(!alloc)
+          return 0;
         ip->addrs[root_index] = balloc(ip->dev);
-      return bmap_indirect(ip, ip->addrs[root_index], indirect_bn, depth);
+        if(ip->addrs[root_index] == 0)
+          return 0;
+      }
+      return bmap_indirect(ip, ip->addrs[root_index], indirect_bn,
+                           depth, alloc);
     }
     indirect_bn -= capacity;
   }
-
-  panic("bmap: out of range");
+  return 0;
 }
 
 struct indirect_frame {
@@ -436,7 +441,13 @@ struct indirect_frame {
   struct buf *bp;
 };
 
-// 使用显式栈后序遍历间接索引树：先释放叶子数据块，再逐层释放索引块。
+/**
+ * Free an indirect tree in iterative post-order.
+ *
+ * @param dev Disk device number.
+ * @param root Root index block.
+ * @param depth Tree depth from 1 through 3.
+ */
 static void
 bfree_indirect(uint dev, uint root, int depth)
 {
@@ -452,14 +463,12 @@ bfree_indirect(uint dev, uint root, int depth)
     uint *entries = (uint*)frame->bp->data;
 
     if(level == depth - 1){
-      // 最后一层索引块直接指向数据块。
       while(frame->next < NINDIRECT){
         uint addr = entries[frame->next++];
         if(addr)
           bfree(dev, addr);
       }
     } else {
-      // 中间层索引块指向下一层索引块，逐个压栈处理。
       while(frame->next < NINDIRECT && entries[frame->next] == 0)
         frame->next++;
       if(frame->next < NINDIRECT){
@@ -478,8 +487,11 @@ bfree_indirect(uint dev, uint root, int depth)
   }
 }
 
-// 截断 inode 并释放全部数据块和各级间接索引块。
-// 调用者必须持有 ip->lock。
+/**
+ * Truncate a locked inode and free every direct/index/data block.
+ *
+ * @param ip Locked inode to clear.
+ */
 void
 itrunc(struct inode *ip)
 {
@@ -502,8 +514,7 @@ itrunc(struct inode *ip)
   iupdate(ip);
 }
 
-// Copy stat information from inode.
-// Caller must hold ip->lock.
+/** Copy persistent inode metadata into a user-visible stat structure. */
 void
 stati(struct inode *ip, struct stat *st)
 {
@@ -514,81 +525,114 @@ stati(struct inode *ip, struct stat *st)
   st->size = ip->size;
 }
 
-// Read data from inode.
-// Caller must hold ip->lock.
-// If user_dst==1, then dst is a user virtual address;
-// otherwise, dst is a kernel address.
+/**
+ * Read bytes from a locked inode without allocating missing blocks.
+ *
+ * @param ip Locked inode.
+ * @param user_dst Whether dst is a user virtual address.
+ * @param dst Destination address.
+ * @param off 64-bit file offset.
+ * @param n Maximum bytes to read.
+ * @return Bytes copied, zero at EOF, or -1 when the first required block is
+ *         missing/copyout fails.
+ */
 int
-readi(struct inode *ip, int user_dst, uint64 dst, uint off, uint n)
+readi(struct inode *ip, int user_dst, uint64 dst, uint64 off, uint n)
 {
-  uint tot, m;
-  struct buf *bp;
+  uint tot = 0;
 
-  if(off > ip->size || off + n < off)
+  if(off > ip->size)
     return 0;
-  if(off + n > ip->size)
+  if((uint64)n > ip->size - off)
     n = ip->size - off;
 
-  for(tot=0; tot<n; tot+=m, off+=m, dst+=m){
-    bp = bread(ip->dev, bmap(ip, off/BSIZE));
-    m = min(n - tot, BSIZE - off%BSIZE);
-    if(either_copyout(user_dst, dst, bp->data + (off % BSIZE), m) == -1) {
+  while(tot < n){
+    uint addr = bmap(ip, off / BSIZE, 0);
+    if(addr == 0)
+      break;
+    struct buf *bp = bread(ip->dev, addr);
+    uint m = min(n - tot, BSIZE - off % BSIZE);
+    if(either_copyout(user_dst, dst, bp->data + off % BSIZE, m) == -1){
       brelse(bp);
       break;
     }
     brelse(bp);
+    tot += m;
+    off += m;
+    dst += m;
   }
+
+  if(tot == 0 && n != 0)
+    return -1;
   return tot;
 }
 
-// Write data to inode.
-// Caller must hold ip->lock.
-// If user_src==1, then src is a user virtual address;
-// otherwise, src is a kernel address.
+/**
+ * Write bytes to a locked inode using a 64-bit file offset.
+ *
+ * The file remains dense and append-like: callers may overwrite existing data
+ * or write exactly at ip->size, but may not create holes. Disk exhaustion
+ * returns a short write (or -1 before the first byte) and persists every newly
+ * linked index block so later truncation can reclaim it.
+ *
+ * @param ip Locked inode.
+ * @param user_src Whether src is a user virtual address.
+ * @param src Source address.
+ * @param off 64-bit file offset.
+ * @param n Bytes requested.
+ * @return Bytes written, or -1 when no byte could be written.
+ */
 int
-writei(struct inode *ip, int user_src, uint64 src, uint off, uint n)
+writei(struct inode *ip, int user_src, uint64 src, uint64 off, uint n)
 {
-  uint tot, m;
-  struct buf *bp;
+  uint tot = 0;
+  uint64 end = off + (uint64)n;
 
-  if(off > ip->size || off + n < off)
-    return -1;
-  if(off + n > MAXFILE*BSIZE)
+  if(off > ip->size || end < off || end > MAXFILE_BYTES)
     return -1;
 
-  for(tot=0; tot<n; tot+=m, off+=m, src+=m){
-    bp = bread(ip->dev, bmap(ip, off/BSIZE));
-    m = min(n - tot, BSIZE - off%BSIZE);
-    if(either_copyin(bp->data + (off % BSIZE), user_src, src, m) == -1) {
+  while(tot < n){
+    uint addr = bmap(ip, off / BSIZE, 1);
+    if(addr == 0)
+      break;
+
+    struct buf *bp = bread(ip->dev, addr);
+    uint m = min(n - tot, BSIZE - off % BSIZE);
+    if(either_copyin(bp->data + off % BSIZE, user_src, src, m) == -1){
       brelse(bp);
       break;
     }
     log_write(bp);
     brelse(bp);
+
+    tot += m;
+    off += m;
+    src += m;
   }
 
   if(n > 0){
     if(off > ip->size)
       ip->size = off;
-    // write the i-node back to disk even if the size didn't change
-    // because the loop above might have called bmap() and added a new
-    // block to ip->addrs[].
+    // bmap() may have linked a new root before a deeper allocation failed.
+    // Persisting addrs[] keeps that partial tree reachable and reclaimable.
     iupdate(ip);
   }
 
-  return n;
+  if(tot == 0 && n != 0)
+    return -1;
+  return tot;
 }
 
 // Directories
 
+/** Compare two fixed-width directory names. */
 int
 namecmp(const char *s, const char *t)
 {
   return strncmp(s, t, DIRSIZ);
 }
 
-// Look for a directory entry in a directory.
-// If found, set *poff to byte offset of entry.
+/** Look up a name in a locked directory. */
 struct inode*
 dirlookup(struct inode *dp, char *name, uint *poff)
 {
@@ -604,18 +648,16 @@ dirlookup(struct inode *dp, char *name, uint *poff)
     if(de.inum == 0)
       continue;
     if(namecmp(name, de.name) == 0){
-      // entry matches path element
       if(poff)
         *poff = off;
       inum = de.inum;
       return iget(dp->dev, inum);
     }
   }
-
   return 0;
 }
 
-// Write a new directory entry (name, inum) into the directory dp.
+/** Add a directory entry to a locked directory. */
 int
 dirlink(struct inode *dp, char *name, uint inum)
 {
@@ -623,13 +665,11 @@ dirlink(struct inode *dp, char *name, uint inum)
   struct dirent de;
   struct inode *ip;
 
-  // Check that name is not present.
   if((ip = dirlookup(dp, name, 0)) != 0){
     iput(ip);
     return -1;
   }
 
-  // Look for an empty dirent.
   for(off = 0; off < dp->size; off += sizeof(de)){
     if(readi(dp, 0, (uint64)&de, off, sizeof(de)) != sizeof(de))
       panic("dirlink read");
@@ -641,24 +681,12 @@ dirlink(struct inode *dp, char *name, uint inum)
   de.inum = inum;
   if(writei(dp, 0, (uint64)&de, off, sizeof(de)) != sizeof(de))
     panic("dirlink");
-
   return 0;
 }
 
 // Paths
 
-// Copy the next path element from path into name.
-// Return a pointer to the element following the copied one.
-// The returned path has no leading slashes,
-// so the caller can check *path=='\0' to see if the name is the last one.
-// If no name to remove, return 0.
-//
-// Examples:
-//   skipelem("a/bb/c", name) = "bb/c", setting name = "a"
-//   skipelem("///a//bb", name) = "bb", setting name = "a"
-//   skipelem("a", name) = "", setting name = "a"
-//   skipelem("", name) = skipelem("////", name) = 0
-//
+/** Copy one path element into name and return the remaining path. */
 static char*
 skipelem(char *path, char *name)
 {
@@ -684,10 +712,7 @@ skipelem(char *path, char *name)
   return path;
 }
 
-// Look up and return the inode for a path name.
-// If parent != 0, return the inode for the parent and copy the final
-// path element into name, which must have room for DIRSIZ bytes.
-// Must be called inside a transaction since it calls iput().
+/** Resolve a path, optionally stopping at and naming its parent. */
 static struct inode*
 namex(char *path, int nameiparent, char *name)
 {
@@ -705,7 +730,6 @@ namex(char *path, int nameiparent, char *name)
       return 0;
     }
     if(nameiparent && *path == '\0'){
-      // Stop one level early.
       iunlock(ip);
       return ip;
     }
@@ -723,6 +747,7 @@ namex(char *path, int nameiparent, char *name)
   return ip;
 }
 
+/** Resolve a path to an unlocked inode reference. */
 struct inode*
 namei(char *path)
 {
@@ -730,6 +755,7 @@ namei(char *path)
   return namex(path, 0, name);
 }
 
+/** Resolve a path's parent and copy its final component into name. */
 struct inode*
 nameiparent(char *path, char *name)
 {

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -1,7 +1,6 @@
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
 
-
 #define ROOTINO  1   // root i-number
 #define BSIZE 1024  // block size
 
@@ -24,31 +23,35 @@ struct superblock {
 
 #define FSMAGIC 0x10203040
 
-#define NDIRECT 11
-#define NINDIRECT (BSIZE / sizeof(uint))//256
-#define NDOUBLEINDIRECT ((BSIZE / sizeof(uint)) * (BSIZE / sizeof(uint)))//256*256
-#define MAXFILE (NDIRECT + NINDIRECT + NDOUBLEINDIRECT)
+#define NDIRECT 9
+#define NINDIRECT (BSIZE / sizeof(uint))
+#define NDOUBLEINDIRECT ((uint64)NINDIRECT * NINDIRECT)
+#define NTRIPLEINDIRECT (NDOUBLEINDIRECT * NINDIRECT)
+#define NINDIRECT_LEVELS 3
+#define MAXFILE ((uint64)NDIRECT + NINDIRECT + NDOUBLEINDIRECT + NTRIPLEINDIRECT)
+#define MAXFILE_BYTES (MAXFILE * (uint64)BSIZE)
 
-// On-disk inode structure
+// On-disk inode structure. Keep this structure exactly 64 bytes so that the
+// inode density and the surrounding disk layout stay stable.
 struct dinode {
-  short type;           // File type
-  short major;          // Major device number (T_DEVICE only)
-  short minor;          // Minor device number (T_DEVICE only)
-  short nlink;          // Number of links to inode in file system
-  uint size;            // Size of file (bytes)
-  uint addrs[NDIRECT+2];   // Data block addresses
+  short type;                        // File type
+  short major;                       // Major device number (T_DEVICE only)
+  short minor;                       // Minor device number (T_DEVICE only)
+  short nlink;                       // Number of links to inode in file system
+  uint64 size;                       // Size of file (bytes)
+  uint addrs[NDIRECT+NINDIRECT_LEVELS]; // Direct and 1/2/3-level index roots
 };
 
 // Inodes per block.
-#define IPB           (BSIZE / sizeof(struct dinode))
+#define IPB (BSIZE / sizeof(struct dinode))
 
-// Block containing inode i
-#define IBLOCK(i, sb)     ((i) / IPB + sb.inodestart)
+// Block containing inode i.
+#define IBLOCK(i, sb) ((i) / IPB + sb.inodestart)
 
-// Bitmap bits per block
-#define BPB           (BSIZE*8)
+// Bitmap bits per block.
+#define BPB (BSIZE*8)
 
-// Block of free map containing bit for block b
+// Block of free map containing bit for block b.
 #define BBLOCK(b, sb) ((b)/BPB + sb.bmapstart)
 
 // Directory is a file containing a sequence of dirent structures.
@@ -58,4 +61,3 @@ struct dirent {
   ushort inum;
   char name[DIRSIZ];
 };
-

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -7,31 +7,14 @@
 #include "fs.h"
 #include "buf.h"
 
-// Simple logging that allows concurrent FS system calls.
-//
-// A log transaction contains the updates of multiple FS system
-// calls. The logging system only commits when there are
-// no FS system calls active. Thus there is never
-// any reasoning required about whether a commit might
-// write an uncommitted system call's updates to disk.
-//
-// A system call should call begin_op()/end_op() to mark
-// its start and end. Usually begin_op() just increments
-// the count of in-progress FS system calls and returns.
-// But if it thinks the log is close to running out, it
-// sleeps until the last outstanding end_op() commits.
-//
-// The log is a physical re-do log containing disk blocks.
-// The on-disk log format:
-//   header block, containing block #s for block A, B, C, ...
-//   block A
-//   block B
-//   block C
-//   ...
-// Log appends are synchronous.
+#define min(a, b) ((a) < (b) ? (a) : (b))
 
-// Contents of the header block, used for both the on-disk header block
-// and to keep track in memory of logged block# before commit.
+// 物理 redo log。所有数据块和续接头块落盘后，最后写入首头块中的 n，
+// 由这一块原子发布事务；安装完成后清零 n。
+
+#define LOG_FIRST_HEADER_ENTRIES ((BSIZE - sizeof(int)) / sizeof(int))
+#define LOG_NEXT_HEADER_ENTRIES  (BSIZE / sizeof(int))
+
 struct logheader {
   int n;
   int block[LOGSIZE];
@@ -40,194 +23,257 @@ struct logheader {
 struct log {
   struct spinlock lock;
   int start;
-  int size;
-  int outstanding; // how many FS sys calls are executing.
-  int committing;  // in commit(), please wait.
+  int size;          // 可用数据槽数量，不包含固定头块。
+  int header_blocks;
+  int outstanding;
+  int committing;
   int dev;
   struct logheader lh;
 };
+
 struct log log;
 
 static void recover_from_log(void);
-static void commit();
+static void commit(void);
 
+/** 返回编码最大日志头所需的固定磁盘块数。 */
+static int
+log_header_block_count(void)
+{
+  if(LOGSIZE <= LOG_FIRST_HEADER_ENTRIES)
+    return 1;
+  return 1 + (LOGSIZE - LOG_FIRST_HEADER_ENTRIES +
+              LOG_NEXT_HEADER_ENTRIES - 1) / LOG_NEXT_HEADER_ENTRIES;
+}
+
+/** 返回编码 n 个 home block 编号实际需要的头块数。 */
+static int
+header_blocks_for_entries(int n)
+{
+  if(n <= LOG_FIRST_HEADER_ENTRIES)
+    return 1;
+  return 1 + (n - LOG_FIRST_HEADER_ENTRIES +
+              LOG_NEXT_HEADER_ENTRIES - 1) / LOG_NEXT_HEADER_ENTRIES;
+}
+
+/** 返回第一个日志数据镜像块的位置。 */
+static int
+log_data_start(void)
+{
+  return log.start + log.header_blocks;
+}
+
+/** 初始化日志几何信息并恢复已发布但未安装的事务。 */
 void
 initlog(int dev, struct superblock *sb)
 {
-  if (sizeof(struct logheader) >= BSIZE)
-    panic("initlog: too big logheader");
-
   initlock(&log.lock, "log");
   log.start = sb->logstart;
-  log.size = sb->nlog;
+  log.header_blocks = log_header_block_count();
+  log.size = sb->nlog - log.header_blocks;
   log.dev = dev;
+
+  if(log.size < MAXOPBLOCKS || log.size > LOGSIZE)
+    panic("initlog: invalid log size");
+
   recover_from_log();
 }
 
-// Copy committed blocks from log to their home location
+/** 把每个已提交日志镜像复制回 home block。 */
 static void
-install_trans(void)
+install_trans(int recovering)
 {
-  int tail;
-
-  for (tail = 0; tail < log.lh.n; tail++) {
-    struct buf *lbuf = bread(log.dev, log.start+tail+1); // read log block
-    struct buf *dbuf = bread(log.dev, log.lh.block[tail]); // read dst
-    memmove(dbuf->data, lbuf->data, BSIZE);  // copy block to dst
-    bwrite(dbuf);  // write dst to disk
-    bunpin(dbuf);
+  for(int tail = 0; tail < log.lh.n; tail++){
+    struct buf *lbuf = bread(log.dev, log_data_start() + tail);
+    struct buf *dbuf = bread(log.dev, log.lh.block[tail]);
+    memmove(dbuf->data, lbuf->data, BSIZE);
+    bwrite(dbuf);
+    if(!recovering)
+      bunpin(dbuf);
     brelse(lbuf);
     brelse(dbuf);
   }
 }
 
-// Read the log header from disk into the in-memory log header
+/** 从多块日志头恢复已发布的 home block 列表。 */
 static void
 read_head(void)
 {
-  struct buf *buf = bread(log.dev, log.start);
-  struct logheader *lh = (struct logheader *) (buf->data);
-  int i;
-  log.lh.n = lh->n;
-  for (i = 0; i < log.lh.n; i++) {
-    log.lh.block[i] = lh->block[i];
+  struct buf *first = bread(log.dev, log.start);
+  int *words = (int*)first->data;
+  int n = words[0];
+
+  if(n < 0 || n > log.size || n > LOGSIZE){
+    brelse(first);
+    panic("read_head: invalid count");
   }
-  brelse(buf);
+
+  log.lh.n = n;
+  int copied = min(n, LOG_FIRST_HEADER_ENTRIES);
+  for(int i = 0; i < copied; i++)
+    log.lh.block[i] = words[i + 1];
+  brelse(first);
+
+  int needed = header_blocks_for_entries(n);
+  for(int header = 1; header < needed; header++){
+    struct buf *bp = bread(log.dev, log.start + header);
+    int *entries = (int*)bp->data;
+    int remaining = n - copied;
+    int count = min(remaining, LOG_NEXT_HEADER_ENTRIES);
+    for(int i = 0; i < count; i++)
+      log.lh.block[copied + i] = entries[i];
+    copied += count;
+    brelse(bp);
+  }
 }
 
-// Write in-memory log header to disk.
-// This is the true point at which the
-// current transaction commits.
+/**
+ * 持久化内存日志头。
+ *
+ * 先写续接头块，最后写含 n 的首头块，使单块写入仍是事务发布点。
+ */
 static void
 write_head(void)
 {
-  struct buf *buf = bread(log.dev, log.start);
-  struct logheader *hb = (struct logheader *) (buf->data);
-  int i;
-  hb->n = log.lh.n;
-  for (i = 0; i < log.lh.n; i++) {
-    hb->block[i] = log.lh.block[i];
+  int n = log.lh.n;
+
+  if(n == 0){
+    struct buf *bp = bread(log.dev, log.start);
+    memset(bp->data, 0, BSIZE);
+    bwrite(bp);
+    brelse(bp);
+    return;
   }
-  bwrite(buf);
-  brelse(buf);
+
+  int needed = header_blocks_for_entries(n);
+  int copied = LOG_FIRST_HEADER_ENTRIES;
+  for(int header = 1; header < needed; header++){
+    struct buf *bp = bread(log.dev, log.start + header);
+    memset(bp->data, 0, BSIZE);
+    int *entries = (int*)bp->data;
+    int remaining = n - copied;
+    int count = min(remaining, LOG_NEXT_HEADER_ENTRIES);
+    for(int i = 0; i < count; i++)
+      entries[i] = log.lh.block[copied + i];
+    copied += count;
+    bwrite(bp);
+    brelse(bp);
+  }
+
+  struct buf *first = bread(log.dev, log.start);
+  memset(first->data, 0, BSIZE);
+  int *words = (int*)first->data;
+  int count = min(n, LOG_FIRST_HEADER_ENTRIES);
+  for(int i = 0; i < count; i++)
+    words[i + 1] = log.lh.block[i];
+  words[0] = n;
+  bwrite(first);
+  brelse(first);
 }
 
+/** 重放已发布事务并清除其提交标记。 */
 static void
 recover_from_log(void)
 {
   read_head();
-  install_trans(); // if committed, copy from log to disk
+  install_trans(1);
   log.lh.n = 0;
-  write_head(); // clear the log
+  write_head();
 }
 
-// Caller must hold log.lock.
+/** 在持锁状态判断能否再预留一个最坏文件系统操作。 */
 static int
 log_has_space_for_new_op_locked(void)
 {
-  int reserved;
-
-  reserved = log.lh.n + (log.outstanding + 1) * MAXOPBLOCKS;
-  return reserved <= LOGSIZE;
+  int reserved = log.lh.n + (log.outstanding + 1) * MAXOPBLOCKS;
+  return reserved <= log.size;
 }
 
-// called at the start of each FS system call.
+/** 进入文件系统操作；提交中或空间不足时睡眠。 */
 void
 begin_op(void)
 {
   acquire(&log.lock);
-
   while(log.committing || !log_has_space_for_new_op_locked())
     sleep(&log, &log.lock);
-
-  log.outstanding += 1;
+  log.outstanding++;
   release(&log.lock);
 }
 
-// called at the end of each FS system call.
-// commits if this was the last outstanding operation.
+/** 离开文件系统操作；最后一个参与者负责提交。 */
 void
 end_op(void)
 {
   acquire(&log.lock);
-  log.outstanding -= 1;
-
+  log.outstanding--;
   if(log.committing)
     panic("log.committing");
 
   if(log.outstanding != 0){
-    // A waiting begin_op() may now fit in the reserved log space.
     wakeup(&log);
     release(&log.lock);
     return;
   }
 
-  // Block new operations before dropping log.lock for disk I/O.
   log.committing = 1;
   release(&log.lock);
-
   commit();
-
   acquire(&log.lock);
   log.committing = 0;
   wakeup(&log);
   release(&log.lock);
 }
 
-// Copy modified blocks from cache to log.
+/** 把修改后的 home buffer 复制到连续日志数据槽。 */
 static void
 write_log(void)
 {
-  int tail;
-
-  for (tail = 0; tail < log.lh.n; tail++) {
-    struct buf *to = bread(log.dev, log.start+tail+1); // log block
-    struct buf *from = bread(log.dev, log.lh.block[tail]); // cache block
+  for(int tail = 0; tail < log.lh.n; tail++){
+    struct buf *to = bread(log.dev, log_data_start() + tail);
+    struct buf *from = bread(log.dev, log.lh.block[tail]);
     memmove(to->data, from->data, BSIZE);
-    bwrite(to);  // write the log
+    bwrite(to);
     brelse(from);
     brelse(to);
   }
 }
 
+/** 提交当前吸收后的事务。 */
 static void
-commit()
+commit(void)
 {
-  if (log.lh.n > 0) {
-    write_log();     // Write modified blocks from cache to log
-    write_head();    // Write header to disk -- the real commit
-    install_trans(); // Now install writes to home locations
+  if(log.lh.n > 0){
+    write_log();
+    write_head();
+    install_trans(0);
     log.lh.n = 0;
-    write_head();    // Erase the transaction from the log
+    write_head();
   }
 }
 
-// Caller has modified b->data and is done with the buffer.
-// Record the block number and pin in the cache by increasing refcnt.
-// commit()/write_log() will do the disk write.
-//
-// log_write() replaces bwrite(); a typical use is:
-//   bp = bread(...)
-//   modify bp->data[]
-//   log_write(bp)
-//   brelse(bp)
+/**
+ * 将一个已锁定的修改 buffer 吸收到当前事务，并保持 pin 直到提交。
+ *
+ * @param b 当前内容必须进入日志的已锁定 buffer。
+ */
 void
 log_write(struct buf *b)
 {
-  int i;
-
-  if (log.lh.n >= LOGSIZE || log.lh.n >= log.size - 1)
-    panic("too big a transaction");
-  if (log.outstanding < 1)
+  if(log.outstanding < 1)
     panic("log_write outside of trans");
 
   acquire(&log.lock);
-  for (i = 0; i < log.lh.n; i++) {
-    if (log.lh.block[i] == b->blockno)   // log absorbtion
+  int i;
+  for(i = 0; i < log.lh.n; i++)
+    if(log.lh.block[i] == b->blockno)
       break;
-  }
-  log.lh.block[i] = b->blockno;
-  if (i == log.lh.n) {  // Add new block to log?
+
+  if(i == log.lh.n){
+    if(log.lh.n >= log.size || log.lh.n >= LOGSIZE){
+      release(&log.lock);
+      panic("too big a transaction");
+    }
+    log.lh.block[i] = b->blockno;
     bpin(b);
     log.lh.n++;
   }

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -6,9 +6,11 @@
 #define NDEV         10  // maximum major device number
 #define ROOTDEV       1  // device number of file system root disk
 #define MAXARG       32  // max exec arguments
-#define MAXOPBLOCKS  10  // max # of blocks any FS op writes
-#define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
-#define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
-// 文件系统镜像需要容纳 MAXFILE 数据块、间接索引块和仓库内置用户程序。
-#define FSSIZE       200000  // size of file system in blocks
-#define MAXPATH      128   // maximum file path name
+#define MAXOPBLOCKS 540  // 4 GiB unlink may dirty every bitmap block in one transaction
+#define LOGSIZE     600  // total on-disk log region; includes header blocks
+#define NBUF        (LOGSIZE + MAXOPBLOCKS) // pinned log blocks plus active I/O
+#ifndef FSSIZE
+#define FSSIZE   200000  // default file-system image size in blocks
+#endif
+#define MAXPATH     128  // maximum file path name
+#define USERSTACK     1  // user stack pages

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1,3 +1,4 @@
+#include <sys/types.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -64,17 +65,31 @@ xint(uint x)
   return y;
 }
 
+/** 将 64 位值编码为 xv6 磁盘使用的小端字节序。 */
+uint64
+xlong(uint64 x)
+{
+  uint64 y;
+  uchar *a = (uchar*)&y;
+  for(int i = 0; i < 8; i++)
+    a[i] = x >> (8 * i);
+  return y;
+}
+
 int
 main(int argc, char *argv[])
 {
   int i, cc, fd;
-  uint rootino, inum, off;
+  uint rootino, inum;
+  uint64 off;
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
 
 
   static_assert(sizeof(int) == 4, "Integers must be 4 bytes!");
+  static_assert(sizeof(uint64) == 8, "uint64 must be 8 bytes!");
+  static_assert(sizeof(struct dinode) == 64, "dinode must remain 64 bytes!");
 
   if(argc < 2){
     fprintf(stderr, "Usage: mkfs fs.img files...\n");
@@ -165,9 +180,9 @@ main(int argc, char *argv[])
 
   // fix size of root inode dir
   rinode(rootino, &din);
-  off = xint(din.size);
+  off = xlong(din.size);
   off = ((off/BSIZE) + 1) * BSIZE;
-  din.size = xint(off);
+  din.size = xlong(off);
   winode(rootino, &din);
 
   balloc(freeblock);
@@ -175,10 +190,12 @@ main(int argc, char *argv[])
   exit(0);
 }
 
+/** 在宿主机上按完整 off_t 偏移写入一个文件系统块。 */
 void
 wsect(uint sec, void *buf)
 {
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+  off_t offset = (off_t)sec * BSIZE;
+  if(lseek(fsfd, offset, 0) != offset){
     perror("lseek");
     exit(1);
   }
@@ -215,10 +232,12 @@ rinode(uint inum, struct dinode *ip)
   *ip = *dip;
 }
 
+/** 在宿主机上按完整 off_t 偏移读取一个文件系统块。 */
 void
 rsect(uint sec, void *buf)
 {
-  if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
+  off_t offset = (off_t)sec * BSIZE;
+  if(lseek(fsfd, offset, 0) != offset){
     perror("lseek");
     exit(1);
   }
@@ -237,7 +256,7 @@ ialloc(ushort type)
   bzero(&din, sizeof(din));
   din.type = xshort(type);
   din.nlink = xshort(1);
-  din.size = xint(0);
+  din.size = xlong(0);
   winode(inum, &din);
   return inum;
 }
@@ -260,22 +279,29 @@ balloc(int used)
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
+/**
+ * 把宿主机文件内容追加到普通启动镜像 inode。
+ *
+ * 启动镜像输入保持较小，本路径只负责直接块和一级间接块；运行中的内核负责
+ * 二级、三级间接扩展。size 使用完整 64 位磁盘编码，避免依赖宿主机字节序。
+ */
 void
 iappend(uint inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint fbn, off, n1;
+  uint64 fbn, off;
+  uint n1;
   struct dinode din;
   char buf[BSIZE];
   uint indirect[NINDIRECT];
   uint x;
 
   rinode(inum, &din);
-  off = xint(din.size);
+  off = xlong(din.size);
   // printf("append inum %d at off %d sz %d\n", inum, off, n);
   while(n > 0){
     fbn = off / BSIZE;
-    assert(fbn < MAXFILE);
+    assert(fbn < (uint64)NDIRECT + NINDIRECT);
     if(fbn < NDIRECT){
       if(xint(din.addrs[fbn]) == 0){
         din.addrs[fbn] = xint(freeblock++);
@@ -292,14 +318,14 @@ iappend(uint inum, void *xp, int n)
       }
       x = xint(indirect[fbn-NDIRECT]);
     }
-    n1 = min(n, (fbn + 1) * BSIZE - off);
+    n1 = min((uint)n, BSIZE - off % BSIZE);
     rsect(x, buf);
-    bcopy(p, buf + off - (fbn * BSIZE), n1);
+    bcopy(p, buf + off % BSIZE, n1);
     wsect(x, buf);
     n -= n1;
     off += n1;
     p += n1;
   }
-  din.size = xint(off);
+  din.size = xlong(off);
   winode(inum, &din);
 }

--- a/mkfs/mkfs_large.c
+++ b/mkfs/mkfs_large.c
@@ -1,0 +1,301 @@
+#include <sys/types.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define stat xv6_stat  // avoid clash with the host struct stat tag
+#include "kernel/types.h"
+#include "kernel/fs.h"
+#include "kernel/stat.h"
+#include "kernel/param.h"
+
+#ifndef static_assert
+#define static_assert(a, b) do { switch (0) case 0: case (a): ; } while (0)
+#endif
+
+#define NINODES 200
+
+int nbitmap = FSSIZE / (BSIZE * 8) + 1;
+int ninodeblocks = NINODES / IPB + 1;
+int nlog = LOGSIZE;
+int nmeta;
+int nblocks;
+
+int fsfd;
+struct superblock sb;
+char zeroes[BSIZE];
+uint freeinode = 1;
+uint freeblock;
+
+void balloc(int);
+void wsect(uint, void*);
+void winode(uint, struct dinode*);
+void rinode(uint, struct dinode*);
+void rsect(uint, void*);
+uint ialloc(ushort);
+void iappend(uint, void*, int);
+void die(const char*);
+
+uint
+xint(uint x)
+{
+  uint y;
+  uchar *a = (uchar*)&y;
+  a[0] = x;
+  a[1] = x >> 8;
+  a[2] = x >> 16;
+  a[3] = x >> 24;
+  return y;
+}
+
+uint64
+xlong(uint64 x)
+{
+  uint64 y;
+  uchar *a = (uchar*)&y;
+  for(int i = 0; i < 8; i++)
+    a[i] = x >> (8 * i);
+  return y;
+}
+
+ushort
+xshort(ushort x)
+{
+  ushort y;
+  uchar *a = (uchar*)&y;
+  a[0] = x;
+  a[1] = x >> 8;
+  return y;
+}
+
+/** Exit mkfs after printing one host-side failure. */
+void
+die(const char *message)
+{
+  perror(message);
+  exit(1);
+}
+
+/** Write one complete file-system sector using an off_t-safe offset. */
+void
+wsect(uint sec, void *buf)
+{
+  off_t offset = (off_t)sec * BSIZE;
+  if(lseek(fsfd, offset, SEEK_SET) != offset)
+    die("lseek write");
+  if(write(fsfd, buf, BSIZE) != BSIZE)
+    die("write sector");
+}
+
+/** Read one complete file-system sector using an off_t-safe offset. */
+void
+rsect(uint sec, void *buf)
+{
+  off_t offset = (off_t)sec * BSIZE;
+  if(lseek(fsfd, offset, SEEK_SET) != offset)
+    die("lseek read");
+  if(read(fsfd, buf, BSIZE) != BSIZE)
+    die("read sector");
+}
+
+void
+winode(uint inum, struct dinode *ip)
+{
+  char buf[BSIZE];
+  uint bn = IBLOCK(inum, sb);
+  rsect(bn, buf);
+  struct dinode *dip = ((struct dinode*)buf) + inum % IPB;
+  *dip = *ip;
+  wsect(bn, buf);
+}
+
+void
+rinode(uint inum, struct dinode *ip)
+{
+  char buf[BSIZE];
+  uint bn = IBLOCK(inum, sb);
+  rsect(bn, buf);
+  struct dinode *dip = ((struct dinode*)buf) + inum % IPB;
+  *ip = *dip;
+}
+
+uint
+ialloc(ushort type)
+{
+  uint inum = freeinode++;
+  struct dinode din;
+  memset(&din, 0, sizeof(din));
+  din.type = xshort(type);
+  din.nlink = xshort(1);
+  din.size = xlong(0);
+  winode(inum, &din);
+  return inum;
+}
+
+/**
+ * Append host bytes to one image inode.
+ *
+ * Initial image inputs are small, so mkfs only needs direct and single-indirect
+ * construction. The running kernel owns double/triple-indirect growth.
+ */
+void
+iappend(uint inum, void *xp, int n)
+{
+  char *p = xp;
+  uint64 off;
+  struct dinode din;
+  char buf[BSIZE];
+  uint indirect[NINDIRECT];
+
+  rinode(inum, &din);
+  off = xlong(din.size);
+
+  while(n > 0){
+    uint64 fbn = off / BSIZE;
+    assert(fbn < (uint64)NDIRECT + NINDIRECT);
+    uint x;
+
+    if(fbn < NDIRECT){
+      if(xint(din.addrs[fbn]) == 0)
+        din.addrs[fbn] = xint(freeblock++);
+      x = xint(din.addrs[fbn]);
+    } else {
+      if(xint(din.addrs[NDIRECT]) == 0){
+        din.addrs[NDIRECT] = xint(freeblock++);
+        memset(indirect, 0, sizeof(indirect));
+        wsect(xint(din.addrs[NDIRECT]), indirect);
+      }
+      rsect(xint(din.addrs[NDIRECT]), indirect);
+      if(indirect[fbn - NDIRECT] == 0){
+        indirect[fbn - NDIRECT] = xint(freeblock++);
+        wsect(xint(din.addrs[NDIRECT]), indirect);
+      }
+      x = xint(indirect[fbn - NDIRECT]);
+    }
+
+    int n1 = n;
+    if(n1 > BSIZE - off % BSIZE)
+      n1 = BSIZE - off % BSIZE;
+    rsect(x, buf);
+    memmove(buf + off % BSIZE, p, n1);
+    wsect(x, buf);
+    n -= n1;
+    off += n1;
+    p += n1;
+  }
+
+  din.size = xlong(off);
+  winode(inum, &din);
+}
+
+/** Mark every block in the allocated prefix across all bitmap sectors. */
+void
+balloc(int used)
+{
+  uchar buf[BSIZE];
+
+  for(int bitmap = 0; bitmap < nbitmap; bitmap++){
+    memset(buf, 0, sizeof(buf));
+    int start = bitmap * BPB;
+    int count = used - start;
+    if(count < 0)
+      count = 0;
+    if(count > BPB)
+      count = BPB;
+    for(int bit = 0; bit < count; bit++)
+      buf[bit / 8] |= 1 << (bit % 8);
+    wsect(xint(sb.bmapstart) + bitmap, buf);
+  }
+}
+
+int
+main(int argc, char *argv[])
+{
+  int i, cc, fd;
+  uint rootino, inum, off;
+  struct dirent de;
+  char buf[BSIZE];
+  struct dinode din;
+
+  static_assert(sizeof(int) == 4, "integers must be 4 bytes");
+  static_assert(sizeof(uint64) == 8, "uint64 must be 8 bytes");
+  static_assert(sizeof(struct dinode) == 64, "dinode must remain 64 bytes");
+  static_assert(BSIZE % sizeof(struct dinode) == 0, "integral inodes per block");
+
+  if(argc < 2){
+    fprintf(stderr, "Usage: mkfs-large fs.img files...\n");
+    exit(1);
+  }
+
+  assert((BSIZE % sizeof(struct dirent)) == 0);
+  nmeta = 2 + nlog + ninodeblocks + nbitmap;
+  nblocks = FSSIZE - nmeta;
+
+  fsfd = open(argv[1], O_RDWR | O_CREAT | O_TRUNC, 0666);
+  if(fsfd < 0)
+    die("open image");
+  if(ftruncate(fsfd, (off_t)FSSIZE * BSIZE) < 0)
+    die("ftruncate image");
+
+  sb.magic = FSMAGIC;
+  sb.size = xint(FSSIZE);
+  sb.nblocks = xint(nblocks);
+  sb.ninodes = xint(NINODES);
+  sb.nlog = xint(nlog);
+  sb.logstart = xint(2);
+  sb.inodestart = xint(2 + nlog);
+  sb.bmapstart = xint(2 + nlog + ninodeblocks);
+
+  printf("nmeta %d (boot, super, log blocks %u inode blocks %u, bitmap blocks %u) blocks %d total %d\n",
+         nmeta, nlog, ninodeblocks, nbitmap, nblocks, FSSIZE);
+
+  memset(buf, 0, sizeof(buf));
+  memmove(buf, &sb, sizeof(sb));
+  wsect(1, buf);
+
+  freeblock = nmeta;
+  rootino = ialloc(T_DIR);
+  assert(rootino == ROOTINO);
+
+  memset(&de, 0, sizeof(de));
+  de.inum = xshort(rootino);
+  strcpy(de.name, ".");
+  iappend(rootino, &de, sizeof(de));
+  strcpy(de.name, "..");
+  iappend(rootino, &de, sizeof(de));
+
+  for(i = 2; i < argc; i++){
+    char *shortname = argv[i];
+    if(strncmp(shortname, "user/", 5) == 0)
+      shortname += 5;
+    assert(index(shortname, '/') == 0);
+
+    if((fd = open(argv[i], O_RDONLY)) < 0)
+      die(argv[i]);
+    if(shortname[0] == '_')
+      shortname++;
+
+    inum = ialloc(T_FILE);
+    memset(&de, 0, sizeof(de));
+    de.inum = xshort(inum);
+    strncpy(de.name, shortname, DIRSIZ);
+    iappend(rootino, &de, sizeof(de));
+
+    while((cc = read(fd, buf, sizeof(buf))) > 0)
+      iappend(inum, buf, cc);
+    close(fd);
+  }
+
+  rinode(rootino, &din);
+  off = xlong(din.size);
+  off = ((off / BSIZE) + 1) * BSIZE;
+  din.size = xlong(off);
+  winode(rootino, &din);
+
+  balloc(freeblock);
+  close(fsfd);
+  return 0;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,8 @@ tests/
 ├── guest/                 编译并在 xv6 内运行的 C/ASM/脚本测试源码
 ├── host/                  在宿主机 pthread 环境运行的测试源码
 ├── legacy/                保留的课程评分脚本与其支持库
-├── run.py                 宿主机 QEMU 生命周期、超时、日志和 suite 编排
+├── run.py                 日常 QEMU 生命周期、超时、日志和 suite 编排
+├── run_largefile.py       显式 4 GiB 稀疏镜像回归编排
 ├── test_runner.py         不启动 QEMU 的 Python runner 自测
 └── README.md
 ```
@@ -26,7 +27,7 @@ tests/
 测试注册：tests/guest/xv6test.c
 → 按 group/name 注册、fork/exec 隔离、wait 回收、输出 XV6TEST 协议
 
-宿主机基础设施：tests/run.py
+宿主机基础设施：tests/run.py / tests/run_largefile.py
 → 启停 QEMU、设置 timeout、保存日志、隔离磁盘 snapshot、汇总 suite
 ```
 
@@ -114,6 +115,26 @@ XV6TEST done status=0
 
 Lab9 的两个测试虽然都属于 `lab9` group，但默认宿主机 suite 使用两次 `--run` 并分别启动 snapshot。`bigfile` 会显著修改文件系统，不应与 `symlinktest` 共用自动化 snapshot。
 
+## 显式 4 GiB 文件回归
+
+Issue #29 的完整回归不属于日常 `pr`、`full` 或 `make test`。它使用宿主机稀疏文件创建约 4.25M 个 1 KiB 块的镜像，但 guest 仍会真实顺序写入和读回超过 `2^32` 字节的数据。
+
+```bash
+# 默认 3 CPU。
+make largefiletest
+
+# 补充单核观察；单核结果不能替代多核结果。
+make largefiletest CPUS=1
+
+# 只启动大镜像，进入 shell 后手工执行。
+make qemu FSIMG=fs-large.img
+xv6test --run largefs-4gib
+```
+
+`tests/guest/largefile.c` 依次验证：直接/一级/二级/三级索引、跨越 `2^32` 的 `fstat.size`、完整顺序读回、磁盘满返回短写而非 panic、删除大文件、以及重新进入三级索引所需的数据块可再次分配。原始日志写入 `test-results/largefs-4gib/`。
+
+教学边界：为了让一次 `unlink` 原子回收 4 GiB 文件可能触及的约 519 个位图块，本实验把日志区域扩展为 600 块，并将单次文件系统操作的最坏写集预留为 540 块。这会使文件系统操作在日志层基本串行化；它是保证最小完整闭环的 xv6 教学取舍，不代表生产文件系统应通过超大事务删除大文件。
+
 ## 新增测试的最短路径
 
 1. guest 测试放入 `tests/guest/`，host-only 测试放入 `tests/host/`；不要放入 `user/`、`kernel/` 或 `notxv6/`。
@@ -141,7 +162,7 @@ make test CPUS=3
 
 ## 日志与 snapshot
 
-每个原子 QEMU suite 从基础 `fs.img` 以 `-snapshot` 启动，写入在实例结束后丢弃。原始输出保存在：
+每个原子 QEMU suite 从基础镜像以 `-snapshot` 启动，写入在实例结束后丢弃。原始输出保存在：
 
 ```text
 test-results/<suite>/<test>.log

--- a/tests/guest/bigfile.c
+++ b/tests/guest/bigfile.c
@@ -1,71 +1,59 @@
 #include "kernel/types.h"
+#include "kernel/fs.h"
+#include "kernel/fcntl.h"
 #include "kernel/stat.h"
 #include "user/user.h"
-#include "kernel/fcntl.h"
-#include "kernel/fs.h"
 
-/**
- * 验证 inode 能映射并读回 MAXFILE 个数据块，同时拒绝第 MAXFILE + 1 个块。
- *
- * 测试使用由 fs.h 定义的 MAXFILE 作为唯一边界，避免文件系统配置或寻址布局
- * 变化后继续无限写入，最终以磁盘耗尽或 QEMU 超时结束。
- *
- * @return 成功时调用 exit(0)；任一写入、边界或读回校验失败时调用 exit(-1)。
- */
+// Lab9 remains a focused direct/single/double-indirect regression. The
+// 4-GiB/triple-indirect path is isolated in largefile.c and is not part of the
+// normal PR suite.
+#define LAB9_BLOCKS ((uint64)NDIRECT + NINDIRECT + NDOUBLEINDIRECT)
+
+static uint buf[BSIZE / sizeof(uint)];
+
+/** Fail the guest test with a stable diagnostic and non-zero status. */
+static void
+fail(char *message)
+{
+  printf("bigfile: %s\n", message);
+  unlink("big.file");
+  exit(1);
+}
+
 int
 main(void)
 {
-  char buf[BSIZE] = {0};
-  int fd, i, blocks;
-  const int max_blocks = (int)MAXFILE;
+  unlink("big.file");
+  int fd = open("big.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create file");
 
-  fd = open("big.file", O_CREATE | O_WRONLY);
-  if(fd < 0){
-    printf("bigfile: cannot open big.file for writing\n");
-    exit(-1);
+  for(uint64 block = 0; block < LAB9_BLOCKS; block++){
+    buf[0] = block;
+    if(write(fd, buf, sizeof(buf)) != sizeof(buf))
+      fail("short write");
   }
 
-  // 只写入寻址布局明确允许的块数，避免依赖“持续写到失败”终止测试。
-  for(blocks = 0; blocks < max_blocks; blocks++){
-    *(int*)buf = blocks;
-    int cc = write(fd, buf, BSIZE);
-    if(cc != BSIZE){
-      printf("bigfile: write error at block %d\n", blocks);
-      exit(-1);
-    }
-    if((blocks + 1) % 100 == 0)
-      printf(".");
-  }
-
-  // writei 必须在 MAXFILE * BSIZE 边界拒绝写入，且不能推进文件偏移。
-  *(int*)buf = max_blocks;
-  if(write(fd, buf, BSIZE) >= 0){
-    printf("bigfile: accepted block %d beyond MAXFILE\n", max_blocks);
-    exit(-1);
-  }
-
-  printf("\nwrote %d blocks\n", blocks);
+  struct stat st;
+  if(fstat(fd, &st) < 0)
+    fail("fstat failed");
+  if(st.size != LAB9_BLOCKS * BSIZE)
+    fail("wrong stat size");
   close(fd);
 
   fd = open("big.file", O_RDONLY);
-  if(fd < 0){
-    printf("bigfile: cannot re-open big.file for reading\n");
-    exit(-1);
+  if(fd < 0)
+    fail("cannot reopen file");
+  for(uint64 block = 0; block < LAB9_BLOCKS; block++){
+    if(read(fd, buf, sizeof(buf)) != sizeof(buf))
+      fail("short read");
+    if(buf[0] != (uint)block)
+      fail("data mismatch");
   }
-  for(i = 0; i < blocks; i++){
-    int cc = read(fd, buf, BSIZE);
-    if(cc != BSIZE){
-      printf("bigfile: read error at block %d\n", i);
-      exit(-1);
-    }
-    if(*(int*)buf != i){
-      printf("bigfile: read the wrong data (%d) for block %d\n",
-             *(int*)buf, i);
-      exit(-1);
-    }
-  }
-
   close(fd);
-  printf("bigfile done; ok\n");
+
+  if(unlink("big.file") < 0)
+    fail("unlink failed");
+  printf("bigfile: wrote and read %l double-indirect blocks\n", LAB9_BLOCKS);
   exit(0);
 }

--- a/tests/guest/largefile.c
+++ b/tests/guest/largefile.c
@@ -1,0 +1,163 @@
+#include "kernel/types.h"
+#include "kernel/fs.h"
+#include "kernel/fcntl.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+#define BLOCKS_PER_IO 256
+#define TARGET_BLOCKS (((uint64)1 << 32) / BSIZE + 1)
+#define TARGET_BYTES (TARGET_BLOCKS * (uint64)BSIZE)
+#define REUSE_BLOCKS ((uint64)NDIRECT + NINDIRECT + NDOUBLEINDIRECT + 1)
+#define PROGRESS_BLOCKS (256 * 1024)
+
+static uint64 io_words[(BLOCKS_PER_IO * BSIZE) / sizeof(uint64)];
+
+/** Print a stable failure, remove test files, and exit non-zero. */
+static void
+fail(char *message)
+{
+  printf("largefile: FAIL %s\n", message);
+  unlink("large.file");
+  unlink("fill.file");
+  unlink("reuse.file");
+  exit(1);
+}
+
+/** Fill count complete blocks with a deterministic block/word pattern. */
+static void
+fill_pattern(uint64 first_block, int count)
+{
+  int words_per_block = BSIZE / sizeof(uint64);
+  for(int block = 0; block < count; block++){
+    uint64 logical = first_block + block;
+    for(int word = 0; word < words_per_block; word++)
+      io_words[block * words_per_block + word] = logical ^ ((uint64)word << 32);
+  }
+}
+
+/** Verify count complete blocks against fill_pattern(). */
+static int
+verify_pattern(uint64 first_block, int count)
+{
+  int words_per_block = BSIZE / sizeof(uint64);
+  for(int block = 0; block < count; block++){
+    uint64 logical = first_block + block;
+    for(int word = 0; word < words_per_block; word++){
+      uint64 expected = logical ^ ((uint64)word << 32);
+      if(io_words[block * words_per_block + word] != expected)
+        return -1;
+    }
+  }
+  return 0;
+}
+
+/** Sequentially write an exact number of patterned blocks. */
+static void
+write_exact_blocks(int fd, uint64 blocks, char *phase)
+{
+  uint64 block = 0;
+  while(block < blocks){
+    int count = BLOCKS_PER_IO;
+    if(blocks - block < (uint64)count)
+      count = blocks - block;
+    fill_pattern(block, count);
+    int bytes = count * BSIZE;
+    if(write(fd, io_words, bytes) != bytes)
+      fail(phase);
+    block += count;
+    if(block % PROGRESS_BLOCKS == 0 || block == blocks)
+      printf("largefile: %s blocks=%l\n", phase, block);
+  }
+}
+
+/** Sequentially read and verify an exact number of patterned blocks. */
+static void
+read_exact_blocks(int fd, uint64 blocks)
+{
+  uint64 block = 0;
+  while(block < blocks){
+    int count = BLOCKS_PER_IO;
+    if(blocks - block < (uint64)count)
+      count = blocks - block;
+    int bytes = count * BSIZE;
+    if(read(fd, io_words, bytes) != bytes)
+      fail("short read before 4 GiB boundary");
+    if(verify_pattern(block, count) < 0)
+      fail("data mismatch");
+    block += count;
+    if(block % PROGRESS_BLOCKS == 0 || block == blocks)
+      printf("largefile: read blocks=%l\n", block);
+  }
+}
+
+/** Consume remaining data blocks and confirm disk-full returns without panic. */
+static uint64
+fill_until_full(void)
+{
+  int fd = open("fill.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create fill.file");
+
+  uint64 bytes = 0;
+  for(;;){
+    fill_pattern(bytes / BSIZE, BLOCKS_PER_IO);
+    int requested = BLOCKS_PER_IO * BSIZE;
+    int written = write(fd, io_words, requested);
+    if(written < 0)
+      break;
+    bytes += written;
+    if(written != requested)
+      break;
+  }
+
+  struct stat st;
+  if(fstat(fd, &st) < 0 || st.size != bytes)
+    fail("disk-full stat mismatch");
+  close(fd);
+  printf("largefile: disk full handled bytes=%l\n", bytes);
+  return bytes;
+}
+
+int
+main(void)
+{
+  unlink("large.file");
+  unlink("fill.file");
+  unlink("reuse.file");
+
+  int fd = open("large.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create large.file");
+  write_exact_blocks(fd, TARGET_BLOCKS, "write");
+
+  struct stat st;
+  if(fstat(fd, &st) < 0)
+    fail("target fstat failed");
+  if(st.size != TARGET_BYTES)
+    fail("target did not cross 2^32 bytes");
+  close(fd);
+
+  fd = open("large.file", O_RDONLY);
+  if(fd < 0)
+    fail("cannot reopen large.file");
+  read_exact_blocks(fd, TARGET_BLOCKS);
+  close(fd);
+
+  fill_until_full();
+
+  if(unlink("large.file") < 0 || unlink("fill.file") < 0)
+    fail("large unlink failed");
+
+  fd = open("reuse.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create reuse.file");
+  write_exact_blocks(fd, REUSE_BLOCKS, "reuse");
+  if(fstat(fd, &st) < 0 || st.size != REUSE_BLOCKS * BSIZE)
+    fail("reclaimed blocks were not reusable");
+  close(fd);
+  if(unlink("reuse.file") < 0)
+    fail("reuse unlink failed");
+
+  printf("largefile: PASS bytes=%l\n", TARGET_BYTES);
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -2,7 +2,13 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
-/** A guest test registered by stable group/name and executed through exec(). */
+/**
+ * 描述一个由 xv6 用户态执行的回归测试。
+ *
+ * group 用于按 Lab 或能力筛选；name 是稳定且全局唯一的测试名称；argv
+ * 是传给 exec() 的空指针结尾参数数组。测试语义由 tests/guest 下的目标
+ * 程序拥有，本入口只负责注册、进程隔离、退出状态传播和统一结果协议。
+ */
 struct xv6_test_case {
   char *group;
   char *name;
@@ -53,8 +59,8 @@ static char *legacy_stressfs_argv[] = {"stressfs", 0};
 static char *legacy_grind_argv[] = {"grind", 0};
 static char *full_usertests_argv[] = {"usertests", 0};
 
-// Destructive or very long tests are selected by --run and receive an isolated
-// host-side QEMU snapshot. largefs-4gib additionally uses fs-large.img.
+// Lab1-Lab10 全部经统一 registry 暴露；破坏磁盘或耗时较长的测试由宿主机
+// 选择 --run 并在独立 QEMU snapshot 中执行，避免 group 内状态相互污染。
 static struct xv6_test_case tests[] = {
   {"lab1", "lab1-sleep", lab1_sleep_argv},
   {"lab1", "lab1-pingpong", lab1_pingpong_argv},
@@ -79,6 +85,8 @@ static struct xv6_test_case tests[] = {
   {"lab6", "lab6-cowtest", lab6_cowtest_argv},
   {"lab7", "lab7-uthread", lab7_uthread_argv},
 
+  // sbrkmuch 同时验证 Lab3 地址空间增长和 Lab8 allocator 锁路径；保留两个
+  // 稳定名称，使按 Lab 验收时都能覆盖该共享行为。
   {"lab8", "lab8-kalloc-sbrkmuch", lab8_kalloc_argv},
   {"lab8", "lab8-createdelete", lab8_createdelete_argv},
   {"lab8", "lab8-fourfiles", lab8_fourfiles_argv},
@@ -102,14 +110,26 @@ static struct xv6_test_case tests[] = {
   {0, 0, 0},
 };
 
-/** Print accepted command-line forms. */
+/**
+ * 输出 xv6test 支持的命令行形式。
+ *
+ * @param program argv[0] 中的程序名称，仅用于错误提示。
+ * @return 无；本函数只向标准错误写入用法说明。
+ */
 static void
 usage(char *program)
 {
   fprintf(2, "Usage: %s [--all | --list | --group name | --run test]\n", program);
 }
 
-/** Return whether a test satisfies all non-null exact filters. */
+/**
+ * 判断测试是否满足当前 group 或 name 过滤条件。
+ *
+ * @param test 待检查的静态测试描述，不会被修改。
+ * @param group_filter group 精确匹配条件；为空时不限制 group。
+ * @param name_filter 测试名称精确匹配条件；为空时不限制名称。
+ * @return 同时满足全部非空过滤条件时返回 1，否则返回 0。
+ */
 static int
 matches_filter(struct xv6_test_case *test, char *group_filter, char *name_filter)
 {
@@ -120,11 +140,16 @@ matches_filter(struct xv6_test_case *test, char *group_filter, char *name_filter
   return 1;
 }
 
-/** List every registered guest test using the stable XV6TEST protocol. */
+/**
+ * 输出当前镜像内注册的全部 guest 测试。
+ *
+ * @return 已列出的测试数量；调用者可据此检查注册表是否为空。
+ */
 static int
 list_tests(void)
 {
   int count = 0;
+
   for(struct xv6_test_case *test = tests; test->name != 0; test++){
     printf("XV6TEST case name=%s group=%s command=%s\n",
            test->name, test->group, test->argv[0]);
@@ -134,26 +159,38 @@ list_tests(void)
   return count;
 }
 
-/** Execute one registered test in a child and propagate its exit status. */
+/**
+ * 在独立子进程中执行一个已注册测试，并把退出状态转换为统一协议。
+ *
+ * @param test 待执行的测试描述；argv 必须以空指针结尾。
+ * @param ordinal 本轮筛选结果中的一基序号，用于稳定标识输出行。
+ * @return 子进程正常退出且状态为 0 时返回 1；fork、exec、wait 或测试失败
+ *         时返回 0。函数不会保留子进程资源。
+ */
 static int
 run_test(struct xv6_test_case *test, int ordinal)
 {
+  int pid;
+  int waited_pid;
   int status = 0;
 
   printf("XV6TEST run %d - %s group=%s\n", ordinal, test->name, test->group);
-  int pid = fork();
+  pid = fork();
   if(pid < 0){
     printf("XV6TEST not ok %d - %s reason=fork\n", ordinal, test->name);
     return 0;
   }
+
   if(pid == 0){
+    // exec() 成功后测试程序接管当前子进程，其 exit status 直接成为测试结果。
     exec(test->argv[0], test->argv);
     printf("XV6TEST diagnostic name=%s exec=%s failed\n",
            test->name, test->argv[0]);
     exit(1);
   }
 
-  int waited_pid = wait(&status);
+  // 每轮只创建一个直接子进程，因此 wait() 必须回收刚启动的测试进程。
+  waited_pid = wait(&status);
   if(waited_pid != pid){
     printf("XV6TEST not ok %d - %s reason=wait expected=%d actual=%d\n",
            ordinal, test->name, pid, waited_pid);
@@ -169,12 +206,20 @@ run_test(struct xv6_test_case *test, int ordinal)
   return 1;
 }
 
-/** Run a filtered set and emit stable begin/summary/done markers. */
+/**
+ * 执行满足过滤条件的测试集合，并输出稳定的开始、汇总和结束协议。
+ *
+ * @param group_filter group 精确匹配条件；为空时选择全部 group。
+ * @param name_filter 测试名称精确匹配条件；为空时选择全部名称。
+ * @return 至少选中一个测试且全部通过时返回 0；空选择或任一失败时返回 1。
+ */
 static int
 run_selected_tests(char *group_filter, char *name_filter)
 {
   int selected = 0;
   int passed = 0;
+  int failed;
+  int status;
 
   printf("XV6TEST begin group=%s test=%s\n",
          group_filter == 0 ? "*" : group_filter,
@@ -188,8 +233,9 @@ run_selected_tests(char *group_filter, char *name_filter)
       passed++;
   }
 
-  int failed = selected - passed;
-  int status = selected == 0 || failed != 0;
+  failed = selected - passed;
+  // 空选择必须失败，否则拼错 group 名时会产生没有执行任何测试的假阳性。
+  status = selected == 0 || failed != 0;
   if(selected == 0)
     printf("XV6TEST diagnostic no tests selected\n");
   printf("XV6TEST summary selected=%d passed=%d failed=%d\n",
@@ -198,6 +244,13 @@ run_selected_tests(char *group_filter, char *name_filter)
   return status;
 }
 
+/**
+ * 解析 xv6test 命令行并执行列表、全部、group 或单项测试模式。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 参数数组；过滤值采用精确匹配，不支持模糊或正则表达式。
+ * @return 本函数通过 exit() 返回：测试成功为 0，测试失败为 1，参数错误为 2。
+ */
 int
 main(int argc, char *argv[])
 {
@@ -207,6 +260,7 @@ main(int argc, char *argv[])
   if(argc == 2 && strcmp(argv[1], "--list") == 0){
     exit(list_tests() == 0);
   } else if(argc == 1 || (argc == 2 && strcmp(argv[1], "--all") == 0)){
+    // 不带参数与显式 --all 等价，便于在 xv6 shell 中直接运行完整集合。
   } else if(argc == 3 && strcmp(argv[1], "--group") == 0){
     group_filter = argv[2];
   } else if(argc == 3 && strcmp(argv[1], "--run") == 0){

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -2,13 +2,7 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
-/**
- * 描述一个由 xv6 用户态执行的回归测试。
- *
- * group 用于按 Lab 或能力筛选；name 是稳定且全局唯一的测试名称；argv
- * 是传给 exec() 的空指针结尾参数数组。测试语义由 tests/guest 下的目标
- * 程序拥有，本入口只负责注册、进程隔离、退出状态传播和统一结果协议。
- */
+/** A guest test registered by stable group/name and executed through exec(). */
 struct xv6_test_case {
   char *group;
   char *name;
@@ -45,6 +39,7 @@ static char *lab8_bigwrite_argv[] = {"usertests", "bigwrite", 0};
 
 static char *lab9_bigfile_argv[] = {"bigfile", 0};
 static char *lab9_symlink_argv[] = {"symlinktest", 0};
+static char *largefs_4gib_argv[] = {"largefile", 0};
 static char *lab10_mmap_argv[] = {"mmaptest", 0};
 
 static char *core_sbrkbugs_argv[] = {"usertests", "sbrkbugs", 0};
@@ -58,8 +53,8 @@ static char *legacy_stressfs_argv[] = {"stressfs", 0};
 static char *legacy_grind_argv[] = {"grind", 0};
 static char *full_usertests_argv[] = {"usertests", 0};
 
-// Lab1-Lab10 全部经统一 registry 暴露；破坏磁盘或耗时较长的测试由宿主机
-// 选择 --run 并在独立 QEMU snapshot 中执行，避免 group 内状态相互污染。
+// Destructive or very long tests are selected by --run and receive an isolated
+// host-side QEMU snapshot. largefs-4gib additionally uses fs-large.img.
 static struct xv6_test_case tests[] = {
   {"lab1", "lab1-sleep", lab1_sleep_argv},
   {"lab1", "lab1-pingpong", lab1_pingpong_argv},
@@ -84,8 +79,6 @@ static struct xv6_test_case tests[] = {
   {"lab6", "lab6-cowtest", lab6_cowtest_argv},
   {"lab7", "lab7-uthread", lab7_uthread_argv},
 
-  // sbrkmuch 同时验证 Lab3 地址空间增长和 Lab8 allocator 锁路径；保留两个
-  // 稳定名称，使按 Lab 验收时都能覆盖该共享行为。
   {"lab8", "lab8-kalloc-sbrkmuch", lab8_kalloc_argv},
   {"lab8", "lab8-createdelete", lab8_createdelete_argv},
   {"lab8", "lab8-fourfiles", lab8_fourfiles_argv},
@@ -93,6 +86,7 @@ static struct xv6_test_case tests[] = {
 
   {"lab9", "lab9-bigfile", lab9_bigfile_argv},
   {"lab9", "lab9-symlink", lab9_symlink_argv},
+  {"largefs", "largefs-4gib", largefs_4gib_argv},
   {"lab10", "lab10-mmap", lab10_mmap_argv},
 
   {"core", "core-sbrkbugs", core_sbrkbugs_argv},
@@ -108,26 +102,14 @@ static struct xv6_test_case tests[] = {
   {0, 0, 0},
 };
 
-/**
- * 输出 xv6test 支持的命令行形式。
- *
- * @param program argv[0] 中的程序名称，仅用于错误提示。
- * @return 无；本函数只向标准错误写入用法说明。
- */
+/** Print accepted command-line forms. */
 static void
 usage(char *program)
 {
   fprintf(2, "Usage: %s [--all | --list | --group name | --run test]\n", program);
 }
 
-/**
- * 判断测试是否满足当前 group 或 name 过滤条件。
- *
- * @param test 待检查的静态测试描述，不会被修改。
- * @param group_filter group 精确匹配条件；为空时不限制 group。
- * @param name_filter 测试名称精确匹配条件；为空时不限制名称。
- * @return 同时满足全部非空过滤条件时返回 1，否则返回 0。
- */
+/** Return whether a test satisfies all non-null exact filters. */
 static int
 matches_filter(struct xv6_test_case *test, char *group_filter, char *name_filter)
 {
@@ -138,16 +120,11 @@ matches_filter(struct xv6_test_case *test, char *group_filter, char *name_filter
   return 1;
 }
 
-/**
- * 输出当前镜像内注册的全部 guest 测试。
- *
- * @return 已列出的测试数量；调用者可据此检查注册表是否为空。
- */
+/** List every registered guest test using the stable XV6TEST protocol. */
 static int
 list_tests(void)
 {
   int count = 0;
-
   for(struct xv6_test_case *test = tests; test->name != 0; test++){
     printf("XV6TEST case name=%s group=%s command=%s\n",
            test->name, test->group, test->argv[0]);
@@ -157,38 +134,26 @@ list_tests(void)
   return count;
 }
 
-/**
- * 在独立子进程中执行一个已注册测试，并把退出状态转换为统一协议。
- *
- * @param test 待执行的测试描述；argv 必须以空指针结尾。
- * @param ordinal 本轮筛选结果中的一基序号，用于稳定标识输出行。
- * @return 子进程正常退出且状态为 0 时返回 1；fork、exec、wait 或测试失败
- *         时返回 0。函数不会保留子进程资源。
- */
+/** Execute one registered test in a child and propagate its exit status. */
 static int
 run_test(struct xv6_test_case *test, int ordinal)
 {
-  int pid;
-  int waited_pid;
   int status = 0;
 
   printf("XV6TEST run %d - %s group=%s\n", ordinal, test->name, test->group);
-  pid = fork();
+  int pid = fork();
   if(pid < 0){
     printf("XV6TEST not ok %d - %s reason=fork\n", ordinal, test->name);
     return 0;
   }
-
   if(pid == 0){
-    // exec() 成功后测试程序接管当前子进程，其 exit status 直接成为测试结果。
     exec(test->argv[0], test->argv);
     printf("XV6TEST diagnostic name=%s exec=%s failed\n",
            test->name, test->argv[0]);
     exit(1);
   }
 
-  // 每轮只创建一个直接子进程，因此 wait() 必须回收刚启动的测试进程。
-  waited_pid = wait(&status);
+  int waited_pid = wait(&status);
   if(waited_pid != pid){
     printf("XV6TEST not ok %d - %s reason=wait expected=%d actual=%d\n",
            ordinal, test->name, pid, waited_pid);
@@ -204,20 +169,12 @@ run_test(struct xv6_test_case *test, int ordinal)
   return 1;
 }
 
-/**
- * 执行满足过滤条件的测试集合，并输出稳定的开始、汇总和结束协议。
- *
- * @param group_filter group 精确匹配条件；为空时选择全部 group。
- * @param name_filter 测试名称精确匹配条件；为空时选择全部名称。
- * @return 至少选中一个测试且全部通过时返回 0；空选择或任一失败时返回 1。
- */
+/** Run a filtered set and emit stable begin/summary/done markers. */
 static int
 run_selected_tests(char *group_filter, char *name_filter)
 {
   int selected = 0;
   int passed = 0;
-  int failed;
-  int status;
 
   printf("XV6TEST begin group=%s test=%s\n",
          group_filter == 0 ? "*" : group_filter,
@@ -231,9 +188,8 @@ run_selected_tests(char *group_filter, char *name_filter)
       passed++;
   }
 
-  failed = selected - passed;
-  // 空选择必须失败，否则拼错 group 名时会产生没有执行任何测试的假阳性。
-  status = selected == 0 || failed != 0;
+  int failed = selected - passed;
+  int status = selected == 0 || failed != 0;
   if(selected == 0)
     printf("XV6TEST diagnostic no tests selected\n");
   printf("XV6TEST summary selected=%d passed=%d failed=%d\n",
@@ -242,13 +198,6 @@ run_selected_tests(char *group_filter, char *name_filter)
   return status;
 }
 
-/**
- * 解析 xv6test 命令行并执行列表、全部、group 或单项测试模式。
- *
- * @param argc 命令行参数数量。
- * @param argv 参数数组；过滤值采用精确匹配，不支持模糊或正则表达式。
- * @return 本函数通过 exit() 返回：测试成功为 0，测试失败为 1，参数错误为 2。
- */
 int
 main(int argc, char *argv[])
 {
@@ -258,7 +207,6 @@ main(int argc, char *argv[])
   if(argc == 2 && strcmp(argv[1], "--list") == 0){
     exit(list_tests() == 0);
   } else if(argc == 1 || (argc == 2 && strcmp(argv[1], "--all") == 0)){
-    // 不带参数与显式 --all 等价，便于在 xv6 shell 中直接运行完整集合。
   } else if(argc == 3 && strcmp(argv[1], "--group") == 0){
     group_filter = argv[2];
   } else if(argc == 3 && strcmp(argv[1], "--run") == 0){

--- a/tests/run_largefile.py
+++ b/tests/run_largefile.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""为稀疏大镜像注册并执行显式 4 GiB xv6 回归。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+TEST_ROOT = Path(__file__).resolve().parent
+if str(TEST_ROOT) not in sys.path:
+    sys.path.insert(0, str(TEST_ROOT))
+
+import run as runner
+
+
+runner.SUITES["largefs-4gib"] = runner.Suite(
+    name="largefs-4gib",
+    description="Explicit 4-GiB sequential write/read/stat/unlink/reuse regression",
+    tests=(
+        runner.TestCase(
+            "largefs-4gib",
+            ("xv6test --run largefs-4gib",),
+            expected=runner.GUEST_SUCCESS,
+            timeout=43_200,
+        ),
+    ),
+)
+
+
+if __name__ == "__main__":
+    raise SystemExit(runner.main())

--- a/tests/test_largefile_runner.py
+++ b/tests/test_largefile_runner.py
@@ -1,0 +1,39 @@
+"""Issue #29 大文件 guest-first 布局与宿主机编排自测。"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class LargeFileRunnerTests(unittest.TestCase):
+    """验证 4 GiB 回归保持显式、隔离且由 guest 承担行为断言。"""
+
+    def test_guest_source_and_make_target_are_registered(self) -> None:
+        self.assertTrue((REPO_ROOT / "tests/guest/largefile.c").is_file())
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn("$U/_largefile", makefile)
+        self.assertIn("largefiletest:", makefile)
+        self.assertIn("fs-large.img", makefile)
+        self.assertIn("mkfs/mkfs_large.c", makefile)
+
+    def test_dedicated_runner_registers_only_explicit_suite(self) -> None:
+        runner_path = REPO_ROOT / "tests/run_largefile.py"
+        spec = importlib.util.spec_from_file_location("run_largefile", runner_path)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        suite = module.runner.SUITES["largefs-4gib"]
+        self.assertEqual(suite.tests[0].commands, ("xv6test --run largefs-4gib",))
+        self.assertNotIn("largefs-4gib", module.runner.SUITES["pr"].includes)
+        self.assertNotIn("largefs-4gib", module.runner.SUITES["full"].includes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user/ls.c
+++ b/user/ls.c
@@ -3,25 +3,26 @@
 #include "user/user.h"
 #include "kernel/fs.h"
 
+/** Return the final path component padded to DIRSIZ for aligned output. */
 char*
 fmtname(char *path)
 {
   static char buf[DIRSIZ+1];
   char *p;
 
-  // Find first character after last slash.
-  for(p=path+strlen(path); p >= path && *p != '/'; p--)
+  for(p = path + strlen(path); p >= path && *p != '/'; p--)
     ;
   p++;
 
-  // Return blank-padded name.
   if(strlen(p) >= DIRSIZ)
     return p;
   memmove(buf, p, strlen(p));
-  memset(buf+strlen(p), ' ', DIRSIZ-strlen(p));
+  memset(buf + strlen(p), ' ', DIRSIZ - strlen(p));
+  buf[DIRSIZ] = 0;
   return buf;
 }
 
+/** List one file or directory and print 64-bit sizes without truncation. */
 void
 ls(char *path)
 {
@@ -34,7 +35,6 @@ ls(char *path)
     fprintf(2, "ls: cannot open %s\n", path);
     return;
   }
-
   if(fstat(fd, &st) < 0){
     fprintf(2, "ls: cannot stat %s\n", path);
     close(fd);
@@ -45,14 +45,13 @@ ls(char *path)
   case T_FILE:
     printf("%s %d %d %l\n", fmtname(path), st.type, st.ino, st.size);
     break;
-
   case T_DIR:
     if(strlen(path) + 1 + DIRSIZ + 1 > sizeof buf){
       printf("ls: path too long\n");
       break;
     }
     strcpy(buf, path);
-    p = buf+strlen(buf);
+    p = buf + strlen(buf);
     *p++ = '/';
     while(read(fd, &de, sizeof(de)) == sizeof(de)){
       if(de.inum == 0)
@@ -63,7 +62,7 @@ ls(char *path)
         printf("ls: cannot stat %s\n", buf);
         continue;
       }
-      printf("%s %d %d %d\n", fmtname(buf), st.type, st.ino, st.size);
+      printf("%s %d %d %l\n", fmtname(buf), st.type, st.ino, st.size);
     }
     break;
   }
@@ -73,13 +72,11 @@ ls(char *path)
 int
 main(int argc, char *argv[])
 {
-  int i;
-
   if(argc < 2){
     ls(".");
     exit(0);
   }
-  for(i=1; i<argc; i++)
+  for(int i = 1; i < argc; i++)
     ls(argv[i]);
   exit(0);
 }

--- a/user/printf.c
+++ b/user/printf.c
@@ -6,86 +6,87 @@
 
 static char digits[] = "0123456789ABCDEF";
 
+/** Write one character to fd. */
 static void
 putc(int fd, char c)
 {
   write(fd, &c, 1);
 }
 
+/** Print an unsigned 64-bit integer in the requested base. */
 static void
-printint(int fd, int xx, int base, int sgn)
+printuint64(int fd, uint64 x, int base)
 {
-  char buf[16];
-  int i, neg;
-  uint x;
+  char buf[32];
+  int i = 0;
 
-  neg = 0;
-  if(sgn && xx < 0){
-    neg = 1;
-    x = -xx;
-  } else {
-    x = xx;
-  }
-
-  i = 0;
   do{
     buf[i++] = digits[x % base];
   }while((x /= base) != 0);
-  if(neg)
-    buf[i++] = '-';
 
   while(--i >= 0)
     putc(fd, buf[i]);
 }
 
+/** Print a signed or unsigned 32-bit integer. */
 static void
-printptr(int fd, uint64 x) {
-  int i;
+printint(int fd, int xx, int base, int sgn)
+{
+  uint x;
+
+  if(sgn && xx < 0){
+    putc(fd, '-');
+    x = -(uint)xx;
+  } else {
+    x = xx;
+  }
+  printuint64(fd, x, base);
+}
+
+/** Print a fixed-width pointer. */
+static void
+printptr(int fd, uint64 x)
+{
   putc(fd, '0');
   putc(fd, 'x');
-  for (i = 0; i < (sizeof(uint64) * 2); i++, x <<= 4)
+  for(int i = 0; i < sizeof(uint64) * 2; i++, x <<= 4)
     putc(fd, digits[x >> (sizeof(uint64) * 8 - 4)]);
 }
 
-// Print to the given fd. Only understands %d, %x, %p, %s.
+// Print to the given fd. Understands %d, %l, %x, %p, %s, %c, and %%.
 void
 vprintf(int fd, const char *fmt, va_list ap)
 {
   char *s;
-  int c, i, state;
+  int state = 0;
 
-  state = 0;
-  for(i = 0; fmt[i]; i++){
-    c = fmt[i] & 0xff;
+  for(int i = 0; fmt[i]; i++){
+    int c = fmt[i] & 0xff;
     if(state == 0){
-      if(c == '%'){
+      if(c == '%')
         state = '%';
-      } else {
+      else
         putc(fd, c);
-      }
     } else if(state == '%'){
-      if(c == 'd'){
+      if(c == 'd')
         printint(fd, va_arg(ap, int), 10, 1);
-      } else if(c == 'l') {
-        printint(fd, va_arg(ap, uint64), 10, 0);
-      } else if(c == 'x') {
+      else if(c == 'l')
+        printuint64(fd, va_arg(ap, uint64), 10);
+      else if(c == 'x')
         printint(fd, va_arg(ap, int), 16, 0);
-      } else if(c == 'p') {
+      else if(c == 'p')
         printptr(fd, va_arg(ap, uint64));
-      } else if(c == 's'){
+      else if(c == 's'){
         s = va_arg(ap, char*);
         if(s == 0)
           s = "(null)";
-        while(*s != 0){
-          putc(fd, *s);
-          s++;
-        }
+        while(*s != 0)
+          putc(fd, *s++);
       } else if(c == 'c'){
         putc(fd, va_arg(ap, uint));
       } else if(c == '%'){
         putc(fd, c);
       } else {
-        // Unknown % sequence.  Print it to draw attention.
         putc(fd, '%');
         putc(fd, c);
       }
@@ -98,7 +99,6 @@ void
 fprintf(int fd, const char *fmt, ...)
 {
   va_list ap;
-
   va_start(ap, fmt);
   vprintf(fd, fmt, ap);
 }
@@ -107,7 +107,6 @@ void
 printf(const char *fmt, ...)
 {
   va_list ap;
-
   va_start(ap, fmt);
   vprintf(1, fmt, ap);
 }


### PR DESCRIPTION
Closes #29

## 实现了什么（功能清单一览）

- 将 inode 文件大小、内存 inode 大小和打开文件偏移统一扩展为 64 位，`readi()` / `writei()` 使用 64 位 offset。
- 在保持磁盘 inode 为 64 字节的前提下，将布局调整为：
  - 9 个直接块；
  - 1 个一级间接根；
  - 1 个二级间接根；
  - 1 个三级间接根。
- 基于 PR #39 的层级思路，将 block mapping / truncate 扩展为深度 1～3 的统一遍历，支持超过 4 GiB 的稠密顺序文件。
- `balloc()` 增加受锁保护的循环分配游标，避免连续分配时每次从位图起点重扫；磁盘满改为返回失败，不再 panic。
- `writei()` / `filewrite()` 支持磁盘满时短写：已提交字节保留并返回，首字节都未写入时返回 `-1`。
- 为一次性删除 4 GiB 文件扩展物理日志：
  - 日志区域 600 块；
  - 多块日志头；
  - 续接头先写、首头中的 `n` 最后写，首头仍作为事务发布点；
  - 单操作最坏写集预留 540 块，可覆盖约 519 个位图块和 inode/目录元数据。
- 新增稀疏大镜像生成器 `mkfs/mkfs_large.c`，逻辑大小约 4.35 GB，不在宿主机预先写满零块。
- 新增 `FSIMG` 可覆盖变量、`fs-large.img` 与显式 `largefiletest`；4 GiB 回归不进入日常 `make test`。
- 修正用户态 `%l` 与 `ls`，避免超过 32 位的文件大小显示截断。
- 将原 Lab9 `bigfile` 固定在直接/一级/二级间接范围，避免 `MAXFILE` 扩大后意外演变成约 17 GiB 日常测试。

## 添加/修改了什么单元测试（断言类）

### guest 断言：`tests/guest/largefile.c`

一次完整执行覆盖：

1. 顺序写入 `4 GiB + 1 KiB` 的确定性数据；
2. `fstat.size` 精确跨越 `2^32`；
3. 关闭并重开文件后完整顺序读回并逐块校验；
4. 继续写满剩余磁盘，验证短写/错误返回而非内核 panic；
5. 删除大文件和填充文件；
6. 再次写到第一个三级间接数据块，验证数据块与索引块已可重用。

### guest registry

- 注册 `xv6test --run largefs-4gib`；
- 保留 `core-shell-history` 等最新主线注册内容，仅增加两行大文件注册差异。

### host 编排自测

- `tests/test_largefile_runner.py` 验证：
  - guest 源码、UPROGS、大镜像和 Make target 已接线；
  - `largefs-4gib` 只存在于显式 runner；
  - 不被日常 `pr` / `full` suite 间接包含。

## 如何通过 CLI 命令进行回归观察此 PR 现象

### 1. 构建普通镜像并做日常回归

```bash
git fetch origin
git switch concept/29-4gib-file
make clean
make
make test-unit
make test CPUS=3
```

### 2. 执行完整 4 GiB 回归（默认 3 CPU）

```bash
make largefiletest CPUS=3
```

成功时应看到：

```text
largefile: PASS bytes=4294968320
XV6TEST summary selected=1 passed=1 failed=0
XV6TEST done status=0
```

### 3. 补充单核观察

```bash
make largefiletest CPUS=1
```

单核结果只用于定位并发差异，不能替代 `CPUS=3` 结果。

### 4. 手工进入大镜像验收

```bash
make fs-large.img
make qemu FSIMG=fs-large.img CPUS=3
```

进入 xv6 shell 后：

```text
xv6test --run largefs-4gib
```

## 单元自动化测试结果

基线 Commit：`92fe5aefc4a8fe155d84dbcafa90099687c4c332`

已实际完成：

- RISC-V Clang 语法检查：
  - `kernel/fs.c`
  - `kernel/file.c`
  - `kernel/log.c`
  - `user/printf.c`
  - `user/ls.c`
  - `tests/guest/bigfile.c`
  - `tests/guest/largefile.c`
  - `tests/guest/xv6test.c`
- 宿主机编译：

```bash
gcc -Wall -Werror -I. -DFSSIZE=4250000 \
  -o /tmp/mkfs-large-check mkfs/mkfs_large.c
```

- 稀疏镜像实测：
  - 逻辑大小：`4352000000` bytes；
  - 实际占用：约 `536 KiB`；
  - 几何信息：600 个日志块、519 个位图块、4,248,866 个数据块。
- `tests/run_largefile.py` / `tests/test_largefile_runner.py` Python 语法检查通过；runner 接线单测通过。
- Make dry-run 已确认 `FSIMG=fs-large.img` 会传递给 QEMU，`largefiletest` 命令与依赖正确。
- 容量不变量检查：
  - 三级最大文件：`17,247,249,408` bytes；
  - 测试目标：`4,294,968,320` bytes；
  - 日志可用数据槽：597；
  - 大文件删除预估写集：519 个位图块 + 少量 inode/目录块，小于 540 预留。

当前执行环境缺少 RISC-V GCC/binutils 与 `qemu-system-riscv64`，因此以下项目**尚未实际运行，不能标记为通过**：

```bash
make clean
make
make test-unit
make test CPUS=3
make largefiletest CPUS=3
make largefiletest CPUS=1
```

Draft PR 保持未就绪，等待具备 xv6 工具链的环境完成上述真实构建和 QEMU 验收。

## review 主线（先看什么，再看什么）

1. `kernel/fs.h` / `kernel/file.h`
   - 先确认 64 字节磁盘 inode 布局、64 位 size/off 与三级容量公式。
2. `kernel/fs.c`
   - 再看 `balloc()` 游标与磁盘满语义；
   - 然后看 `bmap()` / `bmap_indirect()`；
   - 最后看 `bfree_indirect()` / `itrunc()` 和部分分配失败后的可回收性。
3. `kernel/log.c` / `kernel/param.h`
   - 重点检查多块日志头的发布顺序、恢复路径、日志槽与 buffer 数量不变量。
4. `kernel/file.c`
   - 检查短写如何向用户态传播，以及 64 位打开文件偏移如何推进。
5. `mkfs/mkfs_large.c` / `Makefile`
   - 检查稀疏镜像、位图初始化、`FSIMG` 传递和显式测试隔离。
6. `tests/guest/largefile.c`
   - 按“跨 4 GiB → 读回 → 磁盘满 → unlink → 三级重用”顺序核对断言闭环。

## 教学边界与未覆盖范围

- 磁盘 inode 格式发生变化，旧 `fs.img` 不兼容；本 PR 不实现格式迁移。
- 不实现 `lseek`、稀疏文件语义或完整 POSIX large-file API；这里只覆盖现有顺序读写接口的 64 位内部路径。
- 最大容量止于三级间接块，不继续扩展四级索引。
- 600 块日志与 540 块单操作预留会使文件系统操作在日志层基本串行化；这是为保持大文件删除原子性的教学实现，不代表生产文件系统策略。
- 4 GiB 回归会真实读写约 8 GiB 数据量（写入并读回），因此必须显式执行，不纳入普通 PR 回归。
- 本 PR 只修改 xv6 仓库，未修改 Obsidian 笔记。
