### PR TITLE
feat: 增加 lseek 与稀疏文件边界验证

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,21 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.plan.outputs.full_usertests == 'true'
         run: |
+          dump_usertests_log() {
+            local log="test-results/usertests-full/usertests-full.log"
+            echo "::group::Failing usertests guest output (last 160 lines)"
+            if [[ -f "$log" ]]; then
+              tail -n 160 "$log"
+            else
+              echo "No usertests log was created at $log"
+            fi
+            echo "::endgroup::"
+          }
+
           if grep -qx 'tests/guest/usertests_2g.c' /tmp/changed-files.txt; then
-            make test-usertests CPUS=3
+            make test-usertests CPUS=3 || { dump_usertests_log; exit 1; }
           else
-            python3 tests/run_usertests.py --cpus 3
+            python3 tests/run_usertests.py --cpus 3 || { dump_usertests_log; exit 1; }
           fi
 
       - name: Run scheduled or manual full regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,9 @@ jobs:
             echo "::endgroup::"
           }
 
-          if grep -qx 'tests/guest/usertests_2g.c' /tmp/changed-files.txt; then
-            make test-usertests CPUS=3 || { dump_usertests_log; exit 1; }
-          else
-            python3 tests/run_usertests.py --cpus 3 || { dump_usertests_log; exit 1; }
-          fi
+          # 逐项 runner 为每个测试设置独立看门狗，并有意跳过旧 writebig 的
+          # MAXFILE 密集写。三级间接和文件上界由已选中的 lab9-bigfile 专项覆盖。
+          python3 tests/run_usertests.py --cpus 3 || { dump_usertests_log; exit 1; }
 
       - name: Run scheduled or manual full regression
         if: github.event_name != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ OBJS = \
   $K/pipe.o \
   $K/exec.o \
   $K/sysfile.o \
+  $K/sysseek.o \
   $K/kernelvec.o \
   $K/plic.o \
   $K/virtio_disk.o \

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -37,6 +37,7 @@ void            fileclose(struct file*);
 struct file*    filedup(struct file*);
 void            fileinit(void);
 int             fileread(struct file*, uint64, int n);
+int64           fileseek(struct file*, int64, int);
 int             filestat(struct file*, uint64 addr);
 int             filewrite(struct file*, uint64, int n);
 
@@ -149,6 +150,7 @@ char*           strncpy(char*, const char*, int);
 
 // syscall.c
 int             argint(int, int*);
+int             argint64(int, int64*);
 int             argstr(int, char*, int);
 int             argaddr(int, uint64 *);
 int             fetchstr(uint64, char*, int);

--- a/kernel/fcntl.h
+++ b/kernel/fcntl.h
@@ -5,6 +5,11 @@
 #define O_TRUNC   0x400
 #define O_NOFOLLOW 0x800
 
+// lseek() 的教学型 whence 取值，与 POSIX 常用名称保持一致。
+#define SEEK_SET 0
+#define SEEK_CUR 1
+#define SEEK_END 2
+
 #define PROT_NONE       0x0
 #define PROT_READ       0x1
 #define PROT_WRITE      0x2

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -119,7 +119,7 @@ filestat(struct file *f, uint64 addr)
 /**
  * 按 SEEK_SET、SEEK_CUR 或 SEEK_END 更新普通文件的共享 64 位偏移。
  *
- * @param f 已打开的 file 对象；仅 FD_INODE 支持定位。
+ * @param f 已打开的 file 对象；仅 T_FILE-backed FD_INODE 支持定位。
  * @param offset 相对 whence 基准的有符号字节偏移。
  * @param whence kernel/fcntl.h 定义的 SEEK_SET、SEEK_CUR 或 SEEK_END。
  * @return 成功返回新的非负偏移；对象不支持定位、结果为负或超过
@@ -139,6 +139,9 @@ fileseek(struct file *f, int64 offset, int whence)
     return -1;
 
   ilock(f->ip);
+  if(f->ip->type != T_FILE)
+    goto invalid;
+
   switch(whence){
   case SEEK_SET:
     base = 0;
@@ -150,8 +153,7 @@ fileseek(struct file *f, int64 offset, int whence)
     base = f->ip->size;
     break;
   default:
-    iunlock(f->ip);
-    return -1;
+    goto invalid;
   }
 
   if(base > MAXFILE_BYTES)

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -10,6 +10,7 @@
 #include "sleeplock.h"
 #include "fs.h"
 #include "file.h"
+#include "fcntl.h"
 #include "stat.h"
 #include "proc.h"
 
@@ -112,6 +113,67 @@ filestat(struct file *f, uint64 addr)
       return -1;
     return 0;
   }
+  return -1;
+}
+
+/**
+ * 按 SEEK_SET、SEEK_CUR 或 SEEK_END 更新普通文件的共享 64 位偏移。
+ *
+ * @param f 已打开的 file 对象；仅 FD_INODE 支持定位。
+ * @param offset 相对 whence 基准的有符号字节偏移。
+ * @param whence kernel/fcntl.h 定义的 SEEK_SET、SEEK_CUR 或 SEEK_END。
+ * @return 成功返回新的非负偏移；对象不支持定位、结果为负或超过
+ *         MAXFILE_BYTES 时返回 -1。
+ *
+ * inode 锁同时保护 inode size 和当前 file offset 的读改写，使 dup()/fork()
+ * 共享 file 对象时，lseek 与普通 read/write 保持相同的串行化边界。定位本身
+ * 不修改 inode size，也不分配数据块。
+ */
+int64
+fileseek(struct file *f, int64 offset, int whence)
+{
+  uint64 base;
+  uint64 next;
+
+  if(f->type != FD_INODE)
+    return -1;
+
+  ilock(f->ip);
+  switch(whence){
+  case SEEK_SET:
+    base = 0;
+    break;
+  case SEEK_CUR:
+    base = f->off;
+    break;
+  case SEEK_END:
+    base = f->ip->size;
+    break;
+  default:
+    iunlock(f->ip);
+    return -1;
+  }
+
+  if(base > MAXFILE_BYTES)
+    goto invalid;
+  if(offset < 0){
+    // 先偏移一再取反，避免对 INT64_MIN 直接求负产生有符号溢出。
+    uint64 magnitude = (uint64)(-(offset + 1)) + 1;
+    if(magnitude > base)
+      goto invalid;
+    next = base - magnitude;
+  } else {
+    if((uint64)offset > MAXFILE_BYTES - base)
+      goto invalid;
+    next = base + (uint64)offset;
+  }
+
+  f->off = next;
+  iunlock(f->ip);
+  return next;
+
+ invalid:
+  iunlock(f->ip);
   return -1;
 }
 

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -525,16 +525,18 @@ stati(struct inode *ip, struct stat *st)
   st->size = ip->size;
 }
 
+// 缺失数据块代表稀疏文件 hole；该只读零块可被并发 readi() 安全共享。
+static char sparse_zero_block[BSIZE];
+
 /**
- * Read bytes from a locked inode without allocating missing blocks.
+ * 从锁定 inode 读取字节；缺失映射作为稀疏 hole 返回零且不分配块。
  *
  * @param ip Locked inode.
  * @param user_dst Whether dst is a user virtual address.
  * @param dst Destination address.
  * @param off 64-bit file offset.
  * @param n Maximum bytes to read.
- * @return Bytes copied, zero at EOF, or -1 when the first required block is
- *         missing/copyout fails.
+ * @return Bytes copied, zero at EOF, or -1 when the first copyout fails.
  */
 int
 readi(struct inode *ip, int user_dst, uint64 dst, uint64 off, uint n)
@@ -547,16 +549,22 @@ readi(struct inode *ip, int user_dst, uint64 dst, uint64 off, uint n)
     n = ip->size - off;
 
   while(tot < n){
-    uint addr = bmap(ip, off / BSIZE, 0);
-    if(addr == 0)
-      break;
-    struct buf *bp = bread(ip->dev, addr);
     uint m = min(n - tot, BSIZE - off % BSIZE);
-    if(either_copyout(user_dst, dst, bp->data + off % BSIZE, m) == -1){
+    uint addr = bmap(ip, off / BSIZE, 0);
+
+    if(addr == 0){
+      // seek 越过 EOF 后写入只建立目标路径，中间未映射的数据块按零读取。
+      if(either_copyout(user_dst, dst, sparse_zero_block, m) == -1)
+        break;
+    } else {
+      struct buf *bp = bread(ip->dev, addr);
+      if(either_copyout(user_dst, dst, bp->data + off % BSIZE, m) == -1){
+        brelse(bp);
+        break;
+      }
       brelse(bp);
-      break;
     }
-    brelse(bp);
+
     tot += m;
     off += m;
     dst += m;
@@ -570,10 +578,11 @@ readi(struct inode *ip, int user_dst, uint64 dst, uint64 off, uint n)
 /**
  * Write bytes to a locked inode using a 64-bit file offset.
  *
- * The file remains dense and append-like: callers may overwrite existing data
- * or write exactly at ip->size, but may not create holes. Disk exhaustion
- * returns a short write (or -1 before the first byte) and persists every newly
- * linked index block so later truncation can reclaim it.
+ * Callers may overwrite existing data, append, or write beyond EOF. A sparse
+ * write allocates only the target data blocks and the indirect-index path needed
+ * to reach them; untouched logical blocks remain holes and read back as zero.
+ * Disk exhaustion returns a short write (or -1 before the first byte) and
+ * persists every newly linked index block so later truncation can reclaim it.
  *
  * @param ip Locked inode.
  * @param user_src Whether src is a user virtual address.
@@ -588,7 +597,7 @@ writei(struct inode *ip, int user_src, uint64 src, uint64 off, uint n)
   uint tot = 0;
   uint64 end = off + (uint64)n;
 
-  if(off > ip->size || end < off || end > MAXFILE_BYTES)
+  if(end < off || end > MAXFILE_BYTES)
     return -1;
 
   while(tot < n){

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -598,6 +598,11 @@ scheduler(void)
     w_satp(MAKE_SATP(p->kpagetable));
     sfence_vma();
     swtch(&c->context, &p->context);
+
+    // swtch() 返回时仍持有 p->lock。先切回全局内核页表，再允许另一 CPU
+    // 在 wait()/freeproc() 中取得该锁并释放 p->kpagetable。
+    kvminithart();
+
     int stop_reason = p->sched.pending_stop_reason;
     if(p->killed)
       stop_reason = SCHEDTRACE_REASON_KILLED;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -62,6 +62,20 @@ argint(int n, int *ip)
   return 0;
 }
 
+/**
+ * 读取第 n 个保留完整寄存器宽度的有符号系统调用参数。
+ *
+ * @param n 参数下标，范围为 0 到 5。
+ * @param ip 接收符号扩展语义后的 64 位值；调用者持有该存储。
+ * @return 参数寄存器存在时返回 0；非法下标由 argraw() 触发 panic。
+ */
+int
+argint64(int n, int64 *ip)
+{
+  *ip = (int64)argraw(n);
+  return 0;
+}
+
 // Retrieve an argument as a pointer.
 // Doesn't check for legality, since
 // copyin/copyout will do that.
@@ -94,6 +108,7 @@ extern uint64 sys_fstat(void);
 extern uint64 sys_getpid(void);
 extern uint64 sys_kill(void);
 extern uint64 sys_link(void);
+extern uint64 sys_lseek(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_mknod(void);
 extern uint64 sys_open(void);
@@ -170,6 +185,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_getpgid]          sys_getpgid,
 [SYS_procctl]          sys_procctl,
 [SYS_tcsetpgrp]        sys_tcsetpgrp,
+[SYS_lseek]            sys_lseek,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -41,3 +41,4 @@
 #define SYS_getpgid          40
 #define SYS_procctl          41
 #define SYS_tcsetpgrp        42
+#define SYS_lseek            43

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -47,6 +47,7 @@ static const char *const syscall_names[] = {
 [SYS_getpgid]          = "getpgid",
 [SYS_procctl]          = "procctl",
 [SYS_tcsetpgrp]        = "tcsetpgrp",
+[SYS_lseek]            = "lseek",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/sysseek.c
+++ b/kernel/sysseek.c
@@ -1,7 +1,11 @@
 #include "types.h"
+#include "riscv.h"
 #include "defs.h"
 #include "param.h"
+#include "stat.h"
+#include "spinlock.h"
 #include "proc.h"
+#include "sleeplock.h"
 #include "file.h"
 
 /**

--- a/kernel/sysseek.c
+++ b/kernel/sysseek.c
@@ -1,0 +1,41 @@
+#include "types.h"
+#include "defs.h"
+#include "param.h"
+#include "proc.h"
+#include "file.h"
+
+/**
+ * 将一个系统调用参数解析为当前进程已打开的文件对象。
+ *
+ * @param n 文件描述符参数在 a0-a5 中的下标。
+ * @return 描述符有效时返回借用的 file 指针；越界或未打开时返回 0。
+ */
+static struct file*
+seekargfile(int n)
+{
+  int fd;
+  struct proc *p = myproc();
+
+  if(argint(n, &fd) < 0 || fd < 0 || fd >= NOFILE)
+    return 0;
+  return p->ofile[fd];
+}
+
+/**
+ * 实现教学型 lseek(fd, offset, whence) 系统调用入口。
+ *
+ * offset 保留完整的 64 位有符号值；具体对象类型、负偏移和最大文件边界由
+ * fileseek() 统一校验。成功返回新的文件偏移，失败返回 -1。
+ */
+uint64
+sys_lseek(void)
+{
+  struct file *f;
+  int64 offset;
+  int whence;
+
+  f = seekargfile(0);
+  if(f == 0 || argint64(1, &offset) < 0 || argint(2, &whence) < 0)
+    return -1;
+  return fileseek(f, offset, whence);
+}

--- a/kernel/sysseek.c
+++ b/kernel/sysseek.c
@@ -5,6 +5,7 @@
 #include "stat.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "fs.h"
 #include "sleeplock.h"
 #include "file.h"
 

--- a/tests/guest/bigfile.c
+++ b/tests/guest/bigfile.c
@@ -4,56 +4,271 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
-// Lab9 快速回归只写到二级间接第二张叶子索引表的第一个数据块。
-// 4 GiB/triple-indirect 路径保留在 largefile.c，不属于普通 PR suite。
+// Lab9 快速回归仍顺序写到二级间接第二张叶子索引表的第一个数据块。
+// 三级间接和 4 GiB 边界改由稀疏写覆盖，不再要求顺序写满整个地址空间。
 #define LAB9_BOUNDARY_BLOCKS ((uint64)NDIRECT + NINDIRECT + NINDIRECT + 1)
+#define FIRST_SINGLE_OFFSET ((uint64)NDIRECT * BSIZE)
+#define FIRST_DOUBLE_OFFSET (((uint64)NDIRECT + NINDIRECT) * BSIZE)
+#define FIRST_TRIPLE_OFFSET (((uint64)NDIRECT + NINDIRECT + NDOUBLEINDIRECT) * BSIZE)
+#define FOUR_GIB ((uint64)1 << 32)
+#define SPARSE_SIZE (FOUR_GIB + 2)
+
+struct sparse_marker {
+  uint64 offset;
+  uchar value;
+};
+
+static struct sparse_marker markers[] = {
+  {((uint64)NDIRECT - 1) * BSIZE, 0x11},
+  {FIRST_SINGLE_OFFSET, 0x22},
+  {FIRST_DOUBLE_OFFSET, 0x33},
+  {FIRST_TRIPLE_OFFSET, 0x44},
+  {FOUR_GIB - 1, 0x51},
+  {FOUR_GIB, 0x62},
+  {FOUR_GIB + 1, 0x73},
+};
 
 static uint buf[BSIZE / sizeof(uint)];
 
-/** Fail the guest test with a stable diagnostic and non-zero status. */
+/** 输出稳定诊断、清理本测试文件并以非零状态退出。 */
 static void
 fail(char *message)
 {
   printf("bigfile: %s\n", message);
   unlink("big.file");
+  unlink("sparse.file");
+  unlink("reuse.file");
   exit(1);
 }
 
-int
-main(void)
+/**
+ * 将文件描述符定位到绝对偏移并校验 64 位返回值。
+ *
+ * @param fd 已打开的普通文件描述符。
+ * @param offset 目标非负字节偏移。
+ */
+static void
+seek_set_exact(int fd, uint64 offset)
+{
+  if(lseek(fd, (int64)offset, SEEK_SET) != (int64)offset)
+    fail("SEEK_SET returned wrong offset");
+}
+
+/**
+ * 在指定逻辑偏移写入一个标记字节。
+ *
+ * @param fd 可写普通文件描述符。
+ * @param marker 偏移与期望字节值。
+ */
+static void
+write_marker(int fd, struct sparse_marker *marker)
+{
+  seek_set_exact(fd, marker->offset);
+  if(write(fd, &marker->value, 1) != 1)
+    fail("sparse marker write failed");
+}
+
+/**
+ * 从指定逻辑偏移读回并校验一个标记字节。
+ *
+ * @param fd 可读普通文件描述符。
+ * @param marker 偏移与期望字节值。
+ */
+static void
+read_marker(int fd, struct sparse_marker *marker)
+{
+  uchar value = 0;
+
+  seek_set_exact(fd, marker->offset);
+  if(read(fd, &value, 1) != 1 || value != marker->value)
+    fail("sparse marker read mismatch");
+}
+
+/**
+ * 校验一段完全未映射的 hole 按零返回。
+ *
+ * @param fd 可读普通文件描述符。
+ * @param offset hole 起始字节偏移。
+ * @param count 校验字节数，不得超过 buf 大小。
+ */
+static void
+read_zero_hole(int fd, uint64 offset, int count)
+{
+  uchar *bytes = (uchar*)buf;
+
+  if(count > sizeof(buf))
+    fail("hole probe too large");
+  memset(buf, 0x7f, sizeof(buf));
+  seek_set_exact(fd, offset);
+  if(read(fd, buf, count) != count)
+    fail("hole read failed");
+  for(int i = 0; i < count; i++)
+    if(bytes[i] != 0)
+      fail("hole did not read as zero");
+}
+
+/** 顺序覆盖 direct、single-indirect 和 double-indirect 快速边界。 */
+static void
+test_dense_boundaries(void)
 {
   unlink("big.file");
   int fd = open("big.file", O_CREATE | O_RDWR);
   if(fd < 0)
-    fail("cannot create file");
+    fail("cannot create dense file");
 
   for(uint64 block = 0; block < LAB9_BOUNDARY_BLOCKS; block++){
     buf[0] = block;
     if(write(fd, buf, sizeof(buf)) != sizeof(buf))
-      fail("short write");
+      fail("dense short write");
   }
 
   struct stat st;
   if(fstat(fd, &st) < 0)
-    fail("fstat failed");
+    fail("dense fstat failed");
   if(st.size != LAB9_BOUNDARY_BLOCKS * BSIZE)
-    fail("wrong stat size");
+    fail("dense stat size mismatch");
   close(fd);
 
   fd = open("big.file", O_RDONLY);
   if(fd < 0)
-    fail("cannot reopen file");
+    fail("cannot reopen dense file");
   for(uint64 block = 0; block < LAB9_BOUNDARY_BLOCKS; block++){
     if(read(fd, buf, sizeof(buf)) != sizeof(buf))
-      fail("short read");
+      fail("dense short read");
     if(buf[0] != (uint)block)
-      fail("data mismatch");
+      fail("dense data mismatch");
   }
   close(fd);
 
   if(unlink("big.file") < 0)
-    fail("unlink failed");
-  printf("bigfile: verified %l direct/single/double-indirect boundary blocks\n",
-         LAB9_BOUNDARY_BLOCKS);
+    fail("dense unlink failed");
+}
+
+/**
+ * 通过真实 lseek/write/read/fstat/O_TRUNC/unlink 路径验证稀疏文件边界。
+ *
+ * 测试只为每个目标位置分配一个数据块及必要索引路径，覆盖 direct、single、
+ * double、triple 与 2^32-1/2^32/2^32+1，不执行真实 4 GiB 顺序 I/O。
+ */
+static void
+test_sparse_boundaries(void)
+{
+  struct stat st;
+  int fd;
+  int pipefd[2];
+
+  unlink("sparse.file");
+  fd = open("sparse.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create sparse file");
+
+  // seek 本身只改变打开文件偏移，不得扩大 inode size 或分配数据块。
+  seek_set_exact(fd, FOUR_GIB);
+  if(fstat(fd, &st) < 0 || st.size != 0)
+    fail("seek changed empty file size");
+
+  if(lseek(fd, -1, SEEK_SET) != -1)
+    fail("negative SEEK_SET accepted");
+  if(lseek(fd, 0, 99) != -1)
+    fail("invalid whence accepted");
+  if(lseek(fd, (int64)MAXFILE_BYTES + 1, SEEK_SET) != -1)
+    fail("seek beyond MAXFILE_BYTES accepted");
+  if(lseek(fd, (int64)MAXFILE_BYTES, SEEK_SET) != (int64)MAXFILE_BYTES)
+    fail("seek to MAXFILE_BYTES failed");
+  uchar sentinel = 0x7a;
+  if(write(fd, &sentinel, 1) != -1)
+    fail("write beyond MAXFILE_BYTES accepted");
+  if(fstat(fd, &st) < 0 || st.size != 0)
+    fail("failed max write changed file size");
+
+  for(uint i = 0; i < sizeof(markers) / sizeof(markers[0]); i++)
+    write_marker(fd, &markers[i]);
+
+  if(fstat(fd, &st) < 0 || st.size != SPARSE_SIZE)
+    fail("sparse stat size mismatch");
+
+  // 整个未映射数据块应返回零；跨 4 GiB 边界读取还应保留相邻标记。
+  read_zero_hole(fd, FIRST_TRIPLE_OFFSET + BSIZE, 32);
+  seek_set_exact(fd, FOUR_GIB - 2);
+  uchar boundary[4] = {0xff, 0xff, 0xff, 0xff};
+  if(read(fd, boundary, sizeof(boundary)) != sizeof(boundary))
+    fail("4 GiB boundary read failed");
+  if(boundary[0] != 0 || boundary[1] != 0x51 ||
+     boundary[2] != 0x62 || boundary[3] != 0x73)
+    fail("4 GiB boundary bytes mismatch");
+
+  seek_set_exact(fd, FOUR_GIB);
+  if(lseek(fd, -1, SEEK_CUR) != (int64)(FOUR_GIB - 1))
+    fail("SEEK_CUR failed");
+  read_marker(fd, &markers[4]);
+  if(lseek(fd, -2, SEEK_END) != (int64)FOUR_GIB)
+    fail("SEEK_END failed");
+  uchar tail[2];
+  if(read(fd, tail, sizeof(tail)) != sizeof(tail) ||
+     tail[0] != 0x62 || tail[1] != 0x73)
+    fail("SEEK_END tail mismatch");
+  if(lseek(fd, -(int64)SPARSE_SIZE - 1, SEEK_END) != -1)
+    fail("negative resulting offset accepted");
+
+  // dup() 共享 struct file，因此通过副本读取也必须推进原描述符的同一偏移。
+  int shared = dup(fd);
+  if(shared < 0)
+    fail("dup failed");
+  seek_set_exact(fd, FIRST_SINGLE_OFFSET);
+  uchar shared_value = 0;
+  if(read(shared, &shared_value, 1) != 1 || shared_value != 0x22)
+    fail("dup shared offset read failed");
+  if(lseek(fd, 0, SEEK_CUR) != (int64)(FIRST_SINGLE_OFFSET + 1))
+    fail("dup did not share file offset");
+  close(shared);
+
+  if(pipe(pipefd) < 0)
+    fail("pipe creation failed");
+  if(lseek(pipefd[0], 0, SEEK_SET) != -1)
+    fail("pipe unexpectedly seekable");
+  close(pipefd[0]);
+  close(pipefd[1]);
+  close(fd);
+
+  fd = open("sparse.file", O_RDONLY);
+  if(fd < 0)
+    fail("cannot reopen sparse file");
+  for(uint i = 0; i < sizeof(markers) / sizeof(markers[0]); i++)
+    read_marker(fd, &markers[i]);
+  read_zero_hole(fd, FIRST_DOUBLE_OFFSET + BSIZE, 32);
+  close(fd);
+
+  // O_TRUNC 必须释放所有 direct/indirect 数据与索引块，并把 size 恢复为零。
+  fd = open("sparse.file", O_RDWR | O_TRUNC);
+  if(fd < 0 || fstat(fd, &st) < 0 || st.size != 0)
+    fail("O_TRUNC did not clear sparse file");
+  write_marker(fd, &markers[3]);
+  write_marker(fd, &markers[6]);
+  if(fstat(fd, &st) < 0 || st.size != SPARSE_SIZE)
+    fail("sparse rewrite after truncate failed");
+  close(fd);
+  if(unlink("sparse.file") < 0)
+    fail("sparse unlink failed");
+
+  // 删除后再次建立相同 triple/4 GiB 路径，确认释放路径可被后续文件复用。
+  fd = open("reuse.file", O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("cannot create reuse file");
+  write_marker(fd, &markers[3]);
+  write_marker(fd, &markers[6]);
+  if(fstat(fd, &st) < 0 || st.size != SPARSE_SIZE)
+    fail("reclaimed blocks were not reusable");
+  close(fd);
+  if(unlink("reuse.file") < 0)
+    fail("reuse unlink failed");
+}
+
+/** 运行 Lab9 快速密集边界与 lseek 稀疏文件专项回归。 */
+int
+main(void)
+{
+  test_dense_boundaries();
+  test_sparse_boundaries();
+  printf("bigfile: verified dense double-indirect and sparse 4 GiB boundaries\n");
   exit(0);
 }

--- a/tests/guest/bigfile.c
+++ b/tests/guest/bigfile.c
@@ -96,7 +96,7 @@ read_zero_hole(int fd, uint64 offset, int count)
 {
   uchar *bytes = (uchar*)buf;
 
-  if(count > sizeof(buf))
+  if(count < 0 || (uint)count > (uint)sizeof(buf))
     fail("hole probe too large");
   memset(buf, 0x7f, sizeof(buf));
   seek_set_exact(fd, offset);
@@ -228,6 +228,13 @@ test_sparse_boundaries(void)
     fail("pipe unexpectedly seekable");
   close(pipefd[0]);
   close(pipefd[1]);
+
+  int dirfd = open(".", O_RDONLY);
+  if(dirfd < 0)
+    fail("directory open failed");
+  if(lseek(dirfd, 0, SEEK_SET) != -1)
+    fail("directory unexpectedly seekable");
+  close(dirfd);
   close(fd);
 
   fd = open("sparse.file", O_RDONLY);

--- a/tests/guest/usertests_2g.c
+++ b/tests/guest/usertests_2g.c
@@ -3,18 +3,20 @@
 #include "kernel/memviz.h"
 #include "kernel/sysinfo.h"
 
-// 复用原始 usertests 的全部测试函数，但把依赖固定物理容量的入口重命名，
-// 再在本文件提供适配 2 GiB 教学机配置的确定性版本。原始源码保持可直接
+// 复用原始 usertests 的全部测试函数，但把依赖固定物理容量或旧文件语义的入口
+// 重命名，再在本文件提供适配当前教学内核的确定性版本。原始源码保持可直接
 // 与上游对照，适配逻辑集中在单独的 C 翻译单元中。
 #define execout execout_capacity_dependent
 #define mem mem_capacity_dependent
 #define sbrkbasic sbrkbasic_capacity_dependent
 #define sbrkfail sbrkfail_capacity_dependent
+#define truncate2 truncate2_pre_sparse_semantics
 #define run usertests_original_run
 #define main usertests_original_main
 #include "usertests.c"
 #undef main
 #undef run
+#undef truncate2
 #undef sbrkfail
 #undef sbrkbasic
 #undef mem
@@ -370,6 +372,96 @@ sbrkfail(char *s)
   }
   if(adapter_after.free_pages != adapter_before.free_pages){
     printf("%s: aborted sparse process leaked pages\n", s);
+    exit(1);
+  }
+}
+
+/**
+ * truncate2 验证截断不会回退其他打开文件对象的偏移，并且后续越过 EOF 的
+ * 写入会建立可持久化的稀疏文件，而不是沿用上游 xv6 的失败语义。
+ *
+ * @param s 当前 usertests 名称，用于稳定错误输出。
+ *
+ * fd1 写入四字节后停在偏移 4；fd2 将同一 inode 截断到零，但不会修改 fd1
+ * 持有的独立 file offset。fd1 随后写入一个字节，逻辑文件应扩展到五字节，
+ * 偏移 0..3 成为读零的 hole，偏移 4 保存写入的 x。
+ */
+void
+truncate2(char *s)
+{
+  char data[5];
+  struct stat st;
+
+  unlink("truncfile");
+
+  int fd1 = open("truncfile", O_CREATE|O_TRUNC|O_WRONLY);
+  if(fd1 < 0){
+    printf("%s: create failed\n", s);
+    exit(1);
+  }
+  if(write(fd1, "abcd", 4) != 4){
+    printf("%s: initial write failed\n", s);
+    close(fd1);
+    unlink("truncfile");
+    exit(1);
+  }
+
+  int fd2 = open("truncfile", O_TRUNC|O_WRONLY);
+  if(fd2 < 0){
+    printf("%s: truncate open failed\n", s);
+    close(fd1);
+    unlink("truncfile");
+    exit(1);
+  }
+  close(fd2);
+
+  if(write(fd1, "x", 1) != 1){
+    printf("%s: sparse write after truncate failed\n", s);
+    close(fd1);
+    unlink("truncfile");
+    exit(1);
+  }
+  close(fd1);
+
+  // 重开文件验证 hole 与尾部数据已经进入 inode，而非只存在于旧 file offset。
+  int fd = open("truncfile", O_RDONLY);
+  if(fd < 0){
+    printf("%s: reopen failed\n", s);
+    unlink("truncfile");
+    exit(1);
+  }
+  if(fstat(fd, &st) < 0 || st.size != sizeof(data)){
+    printf("%s: sparse size %d, expected %d\n",
+           s, (int)st.size, (int)sizeof(data));
+    close(fd);
+    unlink("truncfile");
+    exit(1);
+  }
+  memset(data, 0x7f, sizeof(data));
+  if(read(fd, data, sizeof(data)) != sizeof(data)){
+    printf("%s: sparse read failed\n", s);
+    close(fd);
+    unlink("truncfile");
+    exit(1);
+  }
+  for(int i = 0; i < 4; i++){
+    if(data[i] != 0){
+      printf("%s: hole byte %d is %d, expected 0\n", s, i, data[i]);
+      close(fd);
+      unlink("truncfile");
+      exit(1);
+    }
+  }
+  if(data[4] != 'x'){
+    printf("%s: sparse tail is %d, expected x\n", s, data[4]);
+    close(fd);
+    unlink("truncfile");
+    exit(1);
+  }
+
+  close(fd);
+  if(unlink("truncfile") < 0){
+    printf("%s: unlink failed\n", s);
     exit(1);
   }
 }

--- a/tests/run_usertests.py
+++ b/tests/run_usertests.py
@@ -19,6 +19,7 @@ sys.modules[SPEC.name] = RUNNER
 SPEC.loader.exec_module(RUNNER)
 
 WATCHDOG_SECONDS = 300
+FAILURE_EXCERPT_LINES = 80
 JOBCTL_STRESS_RUNS = 8
 FORK_STRESS_RUNS = 8
 
@@ -97,6 +98,31 @@ def _assert_command_output(command: str, output: str) -> None:
             raise RUNNER.TestFailure(f"{command}: matched rejected pattern: {pattern}")
 
 
+def _format_failure_output(command: str, output: str) -> str:
+    """把当前失败命令的 guest 输出整理为适合 CI 终端展示的有界片段。
+
+    Args:
+        command: 产生失败输出的 xv6 Shell 命令。
+        output: 从该命令回显后到 Shell prompt 或失败点之前捕获的原始输出。
+
+    Returns:
+        带开始、结束标记的文本片段。最多保留最后 FAILURE_EXCERPT_LINES 行；
+        完整输出仍由调用者写入 test-results 日志，避免完整回归失败时淹没 CI 页面。
+    """
+
+    normalized = RUNNER._normalize_output(output).rstrip("\n")
+    lines = normalized.splitlines() if normalized else []
+    omitted = max(0, len(lines) - FAILURE_EXCERPT_LINES)
+    visible = lines[-FAILURE_EXCERPT_LINES:]
+
+    excerpt = [f"--- failing guest output: {command} ---"]
+    if omitted:
+        excerpt.append(f"... {omitted} earlier lines omitted ...")
+    excerpt.extend(visible or ["<no guest output captured>"])
+    excerpt.append("--- end failing guest output ---")
+    return "\n".join(excerpt)
+
+
 def run(cpus: int, selected_cases: tuple[str, ...] = ()) -> None:
     """在同一 QEMU snapshot 中逐项运行并立即保存失败现场。
 
@@ -106,7 +132,8 @@ def run(cpus: int, selected_cases: tuple[str, ...] = ()) -> None:
 
     Raises:
         RUNNER.TestFailure: QEMU、guest completion 协议或输出约束失败时抛出；
-            所有路径都会先把当前累计输出写入 usertests-full 日志。
+            所有路径都会先把当前累计输出写入 usertests-full 日志，并把当前失败
+            命令的有界输出附在异常中供 CI 直接展示。
     """
 
     child = RUNNER._start_qemu(cpus)
@@ -120,14 +147,20 @@ def run(cpus: int, selected_cases: tuple[str, ...] = ()) -> None:
             output = "\n".join(chunks)
             if result.failure is not None:
                 log_path = RUNNER._write_log("usertests-full", "usertests-full", output)
-                raise RUNNER.TestFailure(f"{result.failure}; log: {log_path}")
+                excerpt = _format_failure_output(command, result.output)
+                raise RUNNER.TestFailure(
+                    f"{result.failure}\n{excerpt}\nfull log: {log_path}"
+                )
             try:
                 _assert_command_output(command, result.output)
             except RUNNER.TestFailure as exc:
                 # 输出断言失败同样属于需要保留的 guest 现场，不能只在 panic/timeout
                 # 路径写日志，否则真正的 status=1 和业务失败文本会被调用者丢失。
                 log_path = RUNNER._write_log("usertests-full", "usertests-full", output)
-                raise RUNNER.TestFailure(f"{exc}; log: {log_path}") from exc
+                excerpt = _format_failure_output(command, result.output)
+                raise RUNNER.TestFailure(
+                    f"{exc}\n{excerpt}\nfull log: {log_path}"
+                ) from exc
 
         output = "\n".join(chunks)
         log_path = RUNNER._write_log("usertests-full", "usertests-full", output)
@@ -160,6 +193,7 @@ def main() -> int:
     try:
         run(args.cpus, tuple(args.cases or ()))
     except RUNNER.TestFailure as exc:
+        # 失败信息写 stderr；GitHub Actions 会与 stdout 一同显示在当前 step 日志中。
         print(f"FAIL usertests-full: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/tests/test_run_usertests.py
+++ b/tests/test_run_usertests.py
@@ -77,6 +77,32 @@ class CommandOutputTests(unittest.TestCase):
             )
 
 
+class FailureExcerptTests(unittest.TestCase):
+    """验证 CI 失败片段保留根因，同时限制历史输出体积。"""
+
+    def test_failure_excerpt_includes_current_guest_output(self) -> None:
+        """当前用例的失败文本和 completion 状态应直接出现在诊断片段中。"""
+
+        excerpt = RUNNER._format_failure_output(
+            "xv6test --usertest truncate2",
+            "truncate2: inode size mismatch\nXV6TEST done status=1\n",
+        )
+
+        self.assertIn("failing guest output: xv6test --usertest truncate2", excerpt)
+        self.assertIn("truncate2: inode size mismatch", excerpt)
+        self.assertIn("XV6TEST done status=1", excerpt)
+
+    def test_failure_excerpt_keeps_only_latest_lines(self) -> None:
+        """超长输出应只保留末尾有界行数，并明确报告省略量。"""
+
+        output = "\n".join(f"line-{index}" for index in range(100))
+        excerpt = RUNNER._format_failure_output("xv6test test", output)
+
+        self.assertIn("... 20 earlier lines omitted ...", excerpt)
+        self.assertNotIn("line-0\n", excerpt)
+        self.assertIn("line-99", excerpt)
+
+
 class FailureLogTests(unittest.TestCase):
     """验证输出断言失败与 panic/timeout 一样会保存累计 guest 日志。"""
 
@@ -91,8 +117,8 @@ class FailureLogTests(unittest.TestCase):
 
             self.command = command
 
-    def test_assertion_failure_writes_log_before_raising(self) -> None:
-        """status=1 路径应把当前命令输出写入稳定日志后再抛错。"""
+    def test_assertion_failure_writes_log_and_exposes_guest_output(self) -> None:
+        """status=1 路径应保存完整日志，并把当前 guest 根因附到异常中。"""
 
         child = self.FakeChild()
         result = RUNNER.RUNNER.QemuCommandResult(
@@ -111,12 +137,13 @@ class FailureLogTests(unittest.TestCase):
             mock.patch.object(RUNNER.RUNNER, "_write_log", return_value=log_path) as write_log,
             mock.patch.object(RUNNER.RUNNER, "_stop_qemu"),
         ):
-            with self.assertRaisesRegex(
-                RUNNER.RUNNER.TestFailure,
-                r"status=1; log: /tmp/usertests-full.log",
-            ):
+            with self.assertRaises(RUNNER.RUNNER.TestFailure) as raised:
                 RUNNER.run(1)
 
+        message = str(raised.exception)
+        self.assertIn("XV6TEST completed with status=1", message)
+        self.assertIn("FAILED -- lost pages", message)
+        self.assertIn("full log: /tmp/usertests-full.log", message)
         write_log.assert_called_once()
         self.assertIn("XV6TEST done status=1", write_log.call_args.args[2])
 

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,17 @@ int open(const char*, int);
 int mknod(const char*, short, short);
 int unlink(const char*);
 int fstat(int fd, struct stat*);
+
+/**
+ * 重新定位普通文件描述符的共享 64 位偏移。
+ *
+ * @param fd 已打开的普通文件描述符；pipe 和 device 不支持定位。
+ * @param offset 相对 whence 基准的有符号字节偏移。
+ * @param whence SEEK_SET、SEEK_CUR 或 SEEK_END。
+ * @return 成功返回新的非负偏移；参数非法或结果越界时返回 -1。
+ */
+int64 lseek(int fd, int64 offset, int whence);
+
 int link(const char*, const char*);
 int mkdir(const char*);
 int chdir(const char*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -29,6 +29,7 @@ entry("open");
 entry("mknod");
 entry("unlink");
 entry("fstat");
+entry("lseek");
 entry("link");
 entry("mkdir");
 entry("chdir");


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #106
- 基线 Commit：`0fa145a478339165f735131668885acf1942b862`
- 当前 Head：`1613694bad4fc705e9fa56b4b5531317652cc024`
- 分支：`concept/106-lseek-sparse-file`
- 状态：Draft，未经用户验收不合并
- 变更类型：文件系统教学能力与边界回归
- 影响范围：系统调用 ABI、打开文件偏移、inode 稀疏读写语义、Lab9 大文件测试
- 一句话摘要：通过最小 `lseek` 和稀疏文件语义，在默认测试镜像中低成本覆盖三级间接块与 4 GiB 文件大小边界。

## 实现了什么

- 新增 `lseek(fd, offset, whence)`，偏移保持 64 位，支持 `SEEK_SET`、`SEEK_CUR` 和 `SEEK_END`；成功返回新偏移，负结果、非法 `whence` 或超过 `MAXFILE_BYTES` 时返回 `-1`。
- 仅普通文件 `T_FILE` 支持定位；pipe、device、目录和未跟随的符号链接保持不可定位。`dup()`/`fork()` 继续通过共享 `struct file` 共享文件偏移。
- `lseek` 本身不修改 inode size、不分配块；定位到 EOF 之后写入时，只分配目标数据块和抵达该块所需的间接索引路径。
- `readi()` 将 inode size 范围内未映射的数据块作为 hole 返回零；`writei()` 允许在 EOF 之后写入并按实际完成位置更新 64 位 size。
- 保留 #105 的测试分层：本 PR 的稀疏边界进入快速 `lab9-bigfile`，真实 4 GiB 顺序写读仍由独立 `largefs-4gib` 专项入口承担。
- 教学边界：不实现 `pwrite()`、完整 POSIX 错误码、文件系统块计数接口或生产级稀疏文件优化；最大偏移仍受 xv6 当前三级间接索引容量限制。

## 添加/修改了什么测试

| 测试场景 | 覆盖边界 | 核心断言 |
|---|---|---|
| 密集文件快速回归 | direct、single-indirect、double-indirect 第二张叶子表 | 顺序写入后 `fstat` size、逐块读回数据和 `unlink` 均正确 |
| `lseek` 参数与对象边界 | `SEEK_SET/CUR/END`、负偏移、非法 `whence`、pipe、目录 | 合法定位返回精确 64 位偏移，非法输入和非普通文件返回 `-1` |
| 稀疏索引边界 | direct、single、double、triple 的首个关键位置 | 每个标记只经 `lseek + write` 写入，重开后按相同偏移读回 |
| 4 GiB 大小边界 | `2^32 - 1`、`2^32`、`2^32 + 1` | 跨边界读回 `[hole-zero, marker, marker, marker]`，`fstat` 为 `2^32 + 2` |
| hole 语义 | 完全未映射的数据块 | 预填非零缓冲区后读取，返回长度正确且每个字节均为零 |
| 偏移共享与资源回收 | `dup`、`O_TRUNC`、`unlink`、重新创建 | 副本推进同一 offset；截断清零 size；删除后可再次建立 triple/4 GiB 稀疏路径 |
| 最大文件边界 | `MAXFILE_BYTES` | 可定位到上界，但继续写入失败且 inode size 不变 |

## 如何通过 CLI 回归观察此 PR 现象

### 前置条件

```bash
git fetch origin
git switch concept/106-lseek-sparse-file
git pull --ff-only
make clean
make -j2 SCHED_POLICY=rr
```

### Issue 专项回归

```bash
python3 tests/run.py --suite lab9-bigfile --cpus 3
```

预期关键输出：

```text
bigfile: verified dense double-indirect and sparse 4 GiB boundaries
XV6TEST ok 1 - lab9-bigfile
XV6TEST done status=0
```

该命令使用默认约 200,000 块的镜像，却能生成 `2^32 + 2` 字节的逻辑文件；测试成功也说明中间 hole 没有被密集分配。它不会运行 `largefs-4gib` 的真实 4 GiB 顺序 I/O。

### PR 级回归

```bash
make test-integration CPUS=3 SCHED_POLICY=rr
```

## 自动化测试结果

Scheduler family CI Run `30031111150`：

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| 完整 diff 范围检查 | 通过 | 相对基线仅修改 12 个预期代码/测试文件，无 Markdown 和无关文件 |
| runner 单元测试 | 通过 | `Run runner unit tests` 成功 |
| `make clean && make -j2 SCHED_POLICY=rr` | 通过 | `Build default RR policy` 成功 |
| `make test-integration CPUS=3 SCHED_POLICY=rr` | 通过 | `Run pull-request regression` 成功；其中包含本 PR 修改的 `lab9-bigfile` |
| RR 三核 smoke、FIFO/SJF/CFS 单核行为、MLFQ 三核 smoke | 通过 | 对应已完成矩阵 job 均成功 |
| `python3 tests/run_usertests.py --cpus 3` | 未通过 | `Run complete usertests` 失败；连接器返回的日志被截断，当前无法可靠确认具体失败用例，未将其误报为已通过 |
| 单核 `reparent2/reparent` | 未执行 | 因上一项失败，后续步骤被工作流跳过 |

### 当前判断

- Issue #106 的核心构建、系统调用接线、QEMU PR 回归和稀疏 4 GiB 边界专项已经通过。
- 额外的完整 `usertests` 仍需单独复核，因此 PR 保持 Draft，不标记 Ready、不合并。

## Review 主线

1. `kernel/fcntl.h`、`kernel/syscall.h`、`user/user.h`、`user/usys.pl`
   - 确认 `lseek` 的 64 位用户态契约、`whence` 常量和系统调用编号。
2. `kernel/sysseek.c` 与 `kernel/syscall.c`
   - 检查参数保留完整寄存器宽度，以及 fd/offset/whence 到核心实现的接线。
3. `kernel/file.c::fileseek`
   - 核对只允许 `T_FILE`，并确认负偏移、`INT64_MIN`、`MAXFILE_BYTES` 和共享 offset 的锁边界。
4. `kernel/fs.c::readi`、`kernel/fs.c::writei`
   - 检查 hole 读零不分配块、越过 EOF 写入只建立目标索引路径，以及 size/部分分配仍可回收的不变量。
5. `tests/guest/bigfile.c`
   - 对照 direct/single/double/triple、4 GiB、`dup`、截断、删除与复用断言完成行为闭环。

## 教学边界

- `lseek` 仅服务普通文件，不实现完整 POSIX seekable object 体系。
- 不提供 errno；失败统一返回 `-1`。
- 不实现 `SEEK_DATA/SEEK_HOLE`、`pwrite/pread` 或块占用统计接口。
- 稀疏文件最大逻辑大小仍由当前三级间接索引结构的 `MAXFILE_BYTES` 限制。
- 真实 4 GiB 顺序 I/O 仍保留在手工专项 `make largefiletest`，不进入 PR 快速回归。