### PR TITLE
ci: 按变更范围选择 PR 回归用例

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: xv6 CI
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # 新加坡时间 02:30 执行完整慢速回归，避免占用白天的 PR 反馈窗口。
+    - cron: "30 18 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,13 +17,16 @@ concurrency:
 
 jobs:
   regression:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 50
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # PR 事件需要同时读取 base/head commit，才能可靠计算 changed files。
+          fetch-depth: 0
 
       - name: Install toolchain
         run: |
@@ -32,7 +39,11 @@ jobs:
 
       - name: Unit-test regression grader
         run: |
-          python3 -m py_compile tests/run.py tests/test_runner.py
+          python3 -m py_compile \
+            tests/run.py \
+            tests/test_runner.py \
+            tests/ci_plan.py \
+            tests/test_ci_plan.py
           make test-unit
           python3 tests/run.py --list
 
@@ -41,11 +52,46 @@ jobs:
           make clean
           make -j2
 
-      - name: Run Lab1-10 QEMU regression
-        run: make test-integration CPUS=3
+      - name: Select PR regression suites
+        if: github.event_name == 'pull_request'
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
+          echo "Changed files:"
+          cat /tmp/changed-files.txt
+          python3 tests/ci_plan.py < /tmp/changed-files.txt | tee -a "$GITHUB_OUTPUT"
 
-      - name: Run complete usertests
-        run: make test-usertests CPUS=3
+      - name: Run shell history interaction regression
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.shell_history == 'true'
+        run: python3 tests/shell_history_interactive.py --cpus 3
+
+      - name: Run selected PR QEMU regression
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.suites != ''
+        env:
+          SELECTED_SUITES: ${{ steps.plan.outputs.suites }}
+        run: |
+          IFS=',' read -r -a suites <<< "$SELECTED_SUITES"
+          args=()
+          for suite in "${suites[@]}"; do
+            if [[ -n "$suite" ]]; then
+              args+=(--suite "$suite")
+            fi
+          done
+          printf 'Selected PR suites: %s\n' "${suites[*]}"
+          python3 tests/run.py "${args[@]}" --cpus 3
+
+      - name: Run scheduled or manual full regression
+        if: github.event_name != 'pull_request'
+        run: |
+          python3 tests/shell_history_interactive.py --cpus 3
+          make test-full CPUS=3
 
       - name: Upload QEMU logs
         if: failure()

--- a/tests/ci_plan.py
+++ b/tests/ci_plan.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""根据 Pull Request 的 changed files 生成最小且安全的 xv6 CI 回归计划。"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Iterable, Sequence
+
+
+# 未识别改动仍执行除 lab9-bigfile 外的现有 PR 回归集，避免选择器漏配后静默降级。
+PR_FALLBACK_SUITES = (
+    "lab-basic",
+    "lab-vm",
+    "lab7-thread",
+    "lab8-locks",
+    "lab9-symlink",
+    "lab10-mmap",
+    "usertests-core",
+)
+FILESYSTEM_SUITES = (
+    "lab9-symlink",
+    "lab10-mmap",
+    "usertests-core",
+    "lab9-bigfile",
+)
+VM_SUITES = ("lab-vm", "usertests-core")
+CONCURRENCY_SUITES = ("lab7-thread", "lab8-locks", "usertests-core")
+BASIC_SUITES = ("lab-basic", "usertests-core")
+USERSPACE_SUITES = ("usertests-core",)
+
+DOCUMENT_SUFFIXES = (".md", ".markdown")
+TEST_INFRASTRUCTURE_PATHS = {
+    ".github/workflows/ci.yml",
+    "tests/ci_plan.py",
+    "tests/run.py",
+    "tests/test_ci_plan.py",
+    "tests/test_runner.py",
+}
+SHELL_HISTORY_PATHS = {
+    "user/sh.c",
+    "tests/guest/consolelinetest.c",
+    "tests/guest/historytest.c",
+    "tests/shell_history_interactive.py",
+}
+FILESYSTEM_PATHS = {
+    "kernel/bio.c",
+    "kernel/file.c",
+    "kernel/fs.c",
+    "kernel/fs.h",
+    "kernel/log.c",
+    "kernel/sysfile.c",
+    "kernel/virtio_disk.c",
+    "mkfs/mkfs.c",
+    "tests/guest/bigfile.c",
+    "tests/guest/symlinktest.c",
+}
+MMAP_PATHS = {
+    "kernel/vma.c",
+    "kernel/vma.h",
+    "tests/guest/mmaptest.c",
+}
+VM_PATHS = {
+    "kernel/exec.c",
+    "kernel/kalloc.c",
+    "kernel/memlayout.h",
+    "kernel/memviz.c",
+    "kernel/riscv.h",
+    "kernel/sysmemviz.c",
+    "kernel/trap.c",
+    "kernel/vm.c",
+    "kernel/vmcopyin.c",
+    "tests/guest/cowtest.c",
+    "tests/guest/lazytests.c",
+    "tests/guest/memviztest.c",
+    "tests/guest/vaaccesstest.c",
+}
+CONCURRENCY_PATHS = {
+    "kernel/proc.c",
+    "kernel/sleeplock.c",
+    "kernel/spinlock.c",
+    "kernel/swtch.S",
+    "tests/guest/uthreadtest.c",
+    "tests/host/barrier.c",
+    "tests/host/ph.c",
+}
+BASIC_PATHS = {
+    "kernel/syscall.c",
+    "kernel/syscall.h",
+    "kernel/sysproc.c",
+    "tests/guest/lab1test.c",
+    "tests/guest/sysinfotest.c",
+    "tests/guest/tracemasktest.c",
+    "tests/guest/tracesmoke.c",
+}
+
+
+@dataclass(frozen=True)
+class CiPlan:
+    """描述 PR 需要运行的 QEMU suite 与额外 shell 交互检查。"""
+
+    suites: tuple[str, ...]
+    run_shell_history: bool = False
+
+
+def _normalize_path(path: str) -> str:
+    """将 Git 输出的相对路径规范为无前导 ``./`` 的 POSIX 路径。
+
+    Args:
+        path: ``git diff --name-only`` 输出的一行路径，允许包含首尾空白。
+
+    Returns:
+        规范化路径；空白输入返回空字符串。
+    """
+
+    stripped = path.strip()
+    if not stripped:
+        return ""
+    normalized = PurePosixPath(stripped).as_posix()
+    return normalized.removeprefix("./")
+
+
+def _deduplicate(values: Iterable[str]) -> tuple[str, ...]:
+    """按首次出现顺序去重 suite 名称。
+
+    Args:
+        values: 按风险规则累积的 suite 名称序列。
+
+    Returns:
+        稳定有序且不含重复项的 suite 元组。
+    """
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+def _is_documentation_path(path: str) -> bool:
+    """判断路径是否只影响不会进入 xv6 镜像的文档或许可证文件。
+
+    Args:
+        path: 已规范化的仓库相对路径。
+
+    Returns:
+        文档或许可证路径返回 True；其他路径返回 False。
+    """
+
+    lower_path = path.lower()
+    return lower_path.endswith(DOCUMENT_SUFFIXES) or lower_path.startswith("license")
+
+
+def build_ci_plan(changed_paths: Iterable[str]) -> CiPlan:
+    """根据 changed files 选择覆盖相关风险的最小回归集合。
+
+    Args:
+        changed_paths: PR 相对 base 分支修改的仓库路径。空行会被忽略。
+
+    Returns:
+        QEMU suite 与 shell history 交互检查组成的不可变计划。文档-only
+        变更返回空 suite；没有任何有效路径时按未知改动回退到完整 PR 集。
+    """
+
+    paths = tuple(
+        normalized
+        for raw_path in changed_paths
+        if (normalized := _normalize_path(raw_path))
+    )
+    if not paths:
+        return CiPlan(PR_FALLBACK_SUITES)
+
+    selected: list[str] = []
+    fallback_required = False
+    runtime_path_seen = False
+    run_shell_history = False
+
+    for path in paths:
+        if _is_documentation_path(path):
+            continue
+
+        runtime_path_seen = True
+        matched = False
+
+        # 测试编排自身变化可能影响所有映射，必须使用较宽的 PR 回归集兜底。
+        if path in TEST_INFRASTRUCTURE_PATHS:
+            fallback_required = True
+            matched = True
+
+        if path in SHELL_HISTORY_PATHS:
+            selected.extend(USERSPACE_SUITES)
+            run_shell_history = True
+            matched = True
+
+        if path in FILESYSTEM_PATHS:
+            selected.extend(FILESYSTEM_SUITES)
+            matched = True
+
+        if path in MMAP_PATHS:
+            selected.extend(("lab10-mmap", "usertests-core"))
+            matched = True
+
+        if path in VM_PATHS:
+            selected.extend(VM_SUITES)
+            matched = True
+
+        if path in CONCURRENCY_PATHS:
+            selected.extend(CONCURRENCY_SUITES)
+            matched = True
+
+        if path in BASIC_PATHS:
+            selected.extend(BASIC_SUITES)
+            matched = True
+
+        # 用户程序、guest 断言与构建清单通过 focused usertests 验证即可；完整
+        # 编译已经在工作流中单独执行，不因 Makefile 变化强制跑全部 Lab。
+        if path == "Makefile" or path == "tests/guest/xv6test.c":
+            selected.extend(USERSPACE_SUITES)
+            matched = True
+        elif path.startswith("user/") or path.startswith("tests/guest/"):
+            selected.extend(USERSPACE_SUITES)
+            matched = True
+        elif path.startswith("tests/host/"):
+            selected.append("lab7-thread")
+            matched = True
+
+        if not matched:
+            fallback_required = True
+
+    if not runtime_path_seen:
+        return CiPlan(())
+
+    if fallback_required:
+        # 未识别改动采用现有 PR 范围；若同时命中文件系统关键路径，仍保留
+        # lab9-bigfile，避免较宽 fallback 反而丢掉慢速边界验证。
+        fallback = list(PR_FALLBACK_SUITES)
+        if "lab9-bigfile" in selected:
+            fallback.append("lab9-bigfile")
+        selected = fallback
+
+    if not selected:
+        selected.extend(PR_FALLBACK_SUITES)
+
+    return CiPlan(
+        suites=_deduplicate(selected),
+        run_shell_history=run_shell_history,
+    )
+
+
+def _read_paths(arguments: Sequence[str]) -> tuple[str, ...]:
+    """读取命令行路径，未提供参数时从标准输入逐行读取。
+
+    Args:
+        arguments: 命令行位置参数中的 changed files。
+
+    Returns:
+        原始路径元组，后续由 ``build_ci_plan`` 统一规范化。
+    """
+
+    if arguments:
+        return tuple(arguments)
+    return tuple(sys.stdin.read().splitlines())
+
+
+def parse_args() -> argparse.Namespace:
+    """解析可选 changed-file 位置参数。"""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="changed file paths; omitted arguments are read from standard input",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """输出可直接追加到 ``GITHUB_OUTPUT`` 的测试计划键值对。
+
+    Returns:
+        成功生成计划时返回 0。路径映射不会因未知文件失败，而是回退到安全集。
+    """
+
+    args = parse_args()
+    plan = build_ci_plan(_read_paths(args.paths))
+    print(f"suites={','.join(plan.suites)}")
+    print(f"shell_history={'true' if plan.run_shell_history else 'false'}")
+    print(
+        "Selected CI plan: "
+        f"suites={plan.suites or ('build-only',)}, "
+        f"shell_history={plan.run_shell_history}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""验证 changed-file 到 xv6 CI suite 的风险映射。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+PLANNER_PATH = Path(__file__).with_name("ci_plan.py")
+SPEC = importlib.util.spec_from_file_location("xv6_ci_plan", PLANNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load CI planner from {PLANNER_PATH}")
+PLANNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = PLANNER
+SPEC.loader.exec_module(PLANNER)
+
+
+class CiPlanSelectionTests(unittest.TestCase):
+    """验证常见改动只选择与风险直接相关的回归集合。"""
+
+    def test_ls_pr_uses_focused_usertests(self) -> None:
+        plan = PLANNER.build_ci_plan(
+            (
+                "Makefile",
+                "tests/guest/lstest.c",
+                "tests/guest/xv6test.c",
+                "user/ls.c",
+            )
+        )
+
+        self.assertEqual(("usertests-core",), plan.suites)
+        self.assertFalse(plan.run_shell_history)
+
+    def test_filesystem_change_keeps_bigfile_boundary_test(self) -> None:
+        plan = PLANNER.build_ci_plan(("kernel/fs.c",))
+
+        self.assertEqual(
+            (
+                "lab9-symlink",
+                "lab10-mmap",
+                "usertests-core",
+                "lab9-bigfile",
+            ),
+            plan.suites,
+        )
+
+    def test_shell_change_runs_interactive_and_core_regression(self) -> None:
+        plan = PLANNER.build_ci_plan(("user/sh.c",))
+
+        self.assertEqual(("usertests-core",), plan.suites)
+        self.assertTrue(plan.run_shell_history)
+
+    def test_test_infrastructure_change_uses_safe_pr_fallback(self) -> None:
+        plan = PLANNER.build_ci_plan(("tests/run.py",))
+
+        self.assertEqual(PLANNER.PR_FALLBACK_SUITES, plan.suites)
+        self.assertNotIn("lab9-bigfile", plan.suites)
+
+    def test_unknown_runtime_path_uses_safe_pr_fallback(self) -> None:
+        plan = PLANNER.build_ci_plan(("tools/new-helper.py",))
+
+        self.assertEqual(PLANNER.PR_FALLBACK_SUITES, plan.suites)
+
+    def test_mixed_unknown_and_filesystem_change_preserves_bigfile(self) -> None:
+        plan = PLANNER.build_ci_plan(("kernel/fs.c", "tools/new-helper.py"))
+
+        self.assertEqual(
+            PLANNER.PR_FALLBACK_SUITES + ("lab9-bigfile",),
+            plan.suites,
+        )
+
+    def test_documentation_only_change_skips_qemu(self) -> None:
+        plan = PLANNER.build_ci_plan(("README.md", "docs/testing.markdown"))
+
+        self.assertEqual((), plan.suites)
+        self.assertFalse(plan.run_shell_history)
+
+    def test_empty_input_fails_safe_to_pr_fallback(self) -> None:
+        plan = PLANNER.build_ci_plan(())
+
+        self.assertEqual(PLANNER.PR_FALLBACK_SUITES, plan.suites)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #96
- 基线 Commit：`e0c6704db56bb5171aecba6887eac159dbec0d4d`
- 分支：`ci/96-selective-regression`
- 变更类型：CI / 测试
- 影响范围：`.github/workflows/ci.yml`、PR changed-file 风险映射、QEMU regression suite 选择
- 一句话摘要：普通 PR 只运行与改动风险相关的 QEMU 回归，完整慢速测试保留在 nightly 和手动工作流中。

## 实现了什么

- 新增 `tests/ci_plan.py`，将 changed files 映射到系统调用、VM、并发、文件系统、mmap 或 focused `usertests-core` 回归。
- PR #94 对应的 `Makefile + lstest + xv6test registry + user/ls.c` 变更只选择 `usertests-core`，不再运行全部 Lab、`lab9-bigfile` 和 `usertests-full`。
- 文件系统关键路径仍显式选择 `lab9-bigfile`；未识别改动回退到除 `lab9-bigfile` 外的现有宽 PR suite 集，避免漏配导致假绿。
- shell 交互测试只在 shell/history 相关文件变化时执行；文档-only PR 完成宿主机单测和完整构建后跳过 QEMU。
- 工作流不再对每个 PR 执行完整 `usertests`；每日 02:30（Asia/Singapore）和 `workflow_dispatch` 继续运行 shell 交互回归与 `make test-full CPUS=3`。

## 添加/修改了什么单元测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `test_ls_pr_uses_focused_usertests` | PR #94 的四文件变更集合 | suite 精确等于 `usertests-core`，且不运行 shell history |
| `test_filesystem_change_keeps_bigfile_boundary_test` | `kernel/fs.c` 变化 | 计划包含 storage、mmap、core 与 `lab9-bigfile` |
| `test_shell_change_runs_interactive_and_core_regression` | `user/sh.c` 变化 | 运行 `usertests-core` 并启用交互式 history 回归 |
| `test_test_infrastructure_change_uses_safe_pr_fallback` | `tests/run.py` 变化 | 回退到宽 PR 集，同时明确排除 `lab9-bigfile` |
| `test_unknown_runtime_path_uses_safe_pr_fallback` | 未识别运行时代码 | 不静默跳过，回退到宽 PR 集 |
| `test_mixed_unknown_and_filesystem_change_preserves_bigfile` | 未识别文件与 FS 文件同时变化 | 宽回归仍保留 `lab9-bigfile` 边界用例 |
| `test_documentation_only_change_skips_qemu` | 仅 Markdown 变化 | suite 为空且不运行 shell 交互测试 |
| `test_empty_input_fails_safe_to_pr_fallback` | changed-file 输入缺失 | 使用安全回退集而非空计划 |

## 如何通过 CLI 回归观察此 PR 现象

### 操作步骤

```bash
python3 -m unittest tests.test_ci_plan -v

printf '%s\n' \
  Makefile \
  tests/guest/lstest.c \
  tests/guest/xv6test.c \
  user/ls.c \
  | python3 tests/ci_plan.py

printf '%s\n' kernel/fs.c | python3 tests/ci_plan.py
printf '%s\n' README.md | python3 tests/ci_plan.py
```

### 预期现象

```text
# ls PR
suites=usertests-core
shell_history=false

# 文件系统核心变化
suites=lab9-symlink,lab10-mmap,usertests-core,lab9-bigfile
shell_history=false

# 文档-only
suites=
shell_history=false
```

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `python3 -m py_compile tests/ci_plan.py tests/test_ci_plan.py` | 通过 | 两个新增 Python 文件语法检查成功 |
| `python3 -m unittest discover -s tests -p 'test_ci_plan.py' -v` | 通过 | `Ran 8 tests`，全部 `OK` |
| 三组选择器 CLI 样例 | 通过 | 分别输出 `usertests-core`、包含 `lab9-bigfile` 的存储计划与空文档计划 |
| `make clean && make -j2` | 待 CI | 当前执行容器无法拉取完整仓库与 RISC-V/QEMU 工具链，交由本 PR Actions 验证 |
| 选定 QEMU regression suites | 待 CI | 本 PR 修改测试基础设施，选择器将安全回退到宽 PR 集，但不会执行 `lab9-bigfile` 或 `usertests-full` |

## Review 主线

1. `tests/ci_plan.py::build_ci_plan`
   - 先确认路径分类、未知改动 fallback、文件系统慢速边界保留和文档-only 行为。
2. `tests/test_ci_plan.py::CiPlanSelectionTests`
   - 对照八类断言确认映射不会因优化而漏掉高风险回归。
3. `.github/workflows/ci.yml`
   - 最后检查 base/head diff、suite 数组传参、PR 条件执行以及 nightly/manual 完整回归入口。