### PR TITLE
feat: 对齐 Linux 风格 ls 长格式输出

### DIFF
--- a/kernel/file.h
+++ b/kernel/file.h
@@ -25,6 +25,7 @@ struct inode {
   short major;
   short minor;
   short nlink;
+  uint mtime;         // Unix seconds of the last visible content change
   uint64 size;
   uint addrs[NDIRECT+NINDIRECT_LEVELS];
 };

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -16,8 +16,10 @@
 #include "fs.h"
 #include "buf.h"
 #include "file.h"
+#include "memlayout.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
+#define NANOSECONDS_PER_SECOND 1000000000ULL
 
 typedef char dinode_must_remain_64_bytes[(sizeof(struct dinode) == 64) ? 1 : -1];
 
@@ -28,6 +30,75 @@ struct superblock sb;
 // the buffer cache sleeplock for each bitmap block.
 static struct spinlock balloc_lock;
 static uint balloc_cursor;
+
+// Goldfish RTC 通过先读低位再读高位形成一次快照；该锁防止不同 CPU 的两次
+// MMIO 读取互相覆盖锁存值。
+static struct spinlock mtime_lock;
+
+/**
+ * 从 QEMU Goldfish RTC 读取当前 Unix 秒数。
+ *
+ * @return 自 1970-01-01 00:00:00 UTC 起的秒数；受 32 位 inode 字段限制，
+ *         该教学实现会在 2106 年回绕。
+ */
+static uint
+filesystem_time(void)
+{
+  uint low;
+  uint high;
+
+  acquire(&mtime_lock);
+  low = *(volatile uint*)RTC_TIME_LOW;
+  high = *(volatile uint*)RTC_TIME_HIGH;
+  release(&mtime_lock);
+
+  return (((uint64)high << 32) | low) / NANOSECONDS_PER_SECOND;
+}
+
+/**
+ * 从保持 64 字节布局的磁盘 inode 中解码修改时间。
+ *
+ * @param dip 已从 inode block 读取的磁盘 inode。
+ * @return 32 位 Unix 秒数。
+ */
+static uint
+dinode_mtime(struct dinode *dip)
+{
+  if(dip->type == T_DEVICE)
+    return (uint)(dip->size >> 32);
+  return ((uint)(ushort)dip->major << 16) | (ushort)dip->minor;
+}
+
+/**
+ * 将修改时间写入按 inode 类型空闲的磁盘字段，不改变 dinode 大小。
+ *
+ * @param dip 待修改的磁盘 inode。
+ * @param type inode 类型；设备节点必须保留 major/minor。
+ * @param mtime 32 位 Unix 秒数。
+ */
+static void
+dinode_set_mtime(struct dinode *dip, short type, uint mtime)
+{
+  if(type == T_DEVICE){
+    dip->size = ((uint64)mtime << 32) | (uint)dip->size;
+    return;
+  }
+  dip->major = (short)(mtime >> 16);
+  dip->minor = (short)(mtime & 0xffff);
+}
+
+/**
+ * 更新锁定 inode 的修改时间，并避免宿主机时钟回拨造成时间倒退。
+ *
+ * @param ip 调用者已持有 sleeplock 的内存 inode。
+ */
+static void
+inode_touch(struct inode *ip)
+{
+  uint now = filesystem_time();
+  if(now >= ip->mtime)
+    ip->mtime = now;
+}
 
 /**
  * Read the file-system superblock from device dev.
@@ -56,6 +127,7 @@ fsinit(int dev)
     panic("invalid file system");
 
   initlock(&balloc_lock, "balloc");
+  initlock(&mtime_lock, "mtime");
   balloc_cursor = sb.size - sb.nblocks;
   initlog(dev, &sb);
 }
@@ -201,6 +273,7 @@ ialloc(uint dev, short type)
     if(dip->type == 0){
       memset(dip, 0, sizeof(*dip));
       dip->type = type;
+      dinode_set_mtime(dip, type, filesystem_time());
       log_write(bp);
       brelse(bp);
       return iget(dev, inum);
@@ -222,10 +295,13 @@ iupdate(struct inode *ip)
   struct dinode *dip = (struct dinode*)bp->data + ip->inum % IPB;
 
   dip->type = ip->type;
-  dip->major = ip->major;
-  dip->minor = ip->minor;
   dip->nlink = ip->nlink;
   dip->size = ip->size;
+  if(ip->type == T_DEVICE){
+    dip->major = ip->major;
+    dip->minor = ip->minor;
+  }
+  dinode_set_mtime(dip, ip->type, ip->mtime);
   memmove(dip->addrs, ip->addrs, sizeof(ip->addrs));
   log_write(bp);
   brelse(bp);
@@ -285,10 +361,17 @@ ilock(struct inode *ip)
     struct buf *bp = bread(ip->dev, IBLOCK(ip->inum, sb));
     struct dinode *dip = (struct dinode*)bp->data + ip->inum % IPB;
     ip->type = dip->type;
-    ip->major = dip->major;
-    ip->minor = dip->minor;
     ip->nlink = dip->nlink;
-    ip->size = dip->size;
+    ip->mtime = dinode_mtime(dip);
+    if(ip->type == T_DEVICE){
+      ip->major = dip->major;
+      ip->minor = dip->minor;
+      ip->size = (uint)dip->size;
+    } else {
+      ip->major = 0;
+      ip->minor = 0;
+      ip->size = dip->size;
+    }
     memmove(ip->addrs, dip->addrs, sizeof(ip->addrs));
     brelse(bp);
     ip->valid = 1;
@@ -356,7 +439,7 @@ static const uint64 indirect_capacity[NINDIRECT_LEVELS] = {
  * @param addr Root index-block address.
  * @param bn Block number relative to this tree.
  * @param depth Tree depth: 1, 2, or 3.
- * @param alloc Non-zero to allocate missing index/data blocks.
+ * @param alloc Non-zero to allocate missing nodes.
  * @return Data block address, or zero for a missing block/allocation failure.
  */
 static uint
@@ -511,6 +594,7 @@ itrunc(struct inode *ip)
   }
 
   ip->size = 0;
+  inode_touch(ip);
   iupdate(ip);
 }
 
@@ -522,6 +606,7 @@ stati(struct inode *ip, struct stat *st)
   st->ino = ip->inum;
   st->type = ip->type;
   st->nlink = ip->nlink;
+  st->mtime = ip->mtime;
   st->size = ip->size;
 }
 
@@ -622,6 +707,8 @@ writei(struct inode *ip, int user_src, uint64 src, uint64 off, uint n)
   if(n > 0){
     if(off > ip->size)
       ip->size = off;
+    if(tot > 0)
+      inode_touch(ip);
     // bmap() may have linked a new root before a deeper allocation failed.
     // Persisting addrs[] keeps that partial tree reachable and reclaimable.
     iupdate(ip);

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -33,12 +33,16 @@ struct superblock {
 
 // On-disk inode structure. Keep this structure exactly 64 bytes so that the
 // inode density and the surrounding disk layout stay stable.
+//
+// xv6 尚未实现权限和多用户字段。为不降低三级索引容量，mtime 复用按类型空闲的
+// 既有字段：非设备 inode 使用 major/minor 的两个 16 位槽；设备 inode 必须保留
+// major/minor，因此将 mtime 放入其逻辑上未使用的 size 高 32 位。
 struct dinode {
   short type;                        // File type
-  short major;                       // Major device number (T_DEVICE only)
-  short minor;                       // Minor device number (T_DEVICE only)
+  short major;                       // Device major, or non-device mtime high 16 bits
+  short minor;                       // Device minor, or non-device mtime low 16 bits
   short nlink;                       // Number of links to inode in file system
-  uint64 size;                       // Size of file (bytes)
+  uint64 size;                       // File size; device mtime occupies high 32 bits
   uint addrs[NDIRECT+NINDIRECT_LEVELS]; // Direct and 1/2/3-level index roots
 };
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -18,6 +18,9 @@ main()
     printf("\n");
     kinit();         // physical page allocator
     kvminit();       // create kernel page table
+    // Goldfish RTC 位于普通 RAM direct map 之外，必须在启用分页前显式映射。
+    // 每进程内核页表会复制全局低半区，因此后续文件系统路径也能读取该 MMIO。
+    kvmmap(RTC, RTC, PGSIZE, PTE_R | PTE_W);
     kvminithart();   // turn on paging
     procinit();      // process table
     trapinit();      // trap vectors

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -4,6 +4,7 @@
 // based on qemu's hw/riscv/virt.c:
 //
 // 00001000 -- boot ROM, provided by qemu
+// 00101000 -- Goldfish real-time clock
 // 02000000 -- CLINT
 // 0C000000 -- PLIC
 // 10000000 -- uart0 
@@ -11,11 +12,17 @@
 // 80000000 -- boot ROM jumps here in machine mode
 //             -kernel loads the kernel here
 // unused RAM after 80000000.
-
+//
 // the kernel uses physical memory thus:
 // 80000000 -- entry.S, then kernel text and data
 // end -- start of kernel page allocation area
 // PHYSTOP -- end RAM used by the kernel
+
+// qemu puts the Goldfish RTC registers here. Reading TIME_LOW first latches
+// TIME_HIGH so the two 32-bit loads describe one nanosecond timestamp.
+#define RTC 0x00101000L
+#define RTC_TIME_LOW  (RTC + 0x00)
+#define RTC_TIME_HIGH (RTC + 0x04)
 
 // qemu puts UART registers here in physical memory.
 #define UART0 0x10000000L
@@ -51,7 +58,7 @@
 // in both user and kernel space.
 #define TRAMPOLINE (MAXVA - PGSIZE)
 
-// map kernel stacks beneath the trampoline,
+// Map kernel stacks beneath the trampoline,
 // each surrounded by invalid guard pages.
 #define KSTACK(p) (TRAMPOLINE - ((p)+1)* 2*PGSIZE)
 

--- a/kernel/stat.h
+++ b/kernel/stat.h
@@ -8,5 +8,6 @@ struct stat {
   uint ino;    // Inode number
   short type;  // Type of file
   short nlink; // Number of links to file
+  uint mtime;  // Last content or directory-entry modification, Unix seconds
   uint64 size; // Size of file in bytes
 };

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -322,11 +322,18 @@ balloc(int used)
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
+/**
+ * 把宿主机文件内容追加到普通启动镜像 inode。
+ *
+ * 启动镜像输入保持较小，本路径只负责直接块和一级间接块；运行中的内核负责
+ * 二级、三级间接扩展。size 使用完整 64 位磁盘编码，避免依赖宿主机字节序。
+ */
 void
 iappend(uint inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint fbn, off, n1;
+  uint64 fbn, off;
+  uint n1;
   struct dinode din;
   char buf[BSIZE];
   uint indirect[NINDIRECT];
@@ -337,7 +344,7 @@ iappend(uint inum, void *xp, int n)
   // printf("append inum %d at off %d sz %d\n", inum, off, n);
   while(n > 0){
     fbn = off / BSIZE;
-    assert(fbn < MAXFILE);
+    assert(fbn < (uint64)NDIRECT + NINDIRECT);
     if(fbn < NDIRECT){
       if(xint(din.addrs[fbn]) == 0){
         din.addrs[fbn] = xint(freeblock++);
@@ -345,10 +352,8 @@ iappend(uint inum, void *xp, int n)
       x = xint(din.addrs[fbn]);
     } else {
       if(xint(din.addrs[NDIRECT]) == 0){
-        // printf("allocate indirect block\n");
         din.addrs[NDIRECT] = xint(freeblock++);
       }
-      // printf("read indirect block\n");
       rsect(xint(din.addrs[NDIRECT]), (char*)indirect);
       if(indirect[fbn - NDIRECT] == 0){
         indirect[fbn - NDIRECT] = xint(freeblock++);
@@ -356,9 +361,9 @@ iappend(uint inum, void *xp, int n)
       }
       x = xint(indirect[fbn-NDIRECT]);
     }
-    n1 = min(n, (fbn + 1) * BSIZE - off);
+    n1 = min((uint)n, BSIZE - off % BSIZE);
     rsect(x, buf);
-    bcopy(p, buf + off - (fbn * BSIZE), n1);
+    bcopy(p, buf + off % BSIZE, n1);
     wsect(x, buf);
     n -= n1;
     off += n1;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <time.h>
 
 #define stat xv6_stat  // avoid clash with host struct stat
 #include "kernel/types.h"
@@ -32,6 +33,7 @@ struct superblock sb;
 char zeroes[BSIZE];
 uint freeinode = 1;
 uint freeblock;
+uint image_mtime;
 
 
 void balloc(int);
@@ -41,6 +43,7 @@ void rinode(uint inum, struct dinode *ip);
 void rsect(uint sec, void *buf);
 uint ialloc(ushort type);
 void iappend(uint inum, void *p, int n);
+void set_dinode_mtime(struct dinode*, ushort, uint);
 
 // convert to intel byte order
 ushort
@@ -76,6 +79,31 @@ xlong(uint64 x)
   return y;
 }
 
+/**
+ * 将构建时修改时间写入保持 64 字节布局的磁盘 inode。
+ *
+ * @param din 待初始化的宿主机端磁盘 inode。
+ * @param type inode 类型。
+ * @param mtime 32 位 Unix 秒数。
+ */
+void
+set_dinode_mtime(struct dinode *din, ushort type, uint mtime)
+{
+  if(type == T_DEVICE){
+    din->size = xlong((uint64)mtime << 32);
+    return;
+  }
+  din->major = xshort(mtime >> 16);
+  din->minor = xshort(mtime & 0xffff);
+}
+
+/**
+ * 构造 xv6 文件系统镜像，并让镜像内初始 inode 共享本次构建时间。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 第一个参数为镜像路径，其余参数为写入根目录的宿主机文件。
+ * @return 构造成功返回 0；输入、时间或 I/O 失败时终止进程。
+ */
 int
 main(int argc, char *argv[])
 {
@@ -85,6 +113,7 @@ main(int argc, char *argv[])
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
+  time_t now;
 
 
   static_assert(sizeof(int) == 4, "Integers must be 4 bytes!");
@@ -95,6 +124,13 @@ main(int argc, char *argv[])
     fprintf(stderr, "Usage: mkfs fs.img files...\n");
     exit(1);
   }
+
+  now = time(0);
+  if(now == (time_t)-1){
+    fprintf(stderr, "mkfs: cannot read host time\n");
+    exit(1);
+  }
+  image_mtime = (uint)now;
 
   assert((BSIZE % sizeof(struct dinode)) == 0);
   assert((BSIZE % sizeof(struct dirent)) == 0);
@@ -247,6 +283,12 @@ rsect(uint sec, void *buf)
   }
 }
 
+/**
+ * 分配一个镜像 inode，并写入本次 mkfs 的统一修改时间。
+ *
+ * @param type 新 inode 类型。
+ * @return 新分配的 inode 编号。
+ */
 uint
 ialloc(ushort type)
 {
@@ -257,6 +299,7 @@ ialloc(ushort type)
   din.type = xshort(type);
   din.nlink = xshort(1);
   din.size = xlong(0);
+  set_dinode_mtime(&din, type, image_mtime);
   winode(inum, &din);
   return inum;
 }
@@ -279,18 +322,11 @@ balloc(int used)
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-/**
- * 把宿主机文件内容追加到普通启动镜像 inode。
- *
- * 启动镜像输入保持较小，本路径只负责直接块和一级间接块；运行中的内核负责
- * 二级、三级间接扩展。size 使用完整 64 位磁盘编码，避免依赖宿主机字节序。
- */
 void
 iappend(uint inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint64 fbn, off;
-  uint n1;
+  uint fbn, off, n1;
   struct dinode din;
   char buf[BSIZE];
   uint indirect[NINDIRECT];
@@ -301,7 +337,7 @@ iappend(uint inum, void *xp, int n)
   // printf("append inum %d at off %d sz %d\n", inum, off, n);
   while(n > 0){
     fbn = off / BSIZE;
-    assert(fbn < (uint64)NDIRECT + NINDIRECT);
+    assert(fbn < MAXFILE);
     if(fbn < NDIRECT){
       if(xint(din.addrs[fbn]) == 0){
         din.addrs[fbn] = xint(freeblock++);
@@ -309,8 +345,10 @@ iappend(uint inum, void *xp, int n)
       x = xint(din.addrs[fbn]);
     } else {
       if(xint(din.addrs[NDIRECT]) == 0){
+        // printf("allocate indirect block\n");
         din.addrs[NDIRECT] = xint(freeblock++);
       }
+      // printf("read indirect block\n");
       rsect(xint(din.addrs[NDIRECT]), (char*)indirect);
       if(indirect[fbn - NDIRECT] == 0){
         indirect[fbn - NDIRECT] = xint(freeblock++);
@@ -318,9 +356,9 @@ iappend(uint inum, void *xp, int n)
       }
       x = xint(indirect[fbn-NDIRECT]);
     }
-    n1 = min((uint)n, BSIZE - off % BSIZE);
+    n1 = min(n, (fbn + 1) * BSIZE - off);
     rsect(x, buf);
-    bcopy(p, buf + off % BSIZE, n1);
+    bcopy(p, buf + off - (fbn * BSIZE), n1);
     wsect(x, buf);
     n -= n1;
     off += n1;

--- a/mkfs/mkfs_large.c
+++ b/mkfs/mkfs_large.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #define stat xv6_stat  // avoid clash with the host struct stat tag
@@ -29,6 +30,7 @@ struct superblock sb;
 char zeroes[BSIZE];
 uint freeinode = 1;
 uint freeblock;
+uint image_mtime;
 
 void balloc(int);
 void wsect(uint, void*);
@@ -38,6 +40,7 @@ void rsect(uint, void*);
 uint ialloc(ushort);
 void iappend(uint, void*, int);
 void die(const char*);
+void set_dinode_mtime(struct dinode*, ushort, uint);
 
 uint
 xint(uint x)
@@ -77,6 +80,24 @@ die(const char *message)
 {
   perror(message);
   exit(1);
+}
+
+/**
+ * 将构建时修改时间写入保持 64 字节布局的磁盘 inode。
+ *
+ * @param din 待初始化的宿主机端磁盘 inode。
+ * @param type inode 类型。
+ * @param mtime 32 位 Unix 秒数。
+ */
+void
+set_dinode_mtime(struct dinode *din, ushort type, uint mtime)
+{
+  if(type == T_DEVICE){
+    din->size = xlong((uint64)mtime << 32);
+    return;
+  }
+  din->major = xshort(mtime >> 16);
+  din->minor = xshort(mtime & 0xffff);
 }
 
 /** Write one complete file-system sector using an off_t-safe offset. */
@@ -122,6 +143,12 @@ rinode(uint inum, struct dinode *ip)
   *ip = *dip;
 }
 
+/**
+ * 分配一个大镜像 inode，并写入本次 mkfs 的统一修改时间。
+ *
+ * @param type 新 inode 类型。
+ * @return 新分配的 inode 编号。
+ */
 uint
 ialloc(ushort type)
 {
@@ -131,6 +158,7 @@ ialloc(ushort type)
   din.type = xshort(type);
   din.nlink = xshort(1);
   din.size = xlong(0);
+  set_dinode_mtime(&din, type, image_mtime);
   winode(inum, &din);
   return inum;
 }
@@ -211,6 +239,13 @@ balloc(int used)
   }
 }
 
+/**
+ * 构造大容量 xv6 文件系统镜像，并为初始 inode 写入统一构建时间。
+ *
+ * @param argc 命令行参数数量。
+ * @param argv 第一个参数为镜像路径，其余参数为写入根目录的宿主机文件。
+ * @return 成功返回 0；输入、时间或 I/O 失败时终止进程。
+ */
 int
 main(int argc, char *argv[])
 {
@@ -219,6 +254,7 @@ main(int argc, char *argv[])
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
+  time_t now;
 
   static_assert(sizeof(int) == 4, "integers must be 4 bytes");
   static_assert(sizeof(uint64) == 8, "uint64 must be 8 bytes");
@@ -229,6 +265,13 @@ main(int argc, char *argv[])
     fprintf(stderr, "Usage: mkfs-large fs.img files...\n");
     exit(1);
   }
+
+  now = time(0);
+  if(now == (time_t)-1){
+    fprintf(stderr, "mkfs-large: cannot read host time\n");
+    exit(1);
+  }
+  image_mtime = (uint)now;
 
   assert((BSIZE % sizeof(struct dirent)) == 0);
   nmeta = 2 + nlog + ninodeblocks + nbitmap;

--- a/tests/guest/lstest.c
+++ b/tests/guest/lstest.c
@@ -3,9 +3,9 @@
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
-#define OUTPUT_SIZE 1024
+#define OUTPUT_SIZE 2048
 
-// 1024 字节足以覆盖专项输出；放在 BSS 避免占满 xv6 的单页用户栈。
+// 专项输出包含 ANSI 颜色和长格式字段；放在 BSS 避免占满 xv6 单页用户栈。
 static char output[OUTPUT_SIZE];
 
 /**
@@ -75,15 +75,61 @@ has_line(char *text, char *expected)
 }
 
 /**
+ * 判断字符是否为十进制数字。
+ *
+ * @param value 待判断字符。
+ * @return 数字返回 1，否则返回 0。
+ */
+static int
+is_digit(char value)
+{
+  return value >= '0' && value <= '9';
+}
+
+/**
+ * 判断长格式输出中是否存在 `Mon DD HH:MM` 形式的 UTC 时间字段。
+ *
+ * @param text ls 输出。
+ * @return 找到合法固定宽度字段返回 1，否则返回 0。
+ */
+static int
+has_mtime_field(char *text)
+{
+  static char *months[] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  };
+  int i;
+  int month;
+
+  for(i = 0; text[i] != 0; i++){
+    if(text[i + 11] == 0)
+      break;
+    for(month = 0; month < 12; month++){
+      if(memcmp(text + i, months[month], 3) != 0)
+        continue;
+      if(text[i + 3] == ' ' &&
+         (text[i + 4] == ' ' || is_digit(text[i + 4])) &&
+         is_digit(text[i + 5]) && text[i + 6] == ' ' &&
+         is_digit(text[i + 7]) && is_digit(text[i + 8]) &&
+         text[i + 9] == ':' && is_digit(text[i + 10]) &&
+         is_digit(text[i + 11]))
+        return 1;
+    }
+  }
+  return 0;
+}
+
+/**
  * 在子进程中执行 ls，并同时捕获 stdout 与 stderr。
  *
  * @param argv 传给 exec("ls") 的空指针结尾参数数组。
- * @param output 输出缓冲区。
- * @param capacity output 容量，必须大于 1。
+ * @param buffer 输出缓冲区。
+ * @param capacity buffer 容量，必须大于 1。
  * @return ls 的退出状态；基础设施失败时直接终止测试。
  */
 static int
-run_ls(char **argv, char *output, int capacity)
+run_ls(char **argv, char *buffer, int capacity)
 {
   int pipefd[2];
   int pid;
@@ -108,12 +154,12 @@ run_ls(char **argv, char *output, int capacity)
   close(pipefd[1]);
   total = 0;
   while(total < capacity - 1){
-    count = read(pipefd[0], output + total, capacity - total - 1);
+    count = read(pipefd[0], buffer + total, capacity - total - 1);
     if(count <= 0)
       break;
     total += count;
   }
-  output[total] = 0;
+  buffer[total] = 0;
   close(pipefd[0]);
   check(wait(&status) == pid, "wait returned wrong child");
   return status;
@@ -166,7 +212,9 @@ remove_fixture(void)
   unlink("-lsdash");
 }
 
-/** 验证默认隐藏、-a、-l、-h、组合选项、-- 和错误状态传播。 */
+/**
+ * 验证默认横向布局、长格式、颜色、total、组合选项和错误状态传播。
+ */
 static void
 test_ls_options(void)
 {
@@ -175,35 +223,41 @@ test_ls_options(void)
   char *long_argv[] = {"ls", "-l", "lstmp", 0};
   char *human_argv[] = {"ls", "-lh", "lstmp", 0};
   char *combined_argv[] = {"ls", "-alh", "lstmp", 0};
+  char *device_argv[] = {"ls", "-l", "console", 0};
   char *dash_argv[] = {"ls", "--", "-lsdash", 0};
   char *help_argv[] = {"ls", "--help", 0};
   char *invalid_argv[] = {"ls", "-z", 0};
   char *multi_argv[] = {"ls", "missing-ls", "lstmp/visible", 0};
+  char *default_expected = "\033[1;34msubdir\033[0m visible link\n";
+  char *all_expected = "\033[1;34m.\033[0m \033[1;34m..\033[0m \033[1;34msubdir\033[0m visible .hidden link\n";
 
   check(run_ls(default_argv, output, sizeof(output)) == 0, "default ls status");
-  check(has_line(output, "visible"), "default ls missing visible");
-  check(has_line(output, "subdir"), "default ls missing directory");
-  check(has_line(output, "link"), "default ls missing symlink");
-  check(!has_line(output, "."), "default ls exposed dot");
-  check(!has_line(output, ".."), "default ls exposed dotdot");
-  check(!has_line(output, ".hidden"), "default ls exposed hidden file");
+  check(strcmp(output, default_expected) == 0, "default ls is not one colored line");
 
   check(run_ls(all_argv, output, sizeof(output)) == 0, "ls -a status");
-  check(has_line(output, "."), "ls -a missing dot");
-  check(has_line(output, ".."), "ls -a missing dotdot");
-  check(has_line(output, ".hidden"), "ls -a missing hidden file");
+  check(strcmp(output, all_expected) == 0, "ls -a layout or hidden entries");
 
   check(run_ls(long_argv, output, sizeof(output)) == 0, "ls -l status");
-  check(contains(output, "1536 visible"), "ls -l missing byte size");
-  check(contains(output, "d "), "ls -l missing directory type");
-  check(contains(output, "l "), "ls -l missing symlink type");
+  check(contains(output, "total "), "ls -l missing total");
+  check(contains(output, "-rw-r--r--"), "ls -l missing file mode");
+  check(contains(output, "drwxr-xr-x"), "ls -l missing directory mode");
+  check(contains(output, "lrwxrwxrwx"), "ls -l missing symlink mode");
+  check(contains(output, " root root "), "ls -l missing owner or group");
+  check(contains(output, "1536 "), "ls -l missing byte size");
+  check(contains(output, "\033[1;34msubdir\033[0m"), "ls -l missing directory color");
+  check(has_mtime_field(output), "ls -l missing modification time");
 
   check(run_ls(human_argv, output, sizeof(output)) == 0, "ls -lh status");
-  check(contains(output, "1.5K visible"), "ls -lh missing human size");
+  check(contains(output, "total 1.5K\n"), "ls -lh missing human total");
+  check(contains(output, "1.5K "), "ls -lh missing human file size");
 
   check(run_ls(combined_argv, output, sizeof(output)) == 0, "ls -alh status");
   check(contains(output, ".hidden"), "ls -alh missing hidden file");
-  check(contains(output, "1.5K visible"), "ls -alh lost human size");
+  check(contains(output, "1.5K "), "ls -alh lost human size");
+
+  check(run_ls(device_argv, output, sizeof(output)) == 0, "ls device status");
+  check(contains(output, "crw-rw-rw-"), "ls missing device mode");
+  check(contains(output, " root root "), "ls device missing owner or group");
 
   check(run_ls(dash_argv, output, sizeof(output)) == 0, "ls -- status");
   check(has_line(output, "-lsdash"), "ls -- did not preserve dash path");
@@ -220,6 +274,45 @@ test_ls_options(void)
   check(has_line(output, "visible"), "multi-path stopped before valid path");
 }
 
+/** 验证 mkfs 初始时间和运行期写入、重开、截断的 mtime 持久化。 */
+static void
+test_mtime(void)
+{
+  int fd;
+  struct stat initial;
+  struct stat before;
+  struct stat after_write;
+  struct stat reopened;
+  struct stat truncated;
+
+  fd = open("README", O_RDONLY);
+  check(fd >= 0, "open README failed");
+  check(fstat(fd, &initial) == 0, "stat README failed");
+  check(initial.mtime > 0, "mkfs inode mtime is zero");
+  close(fd);
+
+  fd = open("lstmp/visible", O_RDWR);
+  check(fd >= 0, "open visible for mtime failed");
+  check(fstat(fd, &before) == 0, "stat before write failed");
+  check(write(fd, "y", 1) == 1, "mtime write failed");
+  check(fstat(fd, &after_write) == 0, "stat after write failed");
+  check(after_write.mtime >= before.mtime, "write moved mtime backwards");
+  close(fd);
+
+  fd = open("lstmp/visible", O_RDONLY);
+  check(fd >= 0, "reopen visible failed");
+  check(fstat(fd, &reopened) == 0, "stat reopened file failed");
+  check(reopened.mtime == after_write.mtime, "mtime was not persisted");
+  close(fd);
+
+  fd = open("lstmp/visible", O_RDWR | O_TRUNC);
+  check(fd >= 0, "truncate visible failed");
+  check(fstat(fd, &truncated) == 0, "stat truncated file failed");
+  check(truncated.size == 0, "truncate did not clear size");
+  check(truncated.mtime >= reopened.mtime, "truncate moved mtime backwards");
+  close(fd);
+}
+
 /**
  * 创建 fixture、执行全部断言并清理。
  *
@@ -230,6 +323,7 @@ main(void)
 {
   create_fixture();
   test_ls_options();
+  test_mtime();
   remove_fixture();
   printf("lstest: OK\n");
   exit(0);

--- a/user/ls.c
+++ b/user/ls.c
@@ -6,6 +6,7 @@
 
 #define LS_PATH_SIZE 512
 #define LS_SIZE_SIZE 32
+#define LS_TIME_SIZE 16
 
 /** 保存一次 ls 调用启用的展示选项。 */
 struct ls_options {
@@ -16,14 +17,36 @@ struct ls_options {
 };
 
 /**
- * 输出当前实现支持的命令行形式和长格式字段。
+ * 描述一种 inode 类型的 Linux 风格 mode 占位和名称样式。
+ *
+ * xv6 尚无权限、UID/GID 和 LS_COLORS；新增类型时只需扩展此表，而不必在
+ * 紧凑输出和长格式输出中分别增加条件分支。
  */
+struct entry_format {
+  short type;
+  char *mode;
+  char *prefix;
+  char *suffix;
+};
+
+static struct entry_format entry_formats[] = {
+  {T_DIR,     "drwxr-xr-x", "\033[1;34m", "\033[0m"},
+  {T_FILE,    "-rw-r--r--", "", ""},
+  {T_DEVICE,  "crw-rw-rw-", "", ""},
+  {T_SYMLINK, "lrwxrwxrwx", "", ""},
+};
+
+static struct entry_format unknown_format = {
+  0, "?---------", "", ""
+};
+
+/** 输出当前实现支持的命令行形式和长格式字段。 */
 static void
 usage(void)
 {
   printf("Usage: ls [-alh] [--help] [--] [FILE ...]\n");
   printf("  -a  show entries starting with .\n");
-  printf("  -l  long format: TYPE NLINK INODE SIZE NAME\n");
+  printf("  -l  long format: MODE NLINK OWNER GROUP SIZE MTIME NAME\n");
   printf("  -h  human-readable sizes with -l\n");
 }
 
@@ -88,8 +111,8 @@ parse_options(int argc, char **argv, struct ls_options *options, int *first_path
  * 从路径中提取用于显示的最后一个名称组件。
  *
  * @param path 输入路径，不会被修改。
- * @param name 输出缓冲区，至少需要 DIRSIZ + 2 字节；过长名称按完整路径
- *             现有上限截断到 DIRSIZ 字节。
+ * @param name 输出缓冲区，至少需要 DIRSIZ + 2 字节；过长名称按 xv6 的
+ *             DIRSIZ 上限截断。
  * @return name 缓冲区首地址。
  */
 static char*
@@ -148,26 +171,35 @@ is_hidden(char *name)
 }
 
 /**
- * 将 xv6 inode 类型映射为简短且可读的类型字符。
+ * 查找 inode 类型对应的 mode 和 ANSI 名称样式。
  *
  * @param type struct stat 中的 T_* 类型。
- * @return 目录、普通文件、设备、符号链接分别返回 d、-、c、l；未知类型返回 ?。
+ * @return 指向静态格式项的指针；未知类型返回固定后备格式。
  */
-static char
-file_type(short type)
+static struct entry_format*
+find_entry_format(short type)
 {
-  switch(type){
-  case T_DIR:
-    return 'd';
-  case T_FILE:
-    return '-';
-  case T_DEVICE:
-    return 'c';
-  case T_SYMLINK:
-    return 'l';
-  default:
-    return '?';
+  int i;
+
+  for(i = 0; i < sizeof(entry_formats) / sizeof(entry_formats[0]); i++){
+    if(entry_formats[i].type == type)
+      return &entry_formats[i];
   }
+  return &unknown_format;
+}
+
+/**
+ * 输出带类型样式的名称，并立即复位 ANSI 状态以免污染 shell 提示符。
+ *
+ * @param name 待展示名称。
+ * @param type inode 类型。
+ */
+static void
+print_styled_name(char *name, short type)
+{
+  struct entry_format *format = find_entry_format(type);
+
+  printf("%s%s%s", format->prefix, name, format->suffix);
 }
 
 /**
@@ -256,6 +288,81 @@ format_size(uint64 size, int human_readable, char *buffer)
 }
 
 /**
+ * 判断公历年份是否为闰年。
+ *
+ * @param year 完整年份。
+ * @return 闰年返回 1，否则返回 0。
+ */
+static int
+is_leap_year(uint year)
+{
+  return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+/**
+ * 返回指定公历月份的天数。
+ *
+ * @param year 完整年份。
+ * @param month 从 0 开始的月份下标。
+ * @return 该月天数。
+ */
+static int
+days_in_month(uint year, int month)
+{
+  static char month_days[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+  if(month == 1 && is_leap_year(year))
+    return 29;
+  return month_days[month];
+}
+
+/**
+ * 将 32 位 Unix 秒数格式化为固定宽度 UTC 时间。
+ *
+ * @param timestamp 自 1970-01-01 起的秒数。
+ * @param buffer 输出 `Mon DD HH:MM`，至少需要 LS_TIME_SIZE 字节。
+ */
+static void
+format_mtime(uint timestamp, char *buffer)
+{
+  static char *months[] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  };
+  uint64 days = timestamp / 86400;
+  uint seconds = timestamp % 86400;
+  uint year = 1970;
+  int month = 0;
+  int day;
+  int hour;
+  int minute;
+
+  while(days >= (uint64)(is_leap_year(year) ? 366 : 365)){
+    days -= is_leap_year(year) ? 366 : 365;
+    year++;
+  }
+  while(days >= (uint64)days_in_month(year, month)){
+    days -= days_in_month(year, month);
+    month++;
+  }
+
+  day = days + 1;
+  hour = seconds / 3600;
+  minute = (seconds % 3600) / 60;
+  memmove(buffer, months[month], 3);
+  buffer[3] = ' ';
+  buffer[4] = day >= 10 ? '0' + day / 10 : ' ';
+  buffer[5] = '0' + day % 10;
+  buffer[6] = ' ';
+  buffer[7] = '0' + hour / 10;
+  buffer[8] = '0' + hour % 10;
+  buffer[9] = ':';
+  buffer[10] = '0' + minute / 10;
+  buffer[11] = '0' + minute % 10;
+  buffer[12] = 0;
+}
+
+/**
  * 在字段内容前输出空格，使其至少达到指定宽度。
  *
  * @param text 待输出字符串。
@@ -273,34 +380,33 @@ print_right_aligned(char *text, int width)
 }
 
 /**
- * 输出一个目录项或文件参数。
+ * 按 Linux 风格字段顺序输出一个长格式条目。
  *
- * @param name 只用于展示的名称，不包含父目录前缀。
+ * 权限和 root owner/group 是 xv6 尚未实现对应模型时的稳定展示占位；mtime、
+ * nlink 和 size 来自真实 inode 元数据。
+ *
+ * @param name 只用于展示的名称。
  * @param st 通过 O_NOFOLLOW 获取的真实 xv6 元数据。
  * @param options 当前展示选项。
  */
 static void
-print_entry(char *name, struct stat *st, struct ls_options *options)
+print_long_entry(char *name, struct stat *st, struct ls_options *options)
 {
   char nlink[LS_SIZE_SIZE];
-  char inode[LS_SIZE_SIZE];
   char size[LS_SIZE_SIZE];
-
-  if(!options->long_format){
-    printf("%s\n", name);
-    return;
-  }
+  char mtime[LS_TIME_SIZE];
+  struct entry_format *format = find_entry_format(st->type);
 
   format_uint64(st->nlink, nlink);
-  format_uint64(st->ino, inode);
   format_size(st->size, options->human_readable, size);
-  printf("%c ", file_type(st->type));
+  format_mtime(st->mtime, mtime);
+  printf("%s ", format->mode);
   print_right_aligned(nlink, 3);
-  printf(" ");
-  print_right_aligned(inode, 5);
-  printf(" ");
+  printf(" root root ");
   print_right_aligned(size, 6);
-  printf(" %s\n", name);
+  printf(" %s ", mtime);
+  print_styled_name(name, st->type);
+  printf("\n");
 }
 
 /**
@@ -366,19 +472,103 @@ join_path(char *directory, char *name, char *path, int capacity)
 }
 
 /**
+ * 将一个原始 dirent 解析为可展示名称、完整路径和 stat。
+ *
+ * @param directory 父目录路径。
+ * @param entry 当前磁盘目录项。
+ * @param options 当前展示选项。
+ * @param name 输出名称缓冲区，容量至少 DIRSIZ + 1。
+ * @param full_path 输出完整路径缓冲区。
+ * @param st 输出 inode 元数据。
+ * @param report_errors 非零时输出路径过长或 stat 失败诊断。
+ * @return 1 表示可展示；0 表示空目录项或被隐藏；-1 表示处理失败。
+ */
+static int
+load_directory_entry(char *directory, struct dirent *entry,
+                     struct ls_options *options, char *name, char *full_path,
+                     struct stat *st, int report_errors)
+{
+  if(entry->inum == 0)
+    return 0;
+  copy_dirent_name(entry->name, name);
+  if(!options->show_all && is_hidden(name))
+    return 0;
+  if(join_path(directory, name, full_path, LS_PATH_SIZE) < 0){
+    if(report_errors)
+      fprintf(2, "ls: path too long: '%s/%s'\n", directory, name);
+    return -1;
+  }
+  if(stat_no_follow(full_path, st) < 0){
+    if(report_errors)
+      fprintf(2, "ls: cannot stat '%s'\n", full_path);
+    return -1;
+  }
+  return 1;
+}
+
+/**
+ * 汇总当前选项实际展示条目的 apparent size。
+ *
+ * xv6 尚未向 stat 暴露已分配块数，因此该值不是 GNU ls 的 st_blocks 汇总；
+ * 稀疏文件和目录会体现这一教学边界。
+ *
+ * @param path 目录路径。
+ * @param options 当前展示选项。
+ * @param total 输出字节总数。
+ * @return 扫描成功返回 0；打开或任一条目读取失败返回 1。
+ */
+static int
+directory_total(char *path, struct ls_options *options, uint64 *total)
+{
+  char full_path[LS_PATH_SIZE];
+  char name[DIRSIZ + 1];
+  int fd;
+  int failed;
+  int status;
+  int count;
+  struct dirent entry;
+  struct stat st;
+
+  *total = 0;
+  fd = open(path, O_RDONLY);
+  if(fd < 0){
+    fprintf(2, "ls: cannot reopen '%s' for total\n", path);
+    return 1;
+  }
+
+  failed = 0;
+  while((count = read(fd, &entry, sizeof(entry))) == sizeof(entry)){
+    status = load_directory_entry(path, &entry, options, name, full_path, &st, 0);
+    if(status > 0)
+      *total += st.size;
+    else if(status < 0)
+      failed = 1;
+  }
+  if(count != 0)
+    failed = 1;
+  close(fd);
+  return failed;
+}
+
+/**
  * 遍历并输出一个真实目录，不跟随目录中的符号链接。
  *
  * @param path 目录路径。
  * @param options 当前展示选项。
- * @return 全部条目成功时返回 0；任一条目路径过长或 stat 失败时返回 1。
+ * @return 全部条目成功时返回 0；任一条目路径过长、stat 或读取失败时返回 1。
  */
 static int
 list_directory(char *path, struct ls_options *options)
 {
   char full_path[LS_PATH_SIZE];
   char name[DIRSIZ + 1];
+  char total_text[LS_SIZE_SIZE];
   int fd;
   int failed;
+  int printed;
+  int status;
+  int count;
+  uint64 total;
   struct dirent entry;
   struct stat st;
 
@@ -389,24 +579,35 @@ list_directory(char *path, struct ls_options *options)
   }
 
   failed = 0;
-  while(read(fd, &entry, sizeof(entry)) == sizeof(entry)){
-    if(entry.inum == 0)
-      continue;
-    copy_dirent_name(entry.name, name);
-    if(!options->show_all && is_hidden(name))
-      continue;
-    if(join_path(path, name, full_path, sizeof(full_path)) < 0){
-      fprintf(2, "ls: path too long: '%s/%s'\n", path, name);
+  if(options->long_format){
+    if(directory_total(path, options, &total) != 0)
       failed = 1;
-      continue;
-    }
-    if(stat_no_follow(full_path, &st) < 0){
-      fprintf(2, "ls: cannot stat '%s'\n", full_path);
-      failed = 1;
-      continue;
-    }
-    print_entry(name, &st, options);
+    format_size(total, options->human_readable, total_text);
+    printf("total %s\n", total_text);
   }
+
+  printed = 0;
+  while((count = read(fd, &entry, sizeof(entry))) == sizeof(entry)){
+    status = load_directory_entry(path, &entry, options, name, full_path, &st, 1);
+    if(status == 0)
+      continue;
+    if(status < 0){
+      failed = 1;
+      continue;
+    }
+    if(options->long_format){
+      print_long_entry(name, &st, options);
+    } else {
+      if(printed)
+        printf(" ");
+      print_styled_name(name, st.type);
+      printed = 1;
+    }
+  }
+  if(count != 0)
+    failed = 1;
+  if(!options->long_format)
+    printf("\n");
   close(fd);
   return failed;
 }
@@ -431,7 +632,12 @@ list_path(char *path, struct ls_options *options)
   if(st.type == T_DIR)
     return list_directory(path, options);
 
-  print_entry(display_name(path, name), &st, options);
+  if(options->long_format)
+    print_long_entry(display_name(path, name), &st, options);
+  else {
+    print_styled_name(display_name(path, name), st.type);
+    printf("\n");
+  }
   return 0;
 }
 


### PR DESCRIPTION
## 目标

在 #90 的参数解析基础上，补齐更接近日常 GNU/Linux 使用习惯的 `ls` 展示，同时保留 xv6 的教学边界。

- 默认 `ls` / `ls -a` 改为单行、空格分隔。
- `ls -l` / `ls -lh` 输出 `MODE NLINK OWNER GROUP SIZE MTIME NAME`。
- 目录名称通过可扩展类型表显示为 ANSI 蓝色粗体。
- 长格式目录列表首行输出 `total`。
- 为 inode 增加可持久化的 32 位 mtime，并由 `fstat` 暴露。

Closes #109
Related to #90

## 基线与范围

- Base：`main`
- Baseline Commit：`4a6c10fb61cd5e7bf9a99b01778d019b12f37676`
- Head Commit：`f348c8fb45371adb2705d3609b7c081759477ea7`
- Branch：`concept/109-linux-style-ls-metadata`
- 仅修改 xv6；无 Obsidian 改动。

## 实现

### ls 展示

- 默认目录内容横向打印，条目之间一个空格，目录结束后统一换行。
- 长格式使用 10 字符 mode 占位：
  - 普通文件：`-rw-r--r--`
  - 目录：`drwxr-xr-x`
  - 设备：`crw-rw-rw-`
  - 符号链接：`lrwxrwxrwx`
- xv6 尚无多用户模型，owner/group 暂固定为 `root root`。
- mtime 按 UTC 格式化为 `Mon DD HH:MM`。
- 类型、mode 与 ANSI 样式集中在一张表中；本轮目录使用 `\033[1;34m...\033[0m`。
- `total` 汇总当前实际展示条目的 apparent size，并复用 `-h` 的 1024 进制格式。

### inode 修改时间

QEMU `virt` 的 Goldfish RTC 作为真实时间源。内核在启用分页前映射 RTC MMIO，并以锁保护低/高 32 位快照读取。

为保持以下不变量：

```text
sizeof(struct dinode) == 64
NDIRECT == 9
一级、二级、三级索引容量不变
```

mtime 复用按类型空闲的既有字段：

- 非设备 inode：`major/minor` 保存 mtime 高/低 16 位；
- 设备 inode：保留 `major/minor`，使用逻辑上未使用的 `size` 高 32 位；
- 内存 inode 与 `struct stat` 使用显式 `uint mtime`。

成功写入、截断和目录项写入通过统一 `writei` / `itrunc` 路径更新时间；时钟回拨时不允许已有 mtime 倒退。普通和大容量 mkfs 均为初始 inode 写入宿主机构建时间。

## 测试覆盖

扩展 `lstest` 覆盖：

- 默认与 `-a` 的单行布局；
- 目录 ANSI 蓝色粗体及复位；
- 四种类型的固定宽度 mode；
- `root root`、字节大小、人类可读大小和 UTC 时间字段；
- `total`；
- mkfs 初始 mtime；
- 写入、重新打开和截断后的 mtime 持久化；
- 原有 `--help`、未知选项、`--` 和多路径错误传播。

## 真实验证结果

### xv6 CI

Run：[xv6 CI #296](https://github.com/mental1104/xv6/actions/runs/30065224159)

- `Unit-test regression grader`：通过
- `Build xv6`：通过
- `Run selected PR QEMU regression`：通过
- `Run VM regression single-core`：通过

### Scheduler family CI

Run：[Scheduler family CI #95](https://github.com/mental1104/xv6/actions/runs/30065224106)

- PR regression：通过
- 完整 `usertests`：通过
- reparent cleanup 单核：通过
- RR、FIFO、SJF、STCF、MLFQ、CFS 单核行为测试：通过
- RR、MLFQ、CFS 三核 smoke：通过

### uthread debug

Run：[uthread debug #75](https://github.com/mental1104/xv6/actions/runs/30065224119)

- Lab7 `CPUS=3`：通过
- Lab7 `CPUS=1`：通过

当前执行环境没有本地 RISC-V 工具链和 QEMU，因此未额外执行本机交互式 `make qemu` 验收；上述结果均来自当前 Head Commit 的 GitHub Actions 真实运行。PR 保持 Draft，等待人工观察显示效果后再决定是否合并。

## 人工验收

```bash
git fetch origin
git switch concept/109-linux-style-ls-metadata
make clean
make
make qemu
```

进入 xv6 shell：

```text
ls
ls -a
ls -lh
ls -alh
xv6test --run core-ls-options
```

重点观察：

- 默认目录内容横向显示；
- `ls -lh` 首行为 `total ...`；
- 长格式包含 `-rw-r--r--` / `drwxr-xr-x`、`root root` 与 `Mon DD HH:MM`；
- 目录名称为蓝色粗体，且 shell 提示符颜色未被污染；
- `lstest: OK` 与 `XV6TEST done status=0`。

## 教学边界

- mode、owner 和 group 是稳定展示占位，不代表 xv6 已实现 Unix 权限检查、UID/GID 或 ACL。
- `total` 是 apparent size 之和；xv6 当前 `stat` 没有 `st_blocks`，因此稀疏文件与目录结果不等价于 GNU `ls` 的已分配块汇总。
- mtime 为 32 位 Unix 秒数，未实现纳秒精度、时区/locale、六个月显示规则、atime 或 ctime。
- ANSI 颜色当前不检测 TTY，也不实现 `LS_COLORS`。

## 风险与回滚

- 风险集中在磁盘 inode 编解码和 RTC MMIO；编译期 64 字节断言、设备节点专项断言、mkfs mtime 与写入持久化回归用于约束。
- 静态复核曾发现普通 `mkfs` 的 64 位追加路径被误回退，已在最终 Head Commit 恢复，未保留无关行为变化。
- 如 RTC 或编码回归影响文件系统，可整体回退本 PR；未修改 superblock、inode 数量、数据块索引数量或文件系统镜像分区布局。