### PR TITLE
feat: 补全 xv6 进程组与前台作业控制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           python3 -m py_compile \
             tests/run.py \
             tests/run_usertests.py \
+            tests/shell_history_interactive.py \
             tests/test_runner.py \
             tests/ci_plan.py \
             tests/test_ci_plan.py
@@ -69,12 +70,23 @@ jobs:
           else
             echo 'full_usertests=false' >> "$GITHUB_OUTPUT"
           fi
+          if grep -Eq '^(kernel/(console\.c|jobctl\.h|proc\.h|sysproc\.c|trap\.c|wait\.h)|user/sh\.c|tests/guest/consolelinetest\.c|tests/shell_history_interactive\.py)$' /tmp/changed-files.txt; then
+            echo 'job_control=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'job_control=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run shell history interaction regression
         if: >-
           github.event_name == 'pull_request' &&
           steps.plan.outputs.shell_history == 'true'
         run: python3 tests/shell_history_interactive.py --cpus 3
+
+      - name: Run job-control regression single-core
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.job_control == 'true'
+        run: python3 tests/run.py --suite usertests-core --cpus 1
 
       - name: Run selected PR QEMU regression
         if: >-

--- a/.github/workflows/scheduler-ci.yml
+++ b/.github/workflows/scheduler-ci.yml
@@ -100,6 +100,9 @@ jobs:
             qemu-system-misc \
             python3-pexpect
 
+      - name: Run runner unit tests
+        run: python3 -m unittest discover -s tests -p 'test_*.py' -v
+
       - name: Build default RR policy
         run: |
           make clean

--- a/.github/workflows/scheduler-ci.yml
+++ b/.github/workflows/scheduler-ci.yml
@@ -110,3 +110,14 @@ jobs:
 
       - name: Run complete usertests
         run: python3 tests/run_usertests.py --cpus 3
+
+      - name: Run reparent cleanup single-core
+        run: |
+          # CPUS 同时参与编译期 schedtrace 元数据和 QEMU -smp，切换到单核前必须
+          # 重新构建，避免使用按三核配置生成的旧目标文件掩盖回收时序问题。
+          make clean
+          make -j2 CPUS=1 SCHED_POLICY=rr
+          python3 tests/run_usertests.py \
+            --cpus 1 \
+            --case reparent2 \
+            --case reparent

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -148,13 +148,14 @@ set_console_mode(struct proc *p, struct file *file, int mode)
 }
 
 /**
- * 在 owner 关闭其 console 文件对象时回收 raw mode。
+ * 在 owner 关闭其 console 文件对象时回收 raw mode 和控制台 Shell 所有权。
  *
  * @param file 正在由 fileclose() 释放引用的文件对象。
  * @param pid 执行关闭操作的当前进程 PID。
  *
  * fileclose() 在进程正常 exit、kill 后退出及用户 trap 异常退出时都会经过此路径。
- * 非 owner、不同 file 或 cooked mode 均为无操作。该函数不持有 ftable.lock，也不睡眠。
+ * 交互式 Shell 自成以自身 PID 为 PGID 的进程组，因此 owner 退出时可通过 PID
+ * 清空 shell_pgid/fg_pgid，让 init 随后启动的新 Shell 重新声明控制台。
  */
 void
 consolefileclose(struct file *file, int pid)
@@ -162,6 +163,13 @@ consolefileclose(struct file *file, int pid)
   acquire(&cons.lock);
   if(cons.raw && cons.raw_owner == pid && cons.raw_file == file)
     clear_raw_locked();
+  if(cons.shell_pgid == pid){
+    cons.shell_pgid = 0;
+    cons.fg_pgid = 0;
+    cons.control_pgid = 0;
+    cons.control_action = 0;
+    wakeup(&cons.r);
+  }
   release(&cons.lock);
 }
 

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -18,6 +18,7 @@
 #include "defs.h"
 #include "proc.h"
 #include "console.h"
+#include "jobctl.h"
 
 #define BACKSPACE 0x100
 #define C(x)  ((x)-'@')  // Control-x
@@ -39,10 +40,12 @@ consputc(int c)
 }
 
 /**
- * 保存 console 输入环形缓冲区及当前最小行规约状态。
+ * 保存 console 输入环形缓冲区、最小行规约和单控制台前台进程组。
  *
  * raw_owner 和 raw_file 共同标识唯一允许读取、重复设置和释放 raw mode 的 Shell。
- * 所有字段均受 cons.lock 保护；raw mode 只改变输入提交与读取语义，不改变输出路径。
+ * fg_pgid 表示当前可读取终端输入的进程组；Ctrl-C/Ctrl-Z 只在 cons.lock 下记录
+ * pending action，真正的进程表扫描由安全锁边界外的 console_apply_pending_control()
+ * 完成。所有字段均受 cons.lock 保护。
  */
 struct {
   struct spinlock lock;
@@ -56,6 +59,10 @@ struct {
   int raw;
   int raw_owner;
   struct file *raw_file;
+  int shell_pgid;
+  int fg_pgid;
+  int control_pgid;
+  int control_action;
 } cons;
 
 /**
@@ -113,7 +120,10 @@ set_console_mode(struct proc *p, struct file *file, int mode)
 
   acquire(&cons.lock);
   if(mode == CONSOLE_MODE_RAW){
-    if(cons.raw){
+    // 只有当前前台 Shell 可以接管逐字节输入；后台进程不能借 raw mode 绕过隔离。
+    if(cons.fg_pgid != 0 && p->pgid != cons.fg_pgid){
+      result = -1;
+    } else if(cons.raw){
       if(cons.raw_owner != p->pid || cons.raw_file != file)
         result = -1;
     } else if(cons.r != cons.w || cons.w != cons.e){
@@ -171,13 +181,73 @@ sys_consolemode(void)
   struct file *file;
   int fd;
   int mode;
+  int pgid;
 
   if(argint(0, &fd) < 0 || argint(1, &mode) < 0)
     return -1;
   if((file = console_file(p, fd)) == 0 ||
      strncmp(p->name, "sh", sizeof(p->name)) != 0)
     return -1;
+  if((pgid = getpgid(0)) < 0)
+    return -1;
+  p->pgid = pgid;
   return set_console_mode(p, file, mode);
+}
+
+/**
+ * 将单控制台的前台输入所有权交给一个进程组。
+ *
+ * 只有最初声明控制台所有权的交互式 sh 进程组可以切换。目标必须是 Shell 自身
+ * 或其直接子进程领导的现有进程组；本接口不实现 session、多个 TTY 或 tcgetpgrp。
+ */
+uint64
+sys_tcsetpgrp(void)
+{
+  struct proc *p = myproc();
+  int pgid;
+  int caller_pgid;
+
+  if(argint(0, &pgid) < 0 || pgid <= 0 ||
+     strncmp(p->name, "sh", sizeof(p->name)) != 0)
+    return -1;
+  if((caller_pgid = getpgid(0)) < 0)
+    return -1;
+  if(pgid != caller_pgid && getpgid(pgid) != pgid)
+    return -1;
+
+  acquire(&cons.lock);
+  if(cons.shell_pgid == 0)
+    cons.shell_pgid = caller_pgid;
+  if(cons.shell_pgid != caller_pgid || cons.raw){
+    release(&cons.lock);
+    return -1;
+  }
+  cons.fg_pgid = pgid;
+  release(&cons.lock);
+  return 0;
+}
+
+/**
+ * 在 console 锁之外应用 Ctrl-C/Ctrl-Z 记录的进程组动作。
+ *
+ * 任意 CPU 的 trap 路径都可以调用本函数。调用者只会竞争很短的 cons.lock，取走
+ * pending action 后再扫描 proc 表，从而保持 `cons.lock -> p->lock` 不形成锁序。
+ */
+void
+console_apply_pending_control(void)
+{
+  int pgid;
+  int action;
+
+  acquire(&cons.lock);
+  pgid = cons.control_pgid;
+  action = cons.control_action;
+  cons.control_pgid = 0;
+  cons.control_action = 0;
+  release(&cons.lock);
+
+  if(pgid > 0 && action != 0)
+    proc_group_control(pgid, action);
 }
 
 //
@@ -206,7 +276,8 @@ consolewrite(int user_src, uint64 src, int n)
  * @param user_dst 非零表示 dst 是用户地址，零表示内核地址。
  * @param dst 输出地址。
  * @param n 最大读取字节数。
- * @return 已复制字节数；进程被杀死、copyout 失败或 raw mode 非 owner 读取返回 -1。
+ * @return 已复制字节数；进程被杀死、copyout 失败、后台进程组或 raw 非 owner
+ *         读取返回 -1。
  *
  * cooked mode 保留原 xv6 Ctrl-D 和换行返回语义。raw mode 只允许 owner 读取，并
  * 立即返回当前可用字节；Shell 每次请求一个字节，从而在用户态维护 Escape 状态机。
@@ -217,10 +288,19 @@ consoleread(int user_dst, uint64 dst, int n)
   uint target;
   int c;
   char cbuf;
-  int pid = myproc()->pid;
+  struct proc *p = myproc();
+  int pid = p->pid;
+  int pgid = getpgid(0);
+
+  if(pgid < 0)
+    return -1;
 
   target = n;
   acquire(&cons.lock);
+  if(cons.fg_pgid != 0 && cons.fg_pgid != pgid){
+    release(&cons.lock);
+    return -1;
+  }
   if(cons.raw && cons.raw_owner != pid){
     release(&cons.lock);
     return -1;
@@ -229,7 +309,11 @@ consoleread(int user_dst, uint64 dst, int n)
   while(n > 0){
     // wait until interrupt handler has put some input into cons.buffer.
     while(cons.r == cons.w){
-      if(myproc()->killed){
+      if(p->killed){
+        release(&cons.lock);
+        return -1;
+      }
+      if(cons.fg_pgid != 0 && cons.fg_pgid != pgid){
         release(&cons.lock);
         return -1;
       }
@@ -280,9 +364,9 @@ consoleread(int user_dst, uint64 dst, int n)
  *
  * @param c UART 提供的输入字节。
  *
- * Ctrl-P 始终保留为内核 procdump 控制键。raw mode 不回显、不转换 CR，也不解释
- * Backspace、Ctrl-U 或 Ctrl-D，并在每个字节到达时唤醒 owner。cooked mode 保持
- * 原 xv6 的逐行提交与内核编辑行为。
+ * Ctrl-P 始终保留为内核 procdump 控制键。当前前台不是 Shell 时，Ctrl-C/Ctrl-Z
+ * 分别记录 TERM/STOP；扫描进程组留给 trap 安全点。raw mode 不回显、不转换 CR，
+ * 也不解释 Backspace、Ctrl-U 或 Ctrl-D，并在每个字节到达时唤醒 owner。
  */
 void
 consoleintr(int c)
@@ -291,6 +375,18 @@ consoleintr(int c)
 
   if(c == C('P')){
     procdump();
+    release(&cons.lock);
+    return;
+  }
+
+  if((c == C('C') || c == C('Z')) && cons.fg_pgid > 0 &&
+     cons.fg_pgid != cons.shell_pgid){
+    int action = c == C('C') ? JOBCTL_TERM : JOBCTL_STOP;
+    // TERM 优先级高于尚未执行的 STOP，避免快速 Ctrl-Z/Ctrl-C 留下永久停止作业。
+    if(cons.control_action == 0 || action == JOBCTL_TERM){
+      cons.control_pgid = cons.fg_pgid;
+      cons.control_action = action;
+    }
     release(&cons.lock);
     return;
   }

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -197,8 +197,9 @@ sys_consolemode(void)
 /**
  * 将单控制台的前台输入所有权交给一个进程组。
  *
- * 只有最初声明控制台所有权的交互式 sh 进程组可以切换。目标必须是 Shell 自身
- * 或其直接子进程领导的现有进程组；本接口不实现 session、多个 TTY 或 tcgetpgrp。
+ * 只有最初声明控制台所有权的交互式 sh 进程组可以切换。stdin 为 pipe/文件的
+ * 非交互 Shell 返回成功但不修改 console，保持现有 pipe-driven Shell 测试隔离。
+ * 目标必须是 Shell 自身或其直接子进程领导的现有进程组。
  */
 uint64
 sys_tcsetpgrp(void)
@@ -212,6 +213,10 @@ sys_tcsetpgrp(void)
     return -1;
   if((caller_pgid = getpgid(0)) < 0)
     return -1;
+
+  // 非交互 Shell 没有 controlling console；不允许它篡改真实交互 Shell 的 fg_pgid。
+  if(console_file(p, 0) == 0)
+    return 0;
   if(pgid != caller_pgid && getpgid(pgid) != pgid)
     return -1;
 

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -26,6 +26,7 @@ void            consoleinit(void);
 void            consoleintr(int);
 void            consputc(int);
 void            consolefileclose(struct file*, int);
+void            console_apply_pending_control(void);
 
 // exec.c
 int             exec(char*, char**);
@@ -98,6 +99,10 @@ int             growproc(int);
 pagetable_t     proc_pagetable(struct proc *);
 void            proc_freepagetable(pagetable_t, uint64);
 int             kill(int);
+int             setpgid(int, int);
+int             getpgid(int);
+int             proc_group_control(int, int);
+void            proc_stop_if_requested(void);
 struct cpu*     mycpu(void);
 struct cpu*     getmycpu(void);
 struct proc*    myproc();

--- a/kernel/jobctl.h
+++ b/kernel/jobctl.h
@@ -1,0 +1,11 @@
+#ifndef XV6_JOBCTL_H
+#define XV6_JOBCTL_H
+
+/** 停止目标进程组；已停止成员保持不变。 */
+#define JOBCTL_STOP 1
+/** 继续目标进程组；STOPPED 成员重新进入 RUNNABLE。 */
+#define JOBCTL_CONT 2
+/** 终止目标进程组；睡眠或停止成员会被唤醒以完成退出。 */
+#define JOBCTL_TERM 3
+
+#endif

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -40,8 +40,8 @@ extern struct cpu cpus[NCPU];
 // uservec in trampoline.S saves user registers in the trapframe,
 // then initializes registers from the trapframe's
 // kernel_sp, kernel_hartid, kernel_satp, and jumps to kernel_trap.
-// usertrapret() and userret in trampoline.S set up
-// the trapframe's kernel_*, restore user registers from the
+// usertrapret() and userret in trampoline.S set up the
+// trapframe's kernel_*, restore user registers from the
 // trapframe, switch to the user page table, and enter user space.
 // the trapframe includes callee-saved user registers like s0-s11 because the
 // return-to-user path via usertrapret() doesn't return through
@@ -99,7 +99,16 @@ _Static_assert((__builtin_offsetof(struct trapframe, a0) -
                USER_CONTEXT_A0_INDEX,
                "user_context a0 index must match trapframe");
 
-enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
+/**
+ * STOPPED 表示进程保留全部资源与用户现场，但不会被 scheduler() 选中。
+ * 继续事件只把该状态恢复为 RUNNABLE，不模拟完整 POSIX signal pending queue。
+ */
+enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, STOPPED, ZOMBIE };
+
+/** 等待父进程一次性消费的停止事件。 */
+#define PROC_EVENT_STOPPED 1
+/** 等待父进程一次性消费的继续事件。 */
+#define PROC_EVENT_CONTINUED 2
 
 // 调度实体内嵌于 proc，调度器和中断路径无需动态分配队列节点。
 struct sched_entity {
@@ -138,6 +147,9 @@ struct proc {
   int killed;                  // If non-zero, have been killed
   int xstate;                  // Exit status to be returned to parent's wait
   int pid;                     // Process ID
+  int pgid;                    // Process-group ID; fork() inherits the parent's value.
+  int stop_requested;          // RUNNING process should enter STOPPED before user return.
+  int wait_events;             // PROC_EVENT_* bits; wait_lock protects consumption.
   struct sched_entity sched;   // Policy-owned scheduling state.
 
   // these are private to the process, so p->lock need not be held.

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -122,6 +122,10 @@ extern uint64 sys_sched_set_weight(void);
 extern uint64 sys_sched_get_stats(void);
 extern uint64 sys_schedtrace(void);
 extern uint64 sys_ucontext_switch(void);
+extern uint64 sys_setpgid(void);
+extern uint64 sys_getpgid(void);
+extern uint64 sys_procctl(void);
+extern uint64 sys_tcsetpgrp(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -162,6 +166,10 @@ static uint64 (*syscalls[])(void) = {
 [SYS_sched_get_stats]  sys_sched_get_stats,
 [SYS_schedtrace]       sys_schedtrace,
 [SYS_ucontext_switch]  sys_ucontext_switch,
+[SYS_setpgid]          sys_setpgid,
+[SYS_getpgid]          sys_getpgid,
+[SYS_procctl]          sys_procctl,
+[SYS_tcsetpgrp]        sys_tcsetpgrp,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -37,3 +37,7 @@
 #define SYS_sched_get_stats  36
 #define SYS_schedtrace       37
 #define SYS_ucontext_switch  38
+#define SYS_setpgid          39
+#define SYS_getpgid          40
+#define SYS_procctl          41
+#define SYS_tcsetpgrp        42

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -43,6 +43,10 @@ static const char *const syscall_names[] = {
 [SYS_sched_get_stats]  = "sched_get_stats",
 [SYS_schedtrace]       = "schedtrace",
 [SYS_ucontext_switch]  = "ucontext_switch",
+[SYS_setpgid]          = "setpgid",
+[SYS_getpgid]          = "getpgid",
+[SYS_procctl]          = "procctl",
+[SYS_tcsetpgrp]        = "tcsetpgrp",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -11,6 +11,321 @@
 #include "schedstat.h"
 #include "schedtrace.h"
 #include "jobctl.h"
+#include "wait.h"
+
+extern struct proc proc[NPROC];
+extern struct spinlock wait_lock;
+
+/**
+ * 保存独立于 proc 槽位生命周期的作业控制状态。
+ *
+ * pid 用于识别槽位复用；当 proc 槽位被分配给新 PID 时，PGID 会从当前父进程
+ * 惰性继承，停止请求和待消费事件则重新清零。全部字段由 wait_lock 保护。
+ */
+struct job_proc_state {
+  int pid;
+  int pgid;
+  int stop_requested;
+  int wait_events;
+};
+
+static struct job_proc_state job_states[NPROC];
+
+/** 返回进程在固定 proc 表中的作业控制状态，调用者必须持有 wait_lock。 */
+static struct job_proc_state*
+job_state_locked(struct proc *p)
+{
+  struct job_proc_state *state = &job_states[p - proc];
+
+  if(state->pid != p->pid){
+    state->pid = p->pid;
+    state->stop_requested = 0;
+    state->wait_events = 0;
+    if(p->parent != 0)
+      state->pgid = job_state_locked(p->parent)->pgid;
+    else
+      state->pgid = p->pid;
+  }
+
+  // struct proc 中的字段只作为调试观察镜像，真实同步仍由 wait_lock 负责。
+  p->pgid = state->pgid;
+  p->stop_requested = state->stop_requested;
+  p->wait_events = state->wait_events;
+  return state;
+}
+
+/** 在 fork 返回父进程前固化子进程继承到的 PGID。 */
+static void
+job_register_fork_child(int child_pid)
+{
+  struct proc *parent = myproc();
+
+  acquire(&wait_lock);
+  for(struct proc *child = proc; child < &proc[NPROC]; child++){
+    acquire(&child->lock);
+    if(child->pid == child_pid && child->parent == parent &&
+       child->state != UNUSED){
+      struct job_proc_state *parent_state = job_state_locked(parent);
+      struct job_proc_state *child_state = job_state_locked(child);
+      child_state->pgid = parent_state->pgid;
+      child->pgid = child_state->pgid;
+      release(&child->lock);
+      break;
+    }
+    release(&child->lock);
+  }
+  release(&wait_lock);
+}
+
+/**
+ * 将当前进程或其直接子进程放入指定进程组。
+ *
+ * pid 为 0 时选择当前进程；pgid 为 0 时创建以目标 PID 为组号的新进程组。
+ * 为保持教学接口可审阅，本实现不允许修改任意无亲缘关系进程。
+ */
+int
+setpgid(int pid, int pgid)
+{
+  struct proc *caller = myproc();
+  int target_pid = pid == 0 ? caller->pid : pid;
+  int result = -1;
+
+  if(target_pid <= 0 || pgid < 0)
+    return -1;
+
+  acquire(&wait_lock);
+  for(struct proc *target = proc; target < &proc[NPROC]; target++){
+    acquire(&target->lock);
+    if(target->pid == target_pid && target->state != UNUSED &&
+       target->state != ZOMBIE &&
+       (target == caller || target->parent == caller)){
+      struct job_proc_state *state = job_state_locked(target);
+      state->pgid = pgid == 0 ? target_pid : pgid;
+      target->pgid = state->pgid;
+      result = 0;
+      release(&target->lock);
+      break;
+    }
+    release(&target->lock);
+  }
+  release(&wait_lock);
+  return result;
+}
+
+/** 查询当前进程或直接子进程的 PGID。 */
+int
+getpgid(int pid)
+{
+  struct proc *caller = myproc();
+  int target_pid = pid == 0 ? caller->pid : pid;
+  int result = -1;
+
+  if(target_pid <= 0)
+    return -1;
+
+  acquire(&wait_lock);
+  for(struct proc *target = proc; target < &proc[NPROC]; target++){
+    acquire(&target->lock);
+    if(target->pid == target_pid && target->state != UNUSED &&
+       target->state != ZOMBIE &&
+       (target == caller || target->parent == caller)){
+      result = job_state_locked(target)->pgid;
+      release(&target->lock);
+      break;
+    }
+    release(&target->lock);
+  }
+  release(&wait_lock);
+  return result;
+}
+
+/**
+ * 对目标进程组应用停止、继续或终止动作。
+ *
+ * STOPPED 进程保留地址空间和文件等资源，但 scheduler 不会选择该状态。正在其他
+ * CPU 运行的成员只记录 stop_requested，并在下一次返回用户态前自行进入 STOPPED，
+ * 避免从远端 CPU 强行修改其运行现场。每个 STOPPED/CONTINUED 事件只置位一次，
+ * 由扩展 waitpid() 在 wait_lock 下消费。
+ */
+int
+proc_group_control(int pgid, int action)
+{
+  int found = 0;
+
+  if(pgid <= 0 ||
+     (action != JOBCTL_STOP && action != JOBCTL_CONT &&
+      action != JOBCTL_TERM))
+    return -1;
+
+  acquire(&wait_lock);
+  for(struct proc *target = proc; target < &proc[NPROC]; target++){
+    struct proc *parent = 0;
+    int event = 0;
+
+    acquire(&target->lock);
+    if(target->state != UNUSED && target->state != ZOMBIE){
+      struct job_proc_state *state = job_state_locked(target);
+      if(state->pgid == pgid){
+        found = 1;
+        parent = target->parent;
+        if(action == JOBCTL_STOP){
+          if(target->state == RUNNING){
+            state->stop_requested = 1;
+            target->stop_requested = 1;
+          } else if(target->state != STOPPED){
+            target->state = STOPPED;
+            state->stop_requested = 0;
+            target->stop_requested = 0;
+            event = PROC_EVENT_STOPPED;
+          }
+        } else if(action == JOBCTL_CONT){
+          if(target->state == STOPPED){
+            target->state = RUNNABLE;
+            state->stop_requested = 0;
+            target->stop_requested = 0;
+            event = PROC_EVENT_CONTINUED;
+          } else if(state->stop_requested){
+            state->stop_requested = 0;
+            target->stop_requested = 0;
+          }
+        } else {
+          target->killed = 1;
+          state->stop_requested = 0;
+          target->stop_requested = 0;
+          if(target->state == SLEEPING || target->state == STOPPED)
+            target->state = RUNNABLE;
+        }
+      }
+    }
+    release(&target->lock);
+
+    // wakeup() 会获取 proc 表中的锁，因此必须位于目标 p->lock 临界区之外。
+    if(event != 0){
+      struct job_proc_state *state = &job_states[target - proc];
+      state->wait_events |= event;
+      target->wait_events = state->wait_events;
+      if(parent != 0)
+        wakeup(parent);
+    }
+  }
+  release(&wait_lock);
+  return found ? 0 : -1;
+}
+
+/**
+ * 让当前 RUNNING 进程在安全调度点兑现远端 STOP 请求。
+ *
+ * 函数先发布停止事件，再持有自身 p->lock 进入 sched()。继续或终止操作必须先取得
+ * wait_lock，因而不会在 STOPPED 状态尚未交给 scheduler 时提前把进程重新设为
+ * RUNNABLE，避免同一 proc 同时在两个 CPU 上运行。
+ */
+void
+proc_stop_if_requested(void)
+{
+  struct proc *p = myproc();
+  struct proc *parent;
+
+  acquire(&wait_lock);
+  acquire(&p->lock);
+  struct job_proc_state *state = job_state_locked(p);
+  if(!state->stop_requested || p->state != RUNNING){
+    release(&p->lock);
+    release(&wait_lock);
+    return;
+  }
+
+  state->stop_requested = 0;
+  state->wait_events |= PROC_EVENT_STOPPED;
+  p->stop_requested = 0;
+  p->wait_events = state->wait_events;
+  p->state = STOPPED;
+  parent = p->parent;
+
+  release(&p->lock);
+  if(parent != 0)
+    wakeup(parent);
+  acquire(&p->lock);
+  release(&wait_lock);
+
+  sched();
+  release(&p->lock);
+}
+
+/** 在 wait_lock 下查找并复制一个匹配的停止或继续事件。 */
+static int
+job_wait_event_locked(int target_pid, uint64 status_addr, int options)
+{
+  struct proc *parent = myproc();
+
+  for(struct proc *child = proc; child < &proc[NPROC]; child++){
+    if(child->parent != parent ||
+       (target_pid != -1 && child->pid != target_pid))
+      continue;
+
+    struct job_proc_state *state = job_state_locked(child);
+    int event = 0;
+    int status = 0;
+    if((options & WUNTRACED) && (state->wait_events & PROC_EVENT_STOPPED)){
+      event = PROC_EVENT_STOPPED;
+      status = WAIT_STATUS_STOPPED;
+    } else if((options & WCONTINUED) &&
+              (state->wait_events & PROC_EVENT_CONTINUED)){
+      event = PROC_EVENT_CONTINUED;
+      status = WAIT_STATUS_CONTINUED;
+    }
+    if(event == 0)
+      continue;
+
+    if(status_addr != 0 &&
+       copyout(parent->pagetable, status_addr, (char *)&status,
+               sizeof(status)) < 0)
+      return -1;
+
+    state->wait_events &= ~event;
+    child->wait_events = state->wait_events;
+    return child->pid;
+  }
+  return 0;
+}
+
+/**
+ * 扩展 waitpid()，一次性消费 STOPPED/CONTINUED 事件并复用旧实现回收 ZOMBIE。
+ *
+ * 原 wait() 仍直接进入 proc.c 的阻塞回收路径。只有显式传入 WUNTRACED 或
+ * WCONTINUED 时才启用事件轮询；事件位持久保存，因此按时钟 tick 短暂睡眠不会
+ * 丢失通知，也不需要把 freeproc() 从 proc.c 的私有边界暴露出来。
+ */
+static int
+job_waitpid(int target_pid, uint64 status_addr, int options)
+{
+  int supported = WNOHANG | WUNTRACED | WCONTINUED;
+
+  if(target_pid == 0 || target_pid < -1 || (options & ~supported) != 0)
+    return -1;
+  if((options & (WUNTRACED | WCONTINUED)) == 0)
+    return waitpid(target_pid, status_addr, options);
+
+  for(;;){
+    acquire(&wait_lock);
+    int event_pid = job_wait_event_locked(target_pid, status_addr, options);
+    release(&wait_lock);
+    if(event_pid != 0)
+      return event_pid;
+
+    int exited_pid = waitpid(target_pid, status_addr, WNOHANG);
+    if(exited_pid != 0)
+      return exited_pid;
+    if(options & WNOHANG)
+      return 0;
+
+    // 事件位不会丢失；等待一个 tick 避免在停止态作业上忙轮询。
+    acquire(&tickslock);
+    uint start = ticks;
+    while(ticks == start)
+      sleep(&ticks, &tickslock);
+    release(&tickslock);
+  }
+}
 
 uint64
 sys_exit(void)
@@ -31,7 +346,10 @@ sys_getpid(void)
 uint64
 sys_fork(void)
 {
-  return fork();
+  int pid = fork();
+  if(pid > 0)
+    job_register_fork_child(pid);
+  return pid;
 }
 
 uint64
@@ -53,7 +371,7 @@ sys_waitpid(void)
      argaddr(1, &status) < 0 ||
      argint(2, &options) < 0)
     return -1;
-  return waitpid(pid, status, options);
+  return job_waitpid(pid, status, options);
 }
 
 /** 将当前进程或直接子进程放入指定进程组。 */
@@ -87,8 +405,6 @@ sys_procctl(void)
   int action;
 
   if(argint(0, &pgid) < 0 || argint(1, &action) < 0)
-    return -1;
-  if(action != JOBCTL_STOP && action != JOBCTL_CONT && action != JOBCTL_TERM)
     return -1;
   return proc_group_control(pgid, action);
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -10,6 +10,7 @@
 #include "sched.h"
 #include "schedstat.h"
 #include "schedtrace.h"
+#include "jobctl.h"
 
 uint64
 sys_exit(void)
@@ -53,6 +54,43 @@ sys_waitpid(void)
      argint(2, &options) < 0)
     return -1;
   return waitpid(pid, status, options);
+}
+
+/** 将当前进程或直接子进程放入指定进程组。 */
+uint64
+sys_setpgid(void)
+{
+  int pid;
+  int pgid;
+
+  if(argint(0, &pid) < 0 || argint(1, &pgid) < 0)
+    return -1;
+  return setpgid(pid, pgid);
+}
+
+/** 查询当前进程或直接子进程的 PGID。 */
+uint64
+sys_getpgid(void)
+{
+  int pid;
+
+  if(argint(0, &pid) < 0)
+    return -1;
+  return getpgid(pid);
+}
+
+/** 对整个进程组执行停止、继续或终止动作。 */
+uint64
+sys_procctl(void)
+{
+  int pgid;
+  int action;
+
+  if(argint(0, &pgid) < 0 || argint(1, &action) < 0)
+    return -1;
+  if(action != JOBCTL_STOP && action != JOBCTL_CONT && action != JOBCTL_TERM)
+    return -1;
+  return proc_group_control(pgid, action);
 }
 
 uint64

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -81,7 +81,8 @@ job_register_fork_child(int child_pid)
  * 将当前进程或其直接子进程放入指定进程组。
  *
  * pid 为 0 时选择当前进程；pgid 为 0 时创建以目标 PID 为组号的新进程组。
- * 为保持教学接口可审阅，本实现不允许修改任意无亲缘关系进程。
+ * ZOMBIE 直接子进程在 wait() 回收前仍保留 PID/PGID，使快速退出命令不会在
+ * 父子双方 setpgid 的竞态窗口中被误判为作业控制初始化失败。
  */
 int
 setpgid(int pid, int pgid)
@@ -97,7 +98,6 @@ setpgid(int pid, int pgid)
   for(struct proc *target = proc; target < &proc[NPROC]; target++){
     acquire(&target->lock);
     if(target->pid == target_pid && target->state != UNUSED &&
-       target->state != ZOMBIE &&
        (target == caller || target->parent == caller)){
       struct job_proc_state *state = job_state_locked(target);
       state->pgid = pgid == 0 ? target_pid : pgid;
@@ -112,7 +112,7 @@ setpgid(int pid, int pgid)
   return result;
 }
 
-/** 查询当前进程或直接子进程的 PGID。 */
+/** 查询当前进程或直接子进程的 PGID，ZOMBIE 在回收前仍可查询。 */
 int
 getpgid(int pid)
 {
@@ -127,9 +127,39 @@ getpgid(int pid)
   for(struct proc *target = proc; target < &proc[NPROC]; target++){
     acquire(&target->lock);
     if(target->pid == target_pid && target->state != UNUSED &&
-       target->state != ZOMBIE &&
        (target == caller || target->parent == caller)){
       result = job_state_locked(target)->pgid;
+      release(&target->lock);
+      break;
+    }
+    release(&target->lock);
+  }
+  release(&wait_lock);
+  return result;
+}
+
+/**
+ * 保持 kill(pid) 的单进程语义，同时让 STOPPED 进程重新可调度以完成退出。
+ */
+static int
+job_kill(int pid)
+{
+  int result = -1;
+
+  if(pid <= 0)
+    return -1;
+
+  acquire(&wait_lock);
+  for(struct proc *target = proc; target < &proc[NPROC]; target++){
+    acquire(&target->lock);
+    if(target->pid == pid && target->state != UNUSED){
+      struct job_proc_state *state = job_state_locked(target);
+      target->killed = 1;
+      state->stop_requested = 0;
+      target->stop_requested = 0;
+      if(target->state == SLEEPING || target->state == STOPPED)
+        target->state = RUNNABLE;
+      result = 0;
       release(&target->lock);
       break;
     }
@@ -468,7 +498,7 @@ sys_kill(void)
 
   if(argint(0, &pid) < 0)
     return -1;
-  return kill(pid);
+  return job_kill(pid);
 }
 
 // return how many clock tick interrupts have occurred

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -153,6 +153,16 @@ usertrap(void)
     p->killed = 1;
   }
 
+  // consoleintr() 只记录 Ctrl-C/Ctrl-Z；在不持有 cons.lock 时应用到整个 PGID。
+  console_apply_pending_control();
+
+  if(p->killed)
+    exit(-1);
+
+  // 远端 CPU 对 RUNNING 成员只能设置 stop_requested；当前进程在这里安全停下。
+  proc_stop_if_requested();
+
+  // STOPPED 作业可能由 TERM 唤醒；恢复后必须在返回用户态前完成退出。
   if(p->killed)
     exit(-1);
 
@@ -186,7 +196,7 @@ usertrapret(void)
   // we're back in user space, where usertrap() is correct.
   intr_off();
 
-  // send syscalls, interrupts, and exceptions to trampoline.S
+  // send interrupts and exceptions to trampoline.S
   w_stvec(TRAMPOLINE + (uservec - trampoline));
 
   // set up trapframe values that uservec will need when
@@ -196,8 +206,9 @@ usertrapret(void)
   p->trapframe->kernel_trap = (uint64)usertrap;
   p->trapframe->kernel_hartid = r_tp();         // hartid for cpuid()
 
-  // set up the registers that the trampoline.S's sret will use
-  // to get to user space.
+  // we're about to switch the destination of traps from
+  // kerneltrap() to usertrap(), so turn off interrupts until
+  // we're back in user space, where usertrap() is correct.
 
   // set S Previous Privilege mode to User.
   unsigned long x = r_sstatus();
@@ -239,6 +250,9 @@ kerneltrap()
     panic("kerneltrap");
   }
 
+  // 前台作业可能正在 sleep()，因此 UART 控制事件也必须能由内核态 trap 代为执行。
+  console_apply_pending_control();
+
   // give up the CPU if this is a timer interrupt.
   if(which_dev == 2 && myproc() != 0 && myproc()->state == RUNNING)
     yield();
@@ -256,53 +270,4 @@ clockintr()
   ticks++;
   wakeup(&ticks);
   release(&tickslock);
-}
-
-// check if it's an external interrupt or software interrupt,
-// and handle it.
-// returns 2 if timer interrupt,
-// 1 if other device,
-// 0 if not recognized.
-int
-devintr()
-{
-  uint64 scause = r_scause();
-
-  if((scause & 0x8000000000000000L) &&
-     (scause & 0xff) == 9){
-    // this is a supervisor external interrupt, via PLIC.
-
-    // irq indicates which device interrupted.
-    int irq = plic_claim();
-
-    if(irq == UART0_IRQ){
-      uartintr();
-    } else if(irq == VIRTIO0_IRQ){
-      virtio_disk_intr();
-    } else if(irq){
-      printf("unexpected interrupt irq=%d\n", irq);
-    }
-
-    // the PLIC allows each device to raise at most one
-    // interrupt at a time; tell the device is now allowed to interrupt again.
-    if(irq)
-      plic_complete(irq);
-
-    return 1;
-  } else if(scause == 0x8000000000000001L){
-    // software interrupt from a machine-mode timer interrupt,
-    // forwarded by timervec in kernelvec.S.
-
-    if(cpuid() == 0){
-      clockintr();
-    }
-
-    // acknowledge the software interrupt by clearing
-    // the SSIP bit in sip.
-    w_sip(r_sip() & ~2);
-
-    return 2;
-  } else {
-    return 0;
-  }
 }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -196,7 +196,7 @@ usertrapret(void)
   // we're back in user space, where usertrap() is correct.
   intr_off();
 
-  // send interrupts and exceptions to trampoline.S
+  // send syscalls, interrupts, and exceptions to trampoline.S
   w_stvec(TRAMPOLINE + (uservec - trampoline));
 
   // set up trapframe values that uservec will need when
@@ -206,9 +206,8 @@ usertrapret(void)
   p->trapframe->kernel_trap = (uint64)usertrap;
   p->trapframe->kernel_hartid = r_tp();         // hartid for cpuid()
 
-  // we're about to switch the destination of traps from
-  // kerneltrap() to usertrap(), so turn off interrupts until
-  // we're back in user space, where usertrap() is correct.
+  // set up the registers that the trampoline.S's sret will use
+  // to get to user space.
 
   // set S Previous Privilege mode to User.
   unsigned long x = r_sstatus();
@@ -270,4 +269,53 @@ clockintr()
   ticks++;
   wakeup(&ticks);
   release(&tickslock);
+}
+
+// check if it's an external interrupt or software interrupt,
+// and handle it.
+// returns 2 if timer interrupt,
+// 1 if other device,
+// 0 if not recognized.
+int
+devintr()
+{
+  uint64 scause = r_scause();
+
+  if((scause & 0x8000000000000000L) &&
+     (scause & 0xff) == 9){
+    // this is a supervisor external interrupt, via PLIC.
+
+    // irq indicates which device interrupted.
+    int irq = plic_claim();
+
+    if(irq == UART0_IRQ){
+      uartintr();
+    } else if(irq == VIRTIO0_IRQ){
+      virtio_disk_intr();
+    } else if(irq){
+      printf("unexpected interrupt irq=%d\n", irq);
+    }
+
+    // the PLIC allows each device to raise at most one
+    // interrupt at a time; tell the device is now allowed to interrupt again.
+    if(irq)
+      plic_complete(irq);
+
+    return 1;
+  } else if(scause == 0x8000000000000001L){
+    // software interrupt from a machine-mode timer interrupt,
+    // forwarded by timervec in kernelvec.S.
+
+    if(cpuid() == 0){
+      clockintr();
+    }
+
+    // acknowledge the software interrupt by clearing
+    // the SSIP bit in sip.
+    w_sip(r_sip() & ~2);
+
+    return 2;
+  } else {
+    return 0;
+  }
 }

--- a/kernel/wait.h
+++ b/kernel/wait.h
@@ -3,10 +3,11 @@
 
 /** waitpid() 在匹配子进程仍运行时立即返回 0。 */
 #define WNOHANG 1
+/* 值 2 保留为历史非法 options 回归，避免扩展后悄悄改变旧测试语义。 */
 /** waitpid() 允许返回尚未退出的 STOPPED 子进程事件。 */
-#define WUNTRACED 2
+#define WUNTRACED 4
 /** waitpid() 允许返回 STOPPED -> RUNNABLE 的继续事件。 */
-#define WCONTINUED 4
+#define WCONTINUED 8
 
 /*
  * xv6 仍直接返回普通 exit status；两个高位常量只标识作业控制事件，

--- a/kernel/wait.h
+++ b/kernel/wait.h
@@ -1,1 +1,23 @@
+#ifndef XV6_WAIT_H
+#define XV6_WAIT_H
+
+/** waitpid() 在匹配子进程仍运行时立即返回 0。 */
 #define WNOHANG 1
+/** waitpid() 允许返回尚未退出的 STOPPED 子进程事件。 */
+#define WUNTRACED 2
+/** waitpid() 允许返回 STOPPED -> RUNNABLE 的继续事件。 */
+#define WCONTINUED 4
+
+/*
+ * xv6 仍直接返回普通 exit status；两个高位常量只标识作业控制事件，
+ * 避免改变既有 wait()/waitpid() 的退出状态兼容性。
+ */
+#define WAIT_STATUS_STOPPED   0x40000000
+#define WAIT_STATUS_CONTINUED 0x20000000
+
+#define WIFSTOPPED(status)   ((status) == WAIT_STATUS_STOPPED)
+#define WIFCONTINUED(status) ((status) == WAIT_STATUS_CONTINUED)
+#define WIFEXITED(status)    (!WIFSTOPPED(status) && !WIFCONTINUED(status))
+#define WEXITSTATUS(status)  (status)
+
+#endif

--- a/tests/guest/consolelinetest.c
+++ b/tests/guest/consolelinetest.c
@@ -1,19 +1,153 @@
 #include "kernel/types.h"
+#include "kernel/wait.h"
+#include "kernel/jobctl.h"
 #include "user/user.h"
+#include "tests/guest/test_assert.h"
+
+/** 子进程组向测试父进程报告的 PGID 继承快照。 */
+struct group_report {
+  int leader_pid;
+  int leader_pgid;
+  int worker_pid;
+  int worker_pgid;
+};
+
+/**
+ * 作为进程组 leader 创建一个 worker，并保持两者可被 STOP/CONT/TERM 控制。
+ *
+ * @param report_fd 写端，用于向测试父进程交付固定快照。
+ */
+static void
+group_leader(int report_fd)
+{
+  struct group_report report;
+  int worker;
+
+  if(setpgid(0, 0) < 0)
+    exit(1);
+  worker = fork();
+  if(worker < 0)
+    exit(1);
+  if(worker == 0){
+    for(;;)
+      sleep(1000);
+  }
+
+  report.leader_pid = getpid();
+  report.leader_pgid = getpgid(0);
+  report.worker_pid = worker;
+  report.worker_pgid = getpgid(worker);
+  if(write(report_fd, &report, sizeof(report)) != sizeof(report))
+    exit(1);
+  close(report_fd);
+
+  for(;;)
+    sleep(1000);
+}
+
+/**
+ * 验证 PGID、停止/继续事件、停止态终止回收和后台控制台读取隔离。
+ */
+static void
+run_jobctl_test(void)
+{
+  int report_pipe[2];
+  int result_pipe[2];
+  int leader;
+  int status = 0;
+  struct group_report report;
+
+  ASSERT_EQ(0, pipe(report_pipe));
+  leader = fork();
+  ASSERT_TRUE(leader > 0);
+  if(leader == 0){
+    close(report_pipe[0]);
+    group_leader(report_pipe[1]);
+  }
+
+  close(report_pipe[1]);
+  EXPECT_EQ(0, setpgid(leader, leader));
+  ASSERT_EQ(sizeof(report), read(report_pipe[0], &report, sizeof(report)));
+  close(report_pipe[0]);
+
+  EXPECT_EQ(leader, report.leader_pid);
+  EXPECT_EQ(leader, report.leader_pgid);
+  EXPECT_TRUE(report.worker_pid > 0);
+  EXPECT_EQ(leader, report.worker_pgid);
+  EXPECT_EQ(leader, getpgid(leader));
+
+  ASSERT_EQ(0, procctl(leader, JOBCTL_STOP));
+  ASSERT_EQ(leader, waitpid(leader, &status, WUNTRACED));
+  EXPECT_TRUE(WIFSTOPPED(status));
+  EXPECT_EQ(0, waitpid(leader, &status, WNOHANG | WUNTRACED));
+
+  ASSERT_EQ(0, procctl(leader, JOBCTL_CONT));
+  ASSERT_EQ(leader, waitpid(leader, &status, WCONTINUED));
+  EXPECT_TRUE(WIFCONTINUED(status));
+  EXPECT_EQ(0, waitpid(leader, &status, WNOHANG | WCONTINUED));
+
+  ASSERT_EQ(0, procctl(leader, JOBCTL_STOP));
+  ASSERT_EQ(leader, waitpid(leader, &status, WUNTRACED));
+  EXPECT_TRUE(WIFSTOPPED(status));
+  ASSERT_EQ(0, procctl(leader, JOBCTL_TERM));
+  ASSERT_EQ(leader, waitpid(leader, &status, 0));
+  EXPECT_EQ(-1, getpgid(leader));
+
+  // 当前测试程序属于前台组；新建子进程组读取 console 必须立即失败。
+  ASSERT_EQ(0, pipe(result_pipe));
+  int reader = fork();
+  ASSERT_TRUE(reader > 0);
+  if(reader == 0){
+    char byte = 0;
+    close(result_pipe[0]);
+    if(setpgid(0, 0) < 0)
+      exit(1);
+    int count = read(0, &byte, 1);
+    write(result_pipe[1], &count, sizeof(count));
+    close(result_pipe[1]);
+    exit(count == -1 ? 0 : 1);
+  }
+  close(result_pipe[1]);
+  EXPECT_EQ(0, setpgid(reader, reader));
+  int read_result = 0;
+  ASSERT_EQ(sizeof(read_result),
+            read(result_pipe[0], &read_result, sizeof(read_result)));
+  close(result_pipe[0]);
+  EXPECT_EQ(-1, read_result);
+  ASSERT_EQ(reader, waitpid(reader, &status, 0));
+  EXPECT_EQ(0, status);
+
+  EXPECT_EQ(-1, setpgid(-1, 1));
+  EXPECT_EQ(-1, getpgid(999999));
+  EXPECT_EQ(-1, procctl(-1, JOBCTL_STOP));
+  EXPECT_EQ(-1, procctl(getpgid(0), 999));
+
+  printf("consolelinetest: jobctl OK\n");
+  TEST_EXIT();
+}
 
 /**
  * 验证外部用户程序启动后 console 已恢复 cooked 行规约。
  *
  * 程序先输出 ready，宿主机再输入 `ab<Backspace>c<Enter>`；内核应完成退格编辑
- * 后一次返回 `ac\n`。握手避免测试输入仍停留在父 Shell 的 raw 缓冲区。
+ * 后一次返回 `ac\n`。传入 `jobctl` 时改为执行无需宿主机输入的作业控制断言。
  *
- * @return 通过 exit status 返回；成功为 0，读取错误或行规约不符为 1。
+ * @return 通过 exit status 返回；成功为 0，读取错误或断言失败为 1。
  */
 int
-main(void)
+main(int argc, char *argv[])
 {
   char buffer[8] = {0};
   int count;
+
+  if(argc == 2 && strcmp(argv[1], "jobctl") == 0){
+    run_jobctl_test();
+    exit(1);
+  }
+  if(argc != 1){
+    fprintf(2, "Usage: consolelinetest [jobctl]\n");
+    exit(2);
+  }
 
   printf("consolelinetest: ready\n");
   count = read(0, buffer, sizeof(buffer));

--- a/tests/guest/consolelinetest.c
+++ b/tests/guest/consolelinetest.c
@@ -127,10 +127,24 @@ run_jobctl_test(void)
 }
 
 /**
+ * 为真实串口作业控制测试提供一个可确定同步的长运行 pipeline 成员。
+ *
+ * ready 行经管道传给 `cat` 后证明两端已经 exec 且 foreground PGID 已生效；随后
+ * 进程保持在可停止、继续和终止的睡眠循环中，不依赖随机时序或性能阈值。
+ */
+static void
+run_hold(void)
+{
+  printf("consolelinetest: hold ready\n");
+  for(;;)
+    sleep(1000);
+}
+
+/**
  * 验证外部用户程序启动后 console 已恢复 cooked 行规约。
  *
  * 程序先输出 ready，宿主机再输入 `ab<Backspace>c<Enter>`；内核应完成退格编辑
- * 后一次返回 `ac\n`。传入 `jobctl` 时改为执行无需宿主机输入的作业控制断言。
+ * 后一次返回 `ac\n`。`jobctl` 执行内核接口断言，`hold` 为串口测试提供长运行点。
  *
  * @return 通过 exit status 返回；成功为 0，读取错误或断言失败为 1。
  */
@@ -144,8 +158,12 @@ main(int argc, char *argv[])
     run_jobctl_test();
     exit(1);
   }
+  if(argc == 2 && strcmp(argv[1], "hold") == 0){
+    run_hold();
+    exit(1);
+  }
   if(argc != 1){
-    fprintf(2, "Usage: consolelinetest [jobctl]\n");
+    fprintf(2, "Usage: consolelinetest [jobctl|hold]\n");
     exit(2);
   }
 

--- a/tests/guest/consolelinetest.c
+++ b/tests/guest/consolelinetest.c
@@ -46,6 +46,59 @@ group_leader(int report_fd)
 }
 
 /**
+ * 验证父进程在快速退出子进程成为 ZOMBIE 后仍能完成 PGID 初始化。
+ *
+ * Shell 与子进程都会在 exec 前尝试 setpgid；该测试固定覆盖子进程先退出的竞态，
+ * 避免短命令被误报为“无法创建进程组”。
+ */
+static void
+test_fast_exit_pgid(void)
+{
+  int status = -1;
+  int quick = fork();
+
+  if(quick == 0){
+    if(setpgid(0, 0) < 0)
+      exit(1);
+    exit(0);
+  }
+  ASSERT_TRUE(quick > 0);
+
+  // 给子进程足够机会进入 ZOMBIE；正确性不依赖具体 tick 数，而依赖后续状态断言。
+  sleep(3);
+  EXPECT_EQ(0, setpgid(quick, quick));
+  EXPECT_EQ(quick, getpgid(quick));
+  ASSERT_EQ(quick, waitpid(quick, &status, 0));
+  EXPECT_EQ(0, status);
+  EXPECT_EQ(-1, getpgid(quick));
+}
+
+/** 验证传统 kill(pid) 能唤醒并最终回收 STOPPED 进程。 */
+static void
+test_kill_stopped_process(void)
+{
+  int status = 0;
+  int stopped = fork();
+
+  if(stopped == 0){
+    if(setpgid(0, 0) < 0)
+      exit(1);
+    for(;;)
+      sleep(1000);
+  }
+  ASSERT_TRUE(stopped > 0);
+  ASSERT_EQ(0, setpgid(stopped, stopped));
+  ASSERT_EQ(0, procctl(stopped, JOBCTL_STOP));
+  ASSERT_EQ(stopped, waitpid(stopped, &status, WUNTRACED));
+  EXPECT_TRUE(WIFSTOPPED(status));
+
+  ASSERT_EQ(0, kill(stopped));
+  ASSERT_EQ(stopped, waitpid(stopped, &status, 0));
+  EXPECT_EQ(-1, status);
+  EXPECT_EQ(-1, getpgid(stopped));
+}
+
+/**
  * 验证 PGID、停止/继续事件、停止态终止回收和后台控制台读取隔离。
  */
 static void
@@ -56,6 +109,9 @@ run_jobctl_test(void)
   int leader;
   int status = 0;
   struct group_report report;
+
+  test_fast_exit_pgid();
+  test_kill_stopped_process();
 
   ASSERT_EQ(0, pipe(report_pipe));
   leader = fork();

--- a/tests/guest/consolelinetest.c
+++ b/tests/guest/consolelinetest.c
@@ -59,11 +59,11 @@ run_jobctl_test(void)
 
   ASSERT_EQ(0, pipe(report_pipe));
   leader = fork();
-  ASSERT_TRUE(leader > 0);
   if(leader == 0){
     close(report_pipe[0]);
     group_leader(report_pipe[1]);
   }
+  ASSERT_TRUE(leader > 0);
 
   close(report_pipe[1]);
   EXPECT_EQ(0, setpgid(leader, leader));
@@ -96,7 +96,6 @@ run_jobctl_test(void)
   // 当前测试程序属于前台组；新建子进程组读取 console 必须立即失败。
   ASSERT_EQ(0, pipe(result_pipe));
   int reader = fork();
-  ASSERT_TRUE(reader > 0);
   if(reader == 0){
     char byte = 0;
     close(result_pipe[0]);
@@ -107,6 +106,7 @@ run_jobctl_test(void)
     close(result_pipe[1]);
     exit(count == -1 ? 0 : 1);
   }
+  ASSERT_TRUE(reader > 0);
   close(result_pipe[1]);
   EXPECT_EQ(0, setpgid(reader, reader));
   int read_result = 0;

--- a/tests/guest/usertests_2g.c
+++ b/tests/guest/usertests_2g.c
@@ -1,6 +1,7 @@
 #include "kernel/types.h"
 #include "kernel/param.h"
 #include "kernel/memviz.h"
+#include "kernel/sysinfo.h"
 
 // 复用原始 usertests 的全部测试函数，但把依赖固定物理容量的入口重命名，
 // 再在本文件提供适配 2 GiB 教学机配置的确定性版本。原始源码保持可直接
@@ -23,6 +24,7 @@
 #define MEM_ALLOCATIONS 2048
 #define SBRK_ABORT_BYTES (64 * 1024 * 1024)
 #define SBRK_ABORT_STRIDE (1024 * 1024)
+#define DESCENDANT_REAP_WAIT_TICKS 100
 
 static struct memviz_snapshot adapter_before;
 static struct memviz_snapshot adapter_during;
@@ -64,6 +66,53 @@ adapter_free_pages(void)
     exit(1);
   }
   return adapter_before.free_pages;
+}
+
+/**
+ * adapter_process_count 返回当前尚未进入 UNUSED 的进程数量。
+ *
+ * @return init、Shell、测试调度进程及其全部活跃后代的总数。
+ */
+static uint64
+adapter_process_count(void)
+{
+  struct sysinfo info;
+
+  if(sysinfo(&info) < 0){
+    printf("usertests: sysinfo failed\n");
+    exit(1);
+  }
+  return info.nproc;
+}
+
+/**
+ * adapter_wait_for_process_baseline 等待由 init 异步回收的测试后代全部释放。
+ *
+ * @param test_name 当前测试名称，用于输出可定位的超时错误。
+ * @param baseline 启动测试 worker 前的进程总数。
+ * @return 进程数在有界时间内恢复到 baseline 或更低时返回 0，否则返回 -1。
+ *
+ * reparent 和 reparent2 会故意制造由 init 接管的孙进程。父测试进程 wait() 只
+ * 保证直接 worker 已回收，不能证明这些后代已经经过 freeproc()。物理页快照
+ * 必须在进程数收敛后采集，否则会把合法的异步回收窗口误判成内存泄漏。
+ */
+static int
+adapter_wait_for_process_baseline(char *test_name, uint64 baseline)
+{
+  uint64 current = adapter_process_count();
+
+  for(int waited = 0;
+      current > baseline && waited < DESCENDANT_REAP_WAIT_TICKS;
+      waited++){
+    sleep(1);
+    current = adapter_process_count();
+  }
+  if(current <= baseline)
+    return 0;
+
+  printf("\n%s: descendant cleanup timed out nproc=%d baseline=%d\n",
+         test_name, (int)current, (int)baseline);
+  return -1;
 }
 
 /**
@@ -326,13 +375,18 @@ sbrkfail(char *s)
 }
 
 /**
- * run 在独立子进程中执行一个测试并根据退出状态报告结果。
+ * run 在独立子进程中执行一个测试，并等待其交给 init 的后代完成回收。
+ *
+ * @param f 被执行的测试函数。
+ * @param s 当前测试名称，用于输出结果和回收超时诊断。
+ * @return 测试成功且后代进程数恢复到启动前基线时返回 1，否则返回 0。
  */
 int
 run(void f(char *), char *s)
 {
   int pid;
   int xstatus;
+  uint64 process_baseline = adapter_process_count();
 
   printf("test %s: ", s);
   if((pid = fork()) < 0){
@@ -345,11 +399,12 @@ run(void f(char *), char *s)
   }
 
   wait(&xstatus);
-  if(xstatus != 0)
+  int cleanup_status = adapter_wait_for_process_baseline(s, process_baseline);
+  if(xstatus != 0 || cleanup_status < 0)
     printf("FAILED\n");
   else
     printf("OK\n");
-  return xstatus == 0;
+  return xstatus == 0 && cleanup_status == 0;
 }
 
 /**

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -49,6 +49,7 @@ static char *core_linkunlink_argv[] = {"usertests", "linkunlink", 0};
 static char *core_openiput_argv[] = {"usertests", "openiput", 0};
 static char *core_schedtrace_argv[] = {"schedtracetest", 0};
 static char *core_history_argv[] = {"historytest", 0};
+static char *core_job_control_argv[] = {"consolelinetest", "jobctl", 0};
 static char *core_ls_options_argv[] = {"lstest", 0};
 static char *legacy_forktest_argv[] = {"forktest", 0};
 static char *legacy_stressfs_argv[] = {"stressfs", 0};
@@ -104,6 +105,7 @@ static struct xv6_test_case tests[] = {
   {"core", "core-openiput", core_openiput_argv},
   {"core", "core-schedtrace", core_schedtrace_argv},
   {"core", "core-shell-history", core_history_argv},
+  {"core", "core-job-control", core_job_control_argv},
   {"core", "core-ls-options", core_ls_options_argv},
   {"legacy", "legacy-forktest", legacy_forktest_argv},
   {"legacy", "legacy-stressfs", legacy_stressfs_argv},

--- a/tests/run_usertests.py
+++ b/tests/run_usertests.py
@@ -45,8 +45,19 @@ STRESS_CASES = (
 )
 
 
-def _commands() -> tuple[str, ...]:
-    """按压力前序和完整逐项回归顺序生成 xv6test 命令。"""
+def _commands(selected_cases: tuple[str, ...] = ()) -> tuple[str, ...]:
+    """生成压力前序、完整逐项或用户指定的 xv6test 命令。
+
+    Args:
+        selected_cases: 需要定向执行的 usertests 名称。非空时保持传入顺序且只运行
+            这些用例，不额外加入默认压力前序；空元组表示执行完整回归。
+
+    Returns:
+        可依次发送到同一 xv6 Shell 的命令元组。
+    """
+
+    if selected_cases:
+        return tuple(f"xv6test --usertest {name}" for name in selected_cases)
 
     commands: list[str] = []
     for name, count in STRESS_CASES:
@@ -86,11 +97,12 @@ def _assert_command_output(command: str, output: str) -> None:
             raise RUNNER.TestFailure(f"{command}: matched rejected pattern: {pattern}")
 
 
-def run(cpus: int) -> None:
+def run(cpus: int, selected_cases: tuple[str, ...] = ()) -> None:
     """在同一 QEMU snapshot 中逐项运行并立即保存失败现场。
 
     Args:
         cpus: QEMU 暴露给 xv6 的 CPU 数量，必须大于 0。
+        selected_cases: 可选定向用例；为空时执行默认完整回归。
 
     Raises:
         RUNNER.TestFailure: QEMU、guest completion 协议或输出约束失败时抛出；
@@ -100,7 +112,7 @@ def run(cpus: int) -> None:
     child = RUNNER._start_qemu(cpus)
     chunks = [child.before]
     try:
-        for command in _commands():
+        for command in _commands(selected_cases):
             child.timeout = WATCHDOG_SECONDS
             child.sendline(command)
             result = RUNNER._wait_for_qemu_command(child)
@@ -125,21 +137,28 @@ def run(cpus: int) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    """解析 QEMU CPU 数量。"""
+    """解析 QEMU CPU 数量和可重复的定向 usertests 名称。"""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--cpus", type=int, default=3, help="QEMU CPU count")
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=USERTEST_CASES,
+        dest="cases",
+        help="run only this usertests case; may be supplied more than once",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
-    """执行逐项回归并返回稳定退出状态。"""
+    """执行请求的完整或定向回归并返回稳定退出状态。"""
 
     args = parse_args()
     if args.cpus < 1:
         raise SystemExit("--cpus must be at least 1")
     try:
-        run(args.cpus)
+        run(args.cpus, tuple(args.cases or ()))
     except RUNNER.TestFailure as exc:
         print(f"FAIL usertests-full: {exc}", file=sys.stderr)
         return 1

--- a/tests/run_usertests.py
+++ b/tests/run_usertests.py
@@ -56,11 +56,29 @@ def _commands() -> tuple[str, ...]:
 
 
 def _assert_command_output(command: str, output: str) -> None:
-    """验证单个 usertests 子项经过统一协议成功结束。"""
+    """验证单个 usertests 子项经过统一协议成功结束。
+
+    Args:
+        command: 发送到 xv6 Shell 的完整命令，用于形成可定位的失败信息。
+        output: 从命令回显开始到下一个 Shell prompt 之前的原始输出。
+
+    Raises:
+        RUNNER.TestFailure: completion 状态非零、缺失协议标记、缺失业务成功文本，
+            或输出匹配默认拒绝模式时抛出。
+    """
 
     normalized = RUNNER._normalize_output(output)
-    if "XV6TEST done status=0" not in normalized:
-        raise RUNNER.TestFailure(f"{command}: missing successful XV6TEST completion")
+    completion = RUNNER.re.search(
+        r"^XV6TEST done status=(-?\d+)$",
+        normalized,
+        RUNNER.re.MULTILINE,
+    )
+    if completion is None:
+        raise RUNNER.TestFailure(f"{command}: missing XV6TEST completion marker")
+
+    status = int(completion.group(1))
+    if status != 0:
+        raise RUNNER.TestFailure(f"{command}: XV6TEST completed with status={status}")
     if "ALL TESTS PASSED" not in normalized:
         raise RUNNER.TestFailure(f"{command}: usertests did not report success")
     for pattern in RUNNER.DEFAULT_REJECTED:
@@ -69,7 +87,15 @@ def _assert_command_output(command: str, output: str) -> None:
 
 
 def run(cpus: int) -> None:
-    """在同一 QEMU snapshot 中逐项运行并立即保存失败现场。"""
+    """在同一 QEMU snapshot 中逐项运行并立即保存失败现场。
+
+    Args:
+        cpus: QEMU 暴露给 xv6 的 CPU 数量，必须大于 0。
+
+    Raises:
+        RUNNER.TestFailure: QEMU、guest completion 协议或输出约束失败时抛出；
+            所有路径都会先把当前累计输出写入 usertests-full 日志。
+    """
 
     child = RUNNER._start_qemu(cpus)
     chunks = [child.before]
@@ -83,7 +109,13 @@ def run(cpus: int) -> None:
             if result.failure is not None:
                 log_path = RUNNER._write_log("usertests-full", "usertests-full", output)
                 raise RUNNER.TestFailure(f"{result.failure}; log: {log_path}")
-            _assert_command_output(command, result.output)
+            try:
+                _assert_command_output(command, result.output)
+            except RUNNER.TestFailure as exc:
+                # 输出断言失败同样属于需要保留的 guest 现场，不能只在 panic/timeout
+                # 路径写日志，否则真正的 status=1 和业务失败文本会被调用者丢失。
+                log_path = RUNNER._write_log("usertests-full", "usertests-full", output)
+                raise RUNNER.TestFailure(f"{exc}; log: {log_path}") from exc
 
         output = "\n".join(chunks)
         log_path = RUNNER._write_log("usertests-full", "usertests-full", output)

--- a/tests/shell_history_interactive.py
+++ b/tests/shell_history_interactive.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""通过真实 QEMU 串口输入验证 xv6 Shell 行编辑与会话历史。"""
+"""通过真实 QEMU 串口输入验证 xv6 Shell 行编辑、历史与作业控制。"""
 
 from __future__ import annotations
 
 import argparse
 import re
+import time
 from pathlib import Path
 from typing import TextIO
 
@@ -94,8 +95,94 @@ def require(pattern: str, output: str, message: str) -> None:
         raise ShellHistoryFailure(f"{message}; pattern={pattern!r}; output={output!r}")
 
 
+def reject(pattern: str, output: str, message: str) -> None:
+    """要求正则模式不出现在输出中。
+
+    Args:
+        pattern: 不允许出现的正则表达式。
+        output: 待检查的终端输出。
+        message: 失败时说明被破坏的行为。
+    """
+
+    if re.search(pattern, output, re.MULTILINE | re.DOTALL) is not None:
+        raise ShellHistoryFailure(f"{message}; pattern={pattern!r}; output={output!r}")
+
+
+def run_job_control_checks(child: pexpect.spawn) -> None:
+    """通过真实控制字符验证前台 pipeline 的停止、继续和终止闭环。
+
+    `consolelinetest hold | cat` 的 ready 行只有在 pipeline 两端均完成 exec 后才会
+    到达串口，因此 Ctrl-Z 不依赖固定启动延迟。随后依次验证 jobs、bg、重复 bg、
+    fg、Ctrl-C、非法 JID，以及后台 `cat` 不能窃取 Shell 的下一条输入。
+
+    Args:
+        child: 已处于 Shell 提示符的 QEMU 子进程。
+    """
+
+    child.timeout = 30
+    child.send("consolelinetest hold | cat")
+    child.send("\r")
+    child.expect_exact("consolelinetest: hold ready")
+    child.sendcontrol("z")
+    child.expect_exact(PROMPT)
+    require(
+        r"\[1\]\s+Stopped\s+consolelinetest hold \| cat",
+        child.before or "",
+        "Ctrl-Z 未停止整个前台 pipeline",
+    )
+
+    output = submit(child, "jobs")
+    require(
+        r"\[1\]\s+\d+\s+Stopped\s+consolelinetest hold \| cat",
+        output,
+        "jobs 未显示停止态 pipeline",
+    )
+
+    output = submit(child, "bg %1")
+    require(
+        r"\[1\]\s+\d+\s+Running\s+consolelinetest hold \| cat",
+        output,
+        "bg 未恢复停止作业",
+    )
+    output = submit(child, "bg %1")
+    require(r"bg: job 1 is already running", output, "重复 bg 没有确定错误")
+
+    output = submit(child, "jobs")
+    require(
+        r"\[1\]\s+\d+\s+Running\s+consolelinetest hold \| cat",
+        output,
+        "后台恢复后 jobs 状态错误",
+    )
+
+    child.send("fg %1")
+    child.send("\r")
+    child.expect_exact("fg %1")
+    # 等待父 Shell 完成 tcsetpgrp 与 CONT；这不是行为判定阈值，只避免控制字节仍落在
+    # Shell raw 输入缓冲区。真正完成条件由随后出现的提示符与作业表断言决定。
+    time.sleep(0.2)
+    child.sendcontrol("c")
+    child.expect_exact(PROMPT, timeout=30)
+
+    output = submit(child, "jobs")
+    reject(r"\[1\].*(Running|Stopped)", output, "Ctrl-C 后作业仍留在 jobs 中")
+    output = submit(child, "echo shell-alive")
+    require(r"\bshell-alive\b", output, "Ctrl-C 误终止了 Shell")
+
+    output = submit(child, "fg %999")
+    require(r"fg: no such job", output, "非法 fg JID 没有确定错误")
+    output = submit(child, "bg %999")
+    require(r"bg: no such job", output, "非法 bg JID 没有确定错误")
+
+    output = submit(child, "cat &")
+    require(r"\[2\]\s+\d+", output, "后台读取作业未登记")
+    output = submit(child, "echo shell-input-safe")
+    require(r"\bshell-input-safe\b", output, "后台 cat 窃取了 Shell 输入")
+    output = submit(child, "jobs")
+    reject(r"Running\s+cat &", output, "后台 console read 失败后作业未退出")
+
+
 def run_checks(child: pexpect.spawn) -> None:
-    """执行历史、方向键、编辑边界及兼容性验收。
+    """执行历史、方向键、编辑边界、作业控制及兼容性验收。
 
     Args:
         child: 已进入全新登录 Shell 的 QEMU 子进程。
@@ -155,6 +242,8 @@ def run_checks(child: pexpect.spawn) -> None:
     # PR #49 的 jobctl 用 pipe 驱动子 Shell，同时覆盖非 console stdin fallback。
     output = submit(child, "usertests jobctl", timeout=120)
     require(r"ALL TESTS PASSED", output, "PR #49 pipe-driven jobctl 回归失败")
+
+    run_job_control_checks(child)
 
     child.send("echo ctrl-d")
     child.sendcontrol("d")

--- a/tests/test_run_usertests.py
+++ b/tests/test_run_usertests.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证逐项 usertests runner 的 completion 协议和失败留档。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+RUNNER_PATH = Path(__file__).with_name("run_usertests.py")
+SPEC = importlib.util.spec_from_file_location("xv6_usertests_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load usertests runner from {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class CommandOutputTests(unittest.TestCase):
+    """验证 guest completion 状态优先于泛化的成功标记和拒绝模式。"""
+
+    def test_successful_completion_passes(self) -> None:
+        """status=0、业务成功文本和无拒绝模式时应通过。"""
+
+        RUNNER._assert_command_output(
+            "xv6test --usertest reparent2",
+            "ALL TESTS PASSED\nXV6TEST done status=0\n",
+        )
+
+    def test_nonzero_completion_reports_status(self) -> None:
+        """guest 明确返回非零状态时应保留该状态，而不是报缺少成功标记。"""
+
+        with self.assertRaisesRegex(
+            RUNNER.RUNNER.TestFailure,
+            r"XV6TEST completed with status=1",
+        ):
+            RUNNER._assert_command_output(
+                "xv6test --usertest reparent2",
+                "FAILED -- lost some free pages\nXV6TEST done status=1\n",
+            )
+
+    def test_missing_completion_marker_is_distinct(self) -> None:
+        """没有任何 done marker 时才报告 completion marker 缺失。"""
+
+        with self.assertRaisesRegex(
+            RUNNER.RUNNER.TestFailure,
+            r"missing XV6TEST completion marker",
+        ):
+            RUNNER._assert_command_output(
+                "xv6test --usertest reparent2",
+                "usertests starting\n",
+            )
+
+
+class FailureLogTests(unittest.TestCase):
+    """验证输出断言失败与 panic/timeout 一样会保存累计 guest 日志。"""
+
+    class FakeChild:
+        """提供 run() 所需的最小 pexpect 子进程接口。"""
+
+        before = "boot output"
+        timeout = 0
+
+        def sendline(self, command: str) -> None:
+            """记录命令发送动作；单元测试不需要真实终端副作用。"""
+
+            self.command = command
+
+    def test_assertion_failure_writes_log_before_raising(self) -> None:
+        """status=1 路径应把当前命令输出写入稳定日志后再抛错。"""
+
+        child = self.FakeChild()
+        result = RUNNER.RUNNER.QemuCommandResult(
+            output="FAILED -- lost pages\nXV6TEST done status=1\n",
+        )
+        log_path = Path("/tmp/usertests-full.log")
+
+        with (
+            mock.patch.object(RUNNER, "_commands", return_value=("xv6test test",)),
+            mock.patch.object(RUNNER.RUNNER, "_start_qemu", return_value=child),
+            mock.patch.object(
+                RUNNER.RUNNER,
+                "_wait_for_qemu_command",
+                return_value=result,
+            ),
+            mock.patch.object(RUNNER.RUNNER, "_write_log", return_value=log_path) as write_log,
+            mock.patch.object(RUNNER.RUNNER, "_stop_qemu"),
+        ):
+            with self.assertRaisesRegex(
+                RUNNER.RUNNER.TestFailure,
+                r"status=1; log: /tmp/usertests-full.log",
+            ):
+                RUNNER.run(1)
+
+        write_log.assert_called_once()
+        self.assertIn("XV6TEST done status=1", write_log.call_args.args[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_usertests.py
+++ b/tests/test_run_usertests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""不启动 QEMU，验证逐项 usertests runner 的 completion 协议和失败留档。"""
+"""不启动 QEMU，验证逐项 usertests runner 的命令选择、协议和失败留档。"""
 
 from __future__ import annotations
 
@@ -17,6 +17,28 @@ if SPEC is None or SPEC.loader is None:
 RUNNER = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = RUNNER
 SPEC.loader.exec_module(RUNNER)
+
+
+class CommandSelectionTests(unittest.TestCase):
+    """验证完整压力顺序和定向回归不会互相污染。"""
+
+    def test_selected_cases_preserve_order_without_stress_prefix(self) -> None:
+        """显式选择用例时应只生成对应命令，并保持调用者给出的顺序。"""
+
+        self.assertEqual(
+            (
+                "xv6test --usertest reparent2",
+                "xv6test --usertest reparent",
+            ),
+            RUNNER._commands(("reparent2", "reparent")),
+        )
+
+    def test_default_commands_keep_stress_prefix(self) -> None:
+        """未指定用例时应继续保留历史压力前序和完整测试列表。"""
+
+        commands = RUNNER._commands()
+        self.assertEqual("xv6test --usertest reparent2", commands[0])
+        self.assertGreater(len(commands), len(RUNNER.USERTEST_CASES))
 
 
 class CommandOutputTests(unittest.TestCase):

--- a/user/sh.c
+++ b/user/sh.c
@@ -6,6 +6,7 @@
 #include "user/shellinput.h"
 #include "kernel/fcntl.h"
 #include "kernel/wait.h"
+#include "kernel/jobctl.h"
 
 // Parsed command representation
 #define EXEC  1
@@ -18,17 +19,21 @@
 #define MAXJOBS 16
 #define MAXCMD  100
 
-enum jobstate { JOB_UNUSED, JOB_RUNNING };
+/** Shell 只跟踪顶层 supervisor；其 pipeline 后代通过 PGID 统一受控。 */
+enum jobstate { JOB_UNUSED, JOB_RUNNING, JOB_STOPPED };
 
+/** 保存一个由当前 Shell 直接创建并负责回收的作业。 */
 struct job {
   int jid;
   int pid;
+  int pgid;
   enum jobstate state;
   char command[MAXCMD];
 };
 
 static struct job jobs[MAXJOBS];
 static int nextjid = 1;
+static int shell_pgid;
 static struct shell_history command_history;
 
 struct cmd {
@@ -73,6 +78,7 @@ struct cmd *parsecmd(char*);
 void runline(struct cmd*);
 void runcmd(struct cmd*) __attribute__((noreturn));
 
+/** 将字符串复制到固定容量缓冲区并保证 NUL 结尾。 */
 static void
 copytext(char *dst, char *src, int size)
 {
@@ -83,6 +89,7 @@ copytext(char *dst, char *src, int size)
   dst[i] = 0;
 }
 
+/** 向格式化命令缓冲区追加文本，超出容量时保留已写部分。 */
 static void
 appendtext(char *dst, int *length, int size, char *text)
 {
@@ -91,6 +98,7 @@ appendtext(char *dst, int *length, int size, char *text)
   dst[*length] = 0;
 }
 
+/** 将命令树压缩成 jobs 可显示的单行文本。 */
 static void
 formatcmd(struct cmd *cmd, char *dst, int *length, int size)
 {
@@ -139,42 +147,26 @@ formatcmd(struct cmd *cmd, char *dst, int *length, int size)
   }
 }
 
+/** 清空作业槽位；JID 不复用，避免旧引用命中新作业。 */
 static void
 clearjob(struct job *job)
 {
   memset(job, 0, sizeof(*job));
 }
 
+/** 根据 JID 查找仍被当前 Shell 跟踪的运行或停止作业。 */
 static struct job*
 findjob(int jid)
 {
   struct job *job;
 
   for(job = jobs; job < &jobs[MAXJOBS]; job++)
-    if(job->state == JOB_RUNNING && job->jid == jid)
+    if(job->state != JOB_UNUSED && job->jid == jid)
       return job;
   return 0;
 }
 
-static void
-reapjobs(void)
-{
-  struct job *job;
-  int status;
-
-  for(job = jobs; job < &jobs[MAXJOBS]; job++){
-    if(job->state != JOB_RUNNING)
-      continue;
-    int pid = waitpid(job->pid, &status, WNOHANG);
-    if(pid == job->pid){
-      printf("[%d] Done %s\n", job->jid, job->command);
-      clearjob(job);
-    } else if(pid < 0){
-      clearjob(job);
-    }
-  }
-}
-
+/** 返回空闲作业槽位；找不到时返回 0。 */
 static struct job*
 emptyjob(void)
 {
@@ -186,29 +178,111 @@ emptyjob(void)
   return 0;
 }
 
+/** 将 supervisor PID/PGID 登记为一个可由 jobs、fg、bg 操作的作业。 */
+static struct job*
+recordjob(int pid, int pgid, enum jobstate state, char *command)
+{
+  struct job *job = emptyjob();
+
+  if(job == 0){
+    fprintf(2, "sh: too many jobs\n");
+    return 0;
+  }
+  job->jid = nextjid++;
+  job->pid = pid;
+  job->pgid = pgid;
+  job->state = state;
+  copytext(job->command, command, sizeof(job->command));
+  return job;
+}
+
+/** 返回作业状态的人类可读名称。 */
+static char*
+jobstatename(enum jobstate state)
+{
+  return state == JOB_STOPPED ? "Stopped" : "Running";
+}
+
+/**
+ * 非阻塞消费后台作业的 EXITED、STOPPED 和 CONTINUED 事件。
+ *
+ * 每个事件由内核只返回一次；退出时清理作业槽，停止/继续只更新状态。快速退出和
+ * 多个后台作业交错完成不会让 Shell 阻塞在提示符安全点。
+ */
+static void
+reapjobs(void)
+{
+  struct job *job;
+
+  for(job = jobs; job < &jobs[MAXJOBS]; job++){
+    if(job->state == JOB_UNUSED)
+      continue;
+
+    for(;;){
+      int status = 0;
+      int pid = waitpid(job->pid, &status,
+                        WNOHANG | WUNTRACED | WCONTINUED);
+      if(pid == 0)
+        break;
+      if(pid < 0){
+        clearjob(job);
+        break;
+      }
+      if(WIFSTOPPED(status)){
+        if(job->state != JOB_STOPPED)
+          printf("[%d] Stopped %s\n", job->jid, job->command);
+        job->state = JOB_STOPPED;
+        continue;
+      }
+      if(WIFCONTINUED(status)){
+        job->state = JOB_RUNNING;
+        continue;
+      }
+      printf("[%d] Done %s\n", job->jid, job->command);
+      clearjob(job);
+      break;
+    }
+  }
+}
+
+/**
+ * 创建后台 supervisor 并让父子双方尝试设置 PGID，缩小 fork/exec 启动竞态。
+ */
 static void
 startjob(struct cmd *cmd, char *command)
 {
-  struct job *job;
   int pid;
+  struct job *job;
 
   reapjobs();
-  if((job = emptyjob()) == 0){
+  if(emptyjob() == 0){
     fprintf(2, "sh: too many background jobs\n");
     return;
   }
 
   pid = fork1();
-  if(pid == 0)
+  if(pid == 0){
+    if(setpgid(0, 0) < 0)
+      exit(1);
     runcmd(cmd);
+  }
 
-  job->jid = nextjid++;
-  job->pid = pid;
-  job->state = JOB_RUNNING;
-  copytext(job->command, command, sizeof(job->command));
-  printf("[%d] %d\n", job->jid, job->pid);
+  if(setpgid(pid, pid) < 0){
+    kill(pid);
+    waitpid(pid, 0, 0);
+    fprintf(2, "sh: cannot create process group\n");
+    return;
+  }
+  job = recordjob(pid, pid, JOB_RUNNING, command);
+  if(job == 0){
+    procctl(pid, JOBCTL_TERM);
+    waitpid(pid, 0, 0);
+    return;
+  }
+  printf("[%d] %d\n", job->jid, job->pgid);
 }
 
+/** 输出当前运行和停止作业；展示值以 PGID 为统一控制标识。 */
 static void
 showjobs(void)
 {
@@ -216,24 +290,68 @@ showjobs(void)
 
   reapjobs();
   for(job = jobs; job < &jobs[MAXJOBS]; job++)
-    if(job->state == JOB_RUNNING)
-      printf("[%d] %d Running %s\n", job->jid, job->pid, job->command);
+    if(job->state != JOB_UNUSED)
+      printf("[%d] %d %s %s\n", job->jid, job->pgid,
+             jobstatename(job->state), job->command);
 }
 
 /**
- * 按从旧到新的顺序输出当前 Shell 进程拥有的会话历史。
+ * 将作业交给控制台前台并等待 supervisor 停止或退出。
  *
- * history 命令在进入内置命令分派前已写入 command_history，因此输出包含自身。
+ * @param job 已登记后台作业；新前台命令传 0。
+ * @param pid Shell 直接子进程 supervisor PID。
+ * @param pgid pipeline 全体成员共享的进程组 ID。
+ * @param command 用于前台命令被停止后创建 jobs 条目的文本。
  */
 static void
-showhistory(void)
+waitforeground(struct job *job, int pid, int pgid, char *command)
 {
-  for(int i = 0; i < shell_history_count(&command_history); i++){
-    const struct shell_history_entry *entry = shell_history_at(&command_history, i);
-    printf("%d %s\n", entry->number, entry->command);
+  int status = 0;
+
+  if(tcsetpgrp(pgid) < 0){
+    fprintf(2, "sh: cannot give console to pgid %d\n", pgid);
+    return;
   }
+
+  if(job != 0 && job->state == JOB_STOPPED){
+    if(procctl(pgid, JOBCTL_CONT) < 0){
+      fprintf(2, "fg: cannot continue job %d\n", job->jid);
+      tcsetpgrp(shell_pgid);
+      return;
+    }
+    job->state = JOB_RUNNING;
+  }
+
+  for(;;){
+    int waited = waitpid(pid, &status, WUNTRACED | WCONTINUED);
+    if(waited < 0){
+      fprintf(2, "sh: wait failed for pgid %d\n", pgid);
+      break;
+    }
+    if(WIFCONTINUED(status)){
+      if(job != 0)
+        job->state = JOB_RUNNING;
+      continue;
+    }
+    if(WIFSTOPPED(status)){
+      if(job == 0)
+        job = recordjob(pid, pgid, JOB_STOPPED, command);
+      else
+        job->state = JOB_STOPPED;
+      if(job != 0)
+        printf("[%d] Stopped %s\n", job->jid, job->command);
+      break;
+    }
+    if(job != 0)
+      clearjob(job);
+    break;
+  }
+
+  if(tcsetpgrp(shell_pgid) < 0)
+    fprintf(2, "sh: cannot reclaim console\n");
 }
 
+/** 解析 `%jid` 或纯数字 JID；非法输入返回 -1。 */
 static int
 parsejid(char *s)
 {
@@ -256,23 +374,54 @@ parsejid(char *s)
   return jid;
 }
 
+/** 将停止或运行的后台作业切换到前台并等待下一次状态边界。 */
 static void
 foreground(char *arg)
 {
-  int jid, status;
+  int jid;
   struct job *job;
 
   if((jid = parsejid(arg)) < 0 || (job = findjob(jid)) == 0){
     fprintf(2, "fg: no such job\n");
     return;
   }
-  if(waitpid(job->pid, &status, 0) < 0){
-    fprintf(2, "fg: wait failed for job %d\n", jid);
-    return;
-  }
-  clearjob(job);
+  waitforeground(job, job->pid, job->pgid, job->command);
 }
 
+/** 恢复停止作业到后台并立即返回提示符。 */
+static void
+background(char *arg)
+{
+  int jid;
+  struct job *job;
+
+  if((jid = parsejid(arg)) < 0 || (job = findjob(jid)) == 0){
+    fprintf(2, "bg: no such job\n");
+    return;
+  }
+  if(job->state != JOB_STOPPED){
+    fprintf(2, "bg: job %d is already running\n", jid);
+    return;
+  }
+  if(procctl(job->pgid, JOBCTL_CONT) < 0){
+    fprintf(2, "bg: cannot continue job %d\n", jid);
+    return;
+  }
+  job->state = JOB_RUNNING;
+  printf("[%d] %d Running %s\n", job->jid, job->pgid, job->command);
+}
+
+/** 按从旧到新的顺序输出当前 Shell 进程拥有的会话历史。 */
+static void
+showhistory(void)
+{
+  for(int i = 0; i < shell_history_count(&command_history); i++){
+    const struct shell_history_entry *entry = shell_history_at(&command_history, i);
+    printf("%d %s\n", entry->number, entry->command);
+  }
+}
+
+/** 判断字符串是否以前缀开头。 */
 static int
 startswith(char *s, char *prefix)
 {
@@ -302,6 +451,10 @@ runbuiltin(char *buf)
   }
   if(startswith(buf, "fg ")){
     foreground(buf + 3);
+    return 1;
+  }
+  if(startswith(buf, "bg ")){
+    background(buf + 3);
     return 1;
   }
   if(startswith(buf, "cd ")){
@@ -421,6 +574,13 @@ main(void)
     }
   }
 
+  // Shell 自成进程组，并成为单控制台初始前台 owner。
+  if(setpgid(0, 0) < 0 || (shell_pgid = getpgid(0)) < 0 ||
+     tcsetpgrp(shell_pgid) < 0){
+    fprintf(2, "sh: cannot initialize job control\n");
+    exit(1);
+  }
+
   // Read and run input commands.
   for(;;){
     reapjobs();
@@ -440,8 +600,9 @@ main(void)
   exit(0);
 }
 
-// Run lists in the shell so every top-level background command remains
-// a direct child that can be tracked and reaped by this shell.
+/**
+ * 在父 Shell 中展开顶层列表，并为每个前台或后台命令创建独立进程组。
+ */
 void
 runline(struct cmd *cmd)
 {
@@ -455,6 +616,7 @@ runline(struct cmd *cmd)
     runline(lcmd->right);
     return;
   }
+
   if(cmd->type == BACK){
     formatcmd(((struct backcmd*)cmd)->cmd, command,
               &command_length, sizeof(command));
@@ -463,11 +625,20 @@ runline(struct cmd *cmd)
     return;
   }
 
+  formatcmd(cmd, command, &command_length, sizeof(command));
   pid = fork1();
-  if(pid == 0)
+  if(pid == 0){
+    if(setpgid(0, 0) < 0)
+      exit(1);
     runcmd(cmd);
-  if(waitpid(pid, 0, 0) < 0)
-    fprintf(2, "sh: wait failed\n");
+  }
+  if(setpgid(pid, pid) < 0){
+    kill(pid);
+    waitpid(pid, 0, 0);
+    fprintf(2, "sh: cannot create foreground process group\n");
+    return;
+  }
+  waitforeground(0, pid, pid, command);
 }
 
 void

--- a/user/user.h
+++ b/user/user.h
@@ -47,6 +47,40 @@ int sched_get_stats(struct sched_stats *stats);
 int schedtrace(int op, struct schedtrace_snapshot *snapshot, int arg);
 
 /**
+ * 将当前进程或直接子进程放入指定进程组。
+ *
+ * @param pid 目标 PID；0 表示当前进程。
+ * @param pgid 目标 PGID；0 表示使用目标 PID 创建新进程组。
+ * @return 成功返回 0；目标不可见、已退出或参数非法时返回 -1。
+ */
+int setpgid(int pid, int pgid);
+
+/**
+ * 查询当前进程或直接子进程的进程组。
+ *
+ * @param pid 目标 PID；0 表示当前进程。
+ * @return 成功返回正 PGID；目标不可见或已退出时返回 -1。
+ */
+int getpgid(int pid);
+
+/**
+ * 对整个进程组执行 JOBCTL_STOP、JOBCTL_CONT 或 JOBCTL_TERM。
+ *
+ * @param pgid 目标进程组 ID，必须为正数。
+ * @param action kernel/jobctl.h 中定义的动作。
+ * @return 至少命中一个活跃成员时返回 0，否则返回 -1。
+ */
+int procctl(int pgid, int action);
+
+/**
+ * 将单控制台的前台所有权交给指定进程组。
+ *
+ * @param pgid 目标进程组 ID；仅交互式 sh 可以调用。
+ * @return 成功返回 0；调用者或状态不满足约束时返回 -1。
+ */
+int tcsetpgrp(int pgid);
+
+/**
  * 保存当前用户现场，并可在同一次系统调用中恢复另一份完整用户现场。
  *
  * @param save 接收当前 epc 和通用寄存器的用户缓冲区；为空时跳过保存。

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -53,3 +53,7 @@ entry("sched_set_weight");
 entry("sched_get_stats");
 entry("schedtrace");
 entry("ucontext_switch");
+entry("setpgid");
+entry("getpgid");
+entry("procctl");
+entry("tcsetpgrp");


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #48
- 最新基线：`main@7411553ae1290cb1ccfe12a2ac085f0429b11be3`
- 当前 Head：`3e41bfbed325c655cd66166b31a8fb96800a717a`
- 分支：`concept/48-xv6-job-control-pgid`
- 状态：Draft，未经用户验收不合并
- 一句话摘要：增加最小 PGID、单控制台 foreground PGID 与 STOP/CONT/TERM 闭环，使一条 pipeline 可由 `Ctrl-Z`、`bg`、`fg`、`Ctrl-C` 统一控制。

## 功能范围

- 为进程增加 PGID、`STOPPED`、远端停止请求和一次性 STOPPED/CONTINUED 事件。
- 新增 `setpgid/getpgid`、`procctl`、`tcsetpgrp` 教学接口。
- `fork()` 固化 PGID 继承；父子双方在 `exec` 前设置 PGID，并覆盖快速退出子进程竞态。
- `waitpid()` 支持 `WUNTRACED/WCONTINUED`，原 `wait()`、普通退出状态和历史非法 options 语义保持兼容。
- `kill(pid)` 可唤醒并终止 `STOPPED` 进程。
- 单控制台维护 Shell PGID 与 foreground PGID；后台进程组读取 console 返回 `-1`。
- `Ctrl-C/Ctrl-Z` 在 `cons.lock` 内只记录动作，trap 安全点在锁外控制前台进程组。
- Shell 增加真实 `Stopped/Running`、`bg %jid` 和前台所有权迁移；停止或退出后收回控制台。
- 非交互 pipe-driven Shell 不修改真实 console owner；Shell 退出时释放 owner，允许 `init` 重启新 Shell。

## 本轮回归修复

### 现象

`reparent2` 或 `reparent` 的业务断言已经输出 `OK`，但紧接着的物理页快照偶发报告：

```text
FAILED -- lost some free pages ...
XV6TEST done status=1
```

该现象在 `main@7411553` 和本 PR 上均可复现，失败点随 `CPUS=1/3` 的调度时序变化，因此不是本 PR 独有的固定页泄漏。

### 根因

`reparent`、`reparent2` 会故意制造由 init 接管的后代。原 2 GiB usertests 适配只等待直接测试 worker，随后立即读取 allocator 快照；此时 init 可能尚未完成后代的 `wait/freeproc`，合法的异步回收窗口会被误判为物理页泄漏。

### 修复

- `tests/guest/usertests_2g.c`
  - 在创建测试 worker 前记录 `sysinfo().nproc` 基线。
  - 直接 worker 退出后，有界等待进程数恢复到基线，再采集物理页快照。
  - 超时明确报告 `descendant cleanup timed out`。
  - 进程数已经收敛但物理页仍减少时，原有页守恒检查继续失败，不掩盖真实泄漏。
- `tests/run_usertests.py`
  - 解析并报告真实 `XV6TEST done status=N`，不再把 `status=1` 泛化成“缺少成功结束”。
  - 输出断言失败也会保存累计 guest 日志。
  - 新增可重复的 `--case`，支持单核定向回归而不重复执行全部慢测试。
- `tests/test_run_usertests.py`
  - 覆盖定向命令顺序、成功协议、非零 completion、缺失 completion 和失败留档。
- `.github/workflows/scheduler-ci.yml`
  - 执行 runner 单元测试。
  - 三核完整 usertests 后，干净重建 `CPUS=1` 并定向运行 `reparent2/reparent`。

## 自动化与行为测试

### 作业控制断言

`xv6test --run core-job-control` 覆盖：

- pipeline leader 与 worker 共享 PGID；
- 整组 STOP、CONT、再次 STOP；
- STOPPED/CONTINUED 事件只消费一次；
- 停止态整组 TERM 与普通 `kill(pid)` 均可最终回收；
- 快速退出子进程在 ZOMBIE 回收前仍可完成 PGID 初始化；
- 后台 console read 隔离；
- 非法 PID、PGID、action 的确定错误。

真实 QEMU 串口由 `tests/shell_history_interactive.py` 自动执行：

```text
consolelinetest hold | cat
Ctrl-Z
jobs
bg %1
bg %1
jobs
fg %1
Ctrl-C
jobs
echo shell-alive
fg %999
bg %999
cat &
echo shell-input-safe
```

### 最新真实结果

Scheduler family CI Run `30027910824` 的 `regression` job 已完成并通过：

- runner 单元测试：通过；
- `make clean && make -j2 SCHED_POLICY=rr`：通过；
- 三核 PR 集成回归：通过；
- 三核完整逐项 `usertests`：通过；
- 干净重建 `CPUS=1` 后定向执行 `reparent2`、`reparent`：通过。

同一 Run 已完成的调度器验证包括 RR/FIFO/STCF/MLFQ 等单核行为测试，以及 MLFQ/CFS 三核 smoke；Run 中剩余矩阵任务以 GitHub Actions 页面最终状态为准，不把进行中状态写成通过。

## 本地验收命令

```bash
git fetch origin
git switch concept/48-xv6-job-control-pgid
git pull --ff-only

make clean
make -j2 CPUS=3 SCHED_POLICY=rr
python3 -m unittest discover -s tests -p 'test_*.py' -v
python3 tests/run_usertests.py --cpus 3

make clean
make -j2 CPUS=1 SCHED_POLICY=rr
python3 tests/run_usertests.py \
  --cpus 1 \
  --case reparent2 \
  --case reparent

make clean
make -j2 CPUS=3 SCHED_POLICY=rr
python3 tests/shell_history_interactive.py --cpus 3
python3 tests/run.py --suite usertests-core --cpus 3
```

手工观察：

```bash
make qemu CPUS=3
```

进入 xv6：

```text
xv6test --run core-job-control
consolelinetest hold | cat
```

出现 ready 后按 `Ctrl-Z`，然后：

```text
jobs
bg %1
jobs
fg %1
```

`fg` 后按 `Ctrl-C`，再执行：

```text
jobs
echo shell-alive
```

## Review 主线

1. `kernel/sysproc.c`：PGID 生命周期、STOP/CONT/TERM、一次性事件和停止态 kill。
2. `kernel/console.c` / `kernel/trap.c`：控制事件锁边界、foreground PGID 和 owner 生命周期。
3. `user/sh.c`：父子设置 PGID、pipeline 继承、`fg/bg/jobs` 状态机。
4. `tests/guest/consolelinetest.c`：作业控制行为与资源回收断言。
5. `tests/guest/usertests_2g.c`：init 异步后代回收与物理页守恒的同步边界。
6. `tests/run_usertests.py`：逐项看门狗、completion 协议和失败日志。

## 教学边界

- 单 console、单 Shell owner；不实现 session 或多个 TTY。
- STOP/CONT/TERM 不是完整 POSIX signal 体系。
- 后台 console read 直接失败，不模拟 `SIGTTIN`。
- 不实现 signal mask、pending queue、disposition、`SIGHUP` 或 orphan process group。
- Issue #48 在 PR 合并前继续保持 Open。