### PR TITLE
[Concept Lab] 展示用户页表顶端固定映射

### DIFF
--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -39,6 +39,47 @@ enum memviz_pte_role {
   MEMVIZ_PTE_ROLE_PLIC = 15,
 };
 
+// trapframe 从页内低偏移到高偏移的稳定 ABI 槽位次序。
+enum memviz_trapframe_slot {
+  MEMVIZ_TF_KERNEL_SATP = 0,
+  MEMVIZ_TF_KERNEL_SP,
+  MEMVIZ_TF_KERNEL_TRAP,
+  MEMVIZ_TF_EPC,
+  MEMVIZ_TF_KERNEL_HARTID,
+  MEMVIZ_TF_RA,
+  MEMVIZ_TF_SP,
+  MEMVIZ_TF_GP,
+  MEMVIZ_TF_TP,
+  MEMVIZ_TF_T0,
+  MEMVIZ_TF_T1,
+  MEMVIZ_TF_T2,
+  MEMVIZ_TF_S0,
+  MEMVIZ_TF_S1,
+  MEMVIZ_TF_A0,
+  MEMVIZ_TF_A1,
+  MEMVIZ_TF_A2,
+  MEMVIZ_TF_A3,
+  MEMVIZ_TF_A4,
+  MEMVIZ_TF_A5,
+  MEMVIZ_TF_A6,
+  MEMVIZ_TF_A7,
+  MEMVIZ_TF_S2,
+  MEMVIZ_TF_S3,
+  MEMVIZ_TF_S4,
+  MEMVIZ_TF_S5,
+  MEMVIZ_TF_S6,
+  MEMVIZ_TF_S7,
+  MEMVIZ_TF_S8,
+  MEMVIZ_TF_S9,
+  MEMVIZ_TF_S10,
+  MEMVIZ_TF_S11,
+  MEMVIZ_TF_T3,
+  MEMVIZ_TF_T4,
+  MEMVIZ_TF_T5,
+  MEMVIZ_TF_T6,
+  MEMVIZ_TRAPFRAME_SLOT_COUNT,
+};
+
 // 一个字符单元覆盖连续物理页，并记录其中可立即分配的页数。
 struct memviz_cell {
   uint total_pages;
@@ -119,6 +160,19 @@ struct memviz_snapshot {
   uint64 stack_used;
   uint64 stack_free;
   uint64 dynamic_start;
+
+  // 用户页表顶端两个 supervisor-only 固定页及其页内逻辑布局。
+  uint64 maxva;
+  uint64 trapframe;
+  uint64 trapframe_pa;
+  uint64 trapframe_flags;
+  uint64 trapframe_used;
+  uint64 trampoline_pa;
+  uint64 trampoline_flags;
+  uint64 trampoline_used;
+  uint64 uservec_offset;
+  uint64 userret_offset;
+  uint64 trapframe_values[MEMVIZ_TRAPFRAME_SLOT_COUNT];
 
   uint64 kalloc_start;
   uint64 kalloc_end;

--- a/kernel/sysmemviz.c
+++ b/kernel/sysmemviz.c
@@ -7,6 +7,59 @@
 #include "memviz.h"
 #include "defs.h"
 
+extern char trampoline[];
+extern char uservec[];
+extern char userret[];
+extern char trampoline_end[];
+
+_Static_assert(sizeof(struct trapframe) ==
+               MEMVIZ_TRAPFRAME_SLOT_COUNT * sizeof(uint64),
+               "memviz trapframe slots must match struct trapframe ABI");
+
+#define ASSERT_TRAPFRAME_SLOT(member, slot) \
+  _Static_assert(__builtin_offsetof(struct trapframe, member) == \
+                 (slot) * sizeof(uint64), \
+                 "memviz trapframe slot mismatch: " #member)
+
+ASSERT_TRAPFRAME_SLOT(kernel_satp, MEMVIZ_TF_KERNEL_SATP);
+ASSERT_TRAPFRAME_SLOT(kernel_sp, MEMVIZ_TF_KERNEL_SP);
+ASSERT_TRAPFRAME_SLOT(kernel_trap, MEMVIZ_TF_KERNEL_TRAP);
+ASSERT_TRAPFRAME_SLOT(epc, MEMVIZ_TF_EPC);
+ASSERT_TRAPFRAME_SLOT(kernel_hartid, MEMVIZ_TF_KERNEL_HARTID);
+ASSERT_TRAPFRAME_SLOT(ra, MEMVIZ_TF_RA);
+ASSERT_TRAPFRAME_SLOT(sp, MEMVIZ_TF_SP);
+ASSERT_TRAPFRAME_SLOT(gp, MEMVIZ_TF_GP);
+ASSERT_TRAPFRAME_SLOT(tp, MEMVIZ_TF_TP);
+ASSERT_TRAPFRAME_SLOT(t0, MEMVIZ_TF_T0);
+ASSERT_TRAPFRAME_SLOT(t1, MEMVIZ_TF_T1);
+ASSERT_TRAPFRAME_SLOT(t2, MEMVIZ_TF_T2);
+ASSERT_TRAPFRAME_SLOT(s0, MEMVIZ_TF_S0);
+ASSERT_TRAPFRAME_SLOT(s1, MEMVIZ_TF_S1);
+ASSERT_TRAPFRAME_SLOT(a0, MEMVIZ_TF_A0);
+ASSERT_TRAPFRAME_SLOT(a1, MEMVIZ_TF_A1);
+ASSERT_TRAPFRAME_SLOT(a2, MEMVIZ_TF_A2);
+ASSERT_TRAPFRAME_SLOT(a3, MEMVIZ_TF_A3);
+ASSERT_TRAPFRAME_SLOT(a4, MEMVIZ_TF_A4);
+ASSERT_TRAPFRAME_SLOT(a5, MEMVIZ_TF_A5);
+ASSERT_TRAPFRAME_SLOT(a6, MEMVIZ_TF_A6);
+ASSERT_TRAPFRAME_SLOT(a7, MEMVIZ_TF_A7);
+ASSERT_TRAPFRAME_SLOT(s2, MEMVIZ_TF_S2);
+ASSERT_TRAPFRAME_SLOT(s3, MEMVIZ_TF_S3);
+ASSERT_TRAPFRAME_SLOT(s4, MEMVIZ_TF_S4);
+ASSERT_TRAPFRAME_SLOT(s5, MEMVIZ_TF_S5);
+ASSERT_TRAPFRAME_SLOT(s6, MEMVIZ_TF_S6);
+ASSERT_TRAPFRAME_SLOT(s7, MEMVIZ_TF_S7);
+ASSERT_TRAPFRAME_SLOT(s8, MEMVIZ_TF_S8);
+ASSERT_TRAPFRAME_SLOT(s9, MEMVIZ_TF_S9);
+ASSERT_TRAPFRAME_SLOT(s10, MEMVIZ_TF_S10);
+ASSERT_TRAPFRAME_SLOT(s11, MEMVIZ_TF_S11);
+ASSERT_TRAPFRAME_SLOT(t3, MEMVIZ_TF_T3);
+ASSERT_TRAPFRAME_SLOT(t4, MEMVIZ_TF_T4);
+ASSERT_TRAPFRAME_SLOT(t5, MEMVIZ_TF_T5);
+ASSERT_TRAPFRAME_SLOT(t6, MEMVIZ_TF_T6);
+
+#undef ASSERT_TRAPFRAME_SLOT
+
 static struct spinlock memvizsys_lock;
 static int memvizsys_lock_ready;
 static struct memviz_snapshot memvizsys_snapshot;
@@ -25,6 +78,63 @@ ensure_memvizsys_lock(void)
     initlock(&memvizsys_lock, "memvizsys");
     memvizsys_lock_ready = 1;
   }
+}
+
+/**
+ * fill_user_leaf_mapping 读取用户页表中一个固定页的叶子映射。
+ *
+ * @param pagetable 当前进程用户页表，只读访问。
+ * @param va 要查询的页对齐虚拟地址。
+ * @param pa 接收页对齐物理地址；未映射时写 0。
+ * @param flags 接收 PTE 低十位 flags；未映射时写 0。
+ */
+static void
+fill_user_leaf_mapping(pagetable_t pagetable, uint64 va,
+                       uint64 *pa, uint64 *flags)
+{
+  *pa = 0;
+  *flags = 0;
+
+  pte_t *pte = walk(pagetable, va, 0);
+  if(pte == 0 || (*pte & PTE_V) == 0)
+    return;
+  if((*pte & (PTE_R | PTE_W | PTE_X)) == 0)
+    return;
+
+  *pa = PTE2PA(*pte);
+  *flags = PTE_FLAGS(*pte);
+}
+
+/**
+ * fill_user_top_snapshot 补充用户页表顶端两个 supervisor-only 固定页。
+ *
+ * @param p 当前进程；调用期间页表、trapframe 与 trampoline 映射保持有效。
+ * @param snapshot 已由 memviz_snapshot 填写的快照，函数在原地补充顶端布局。
+ *
+ * TRAPFRAME 的 36 个连续 uint64 槽按真实 ABI 原样复制，使用户态 renderer
+ * 能同时展示页内偏移、虚拟地址、物理地址和采样值。TRAMPOLINE 的代码范围
+ * 由汇编标签计算，不依赖手写指令长度。
+ */
+static void
+fill_user_top_snapshot(struct proc *p, struct memviz_snapshot *snapshot)
+{
+  snapshot->maxva = MAXVA;
+  snapshot->trapframe = TRAPFRAME;
+  snapshot->trampoline = TRAMPOLINE;
+  snapshot->trapframe_used = sizeof(struct trapframe);
+  snapshot->uservec_offset = (uint64)uservec - (uint64)trampoline;
+  snapshot->userret_offset = (uint64)userret - (uint64)trampoline;
+  snapshot->trampoline_used = (uint64)trampoline_end - (uint64)trampoline;
+
+  memmove(snapshot->trapframe_values, p->trapframe,
+          sizeof(snapshot->trapframe_values));
+
+  fill_user_leaf_mapping(p->pagetable, TRAPFRAME,
+                         &snapshot->trapframe_pa,
+                         &snapshot->trapframe_flags);
+  fill_user_leaf_mapping(p->pagetable, TRAMPOLINE,
+                         &snapshot->trampoline_pa,
+                         &snapshot->trampoline_flags);
 }
 
 /**
@@ -54,6 +164,7 @@ sys_memsnapshot(void)
   }
 
   struct proc *p = myproc();
+  fill_user_top_snapshot(p, &memvizsys_snapshot);
   if(copyout(p->pagetable, address, (char *)&memvizsys_snapshot,
              sizeof(memvizsys_snapshot)) < 0){
     release(&memvizsys_lock);

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -5,7 +5,7 @@
         # (TRAMPOLINE) in user and kernel space so that
         # it continues to work when it switches page tables.
 	#
-	# kernel.ld causes this to be aligned
+        # kernel.ld causes this to be aligned
         # to a page boundary.
         #
 	.section trampsec
@@ -139,3 +139,7 @@ userret:
         # return to user mode and user pc.
         # usertrapret() set up sstatus and sepc.
         sret
+
+        # memviz 通过该标签计算 trampoline 页内真实代码占用，不手写指令长度。
+.globl trampoline_end
+trampoline_end:

--- a/tests/guest/memviztest.c
+++ b/tests/guest/memviztest.c
@@ -8,6 +8,7 @@
 static struct memviz_snapshot before;
 static struct memviz_snapshot after_alloc;
 static struct memviz_snapshot after_free;
+static char render_output[32768];
 
 /**
  * fail 输出失败原因并以非零状态终止测试。
@@ -19,6 +20,26 @@ fail(char *message)
 {
   printf("memviztest: FAIL: %s\n", message);
   exit(1);
+}
+
+/**
+ * text_contains 判断完整输出中是否包含指定稳定片段。
+ *
+ * @param text 以 NUL 结尾的完整输出。
+ * @param pattern 非空匹配片段。
+ * @return 找到返回 1，否则返回 0。
+ */
+static int
+text_contains(char *text, char *pattern)
+{
+  for(int i = 0; text[i] != 0; i++){
+    int j = 0;
+    while(pattern[j] != 0 && text[i + j] == pattern[j])
+      j++;
+    if(pattern[j] == 0)
+      return 1;
+  }
+  return 0;
 }
 
 /**
@@ -43,7 +64,7 @@ cell_page_count(uint64 total_pages, int cell)
 }
 
 /**
- * test_user_snapshot 验证用户栈、动态边界和物理计数的基本不变量。
+ * test_user_snapshot 验证用户栈、顶端固定页和物理计数的基本不变量。
  */
 static void
 test_user_snapshot(void)
@@ -54,12 +75,59 @@ test_user_snapshot(void)
     fail("user snapshot syscall");
   if(before.user_limit != USERMAX)
     fail("user limit mismatch");
+  if(before.maxva != MAXVA)
+    fail("MAXVA mismatch");
+  if(before.trapframe != TRAPFRAME || before.trapframe != before.user_limit)
+    fail("trapframe VA mismatch");
+  if(before.trampoline != TRAMPOLINE)
+    fail("trampoline VA mismatch");
+  if(before.trapframe + PGSIZE != before.trampoline ||
+     before.trampoline + PGSIZE != before.maxva)
+    fail("top fixed pages are not adjacent");
+
+  if(before.trapframe_pa == 0 || before.trampoline_pa == 0)
+    fail("top fixed page PA missing");
+  if((before.trapframe_pa % PGSIZE) != 0 ||
+     (before.trampoline_pa % PGSIZE) != 0)
+    fail("top fixed page PA alignment");
+  if(before.trapframe_pa == before.trampoline_pa)
+    fail("top fixed pages share PA");
+
+  uint64 trapframe_required = PTE_V | PTE_R | PTE_W;
+  if((before.trapframe_flags & trapframe_required) != trapframe_required)
+    fail("trapframe PTE permissions");
+  if(before.trapframe_flags & (PTE_X | PTE_U))
+    fail("trapframe executable or user-accessible");
+
+  uint64 trampoline_required = PTE_V | PTE_R | PTE_X;
+  if((before.trampoline_flags & trampoline_required) != trampoline_required)
+    fail("trampoline PTE permissions");
+  if(before.trampoline_flags & (PTE_W | PTE_U))
+    fail("trampoline writable or user-accessible");
+
+  if(before.trapframe_used !=
+     MEMVIZ_TRAPFRAME_SLOT_COUNT * sizeof(uint64))
+    fail("trapframe used bytes");
+  if(before.trapframe_used >= PGSIZE)
+    fail("trapframe does not fit one page");
+  if(before.uservec_offset > before.userret_offset ||
+     before.userret_offset >= before.trampoline_used ||
+     before.trampoline_used >= PGSIZE)
+    fail("trampoline symbol order");
+
   if(!before.user_stack_valid)
     fail("user stack invalid");
   if(before.stack_used + before.stack_free != PGSIZE)
     fail("user stack accounting");
   if(before.user_sp < before.stack_bottom || before.user_sp > before.stack_top)
     fail("user sp outside stack bounds");
+  if(before.trapframe_values[MEMVIZ_TF_SP] != before.user_sp)
+    fail("trapframe SP snapshot mismatch");
+  if(before.trapframe_values[MEMVIZ_TF_KERNEL_SATP] == 0 ||
+     before.trapframe_values[MEMVIZ_TF_KERNEL_SP] == 0 ||
+     before.trapframe_values[MEMVIZ_TF_KERNEL_TRAP] == 0)
+    fail("trapframe kernel entry context missing");
+
   if(before.dynamic_start != before.stack_top)
     fail("dynamic start mismatch");
   if(before.process_size < before.dynamic_start)
@@ -75,6 +143,75 @@ test_user_snapshot(void)
     fail("physical total in user view");
 
   printf("memviztest: user invariants OK\n");
+}
+
+/**
+ * test_user_render 黑盒验证增强字符图确实显示固定页、物理页和比例断裂。
+ *
+ * 子进程通过 pipe 重定向 stdout 后 exec 真实 memviz 命令；父进程只断言稳定
+ * 教学标签，不复制 renderer 的地址或布局计算。
+ */
+static void
+test_user_render(void)
+{
+  int fds[2];
+  if(pipe(fds) < 0)
+    fail("render pipe");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("render fork");
+  if(pid == 0){
+    close(fds[0]);
+    close(1);
+    if(dup(fds[1]) != 1)
+      exit(1);
+    close(fds[1]);
+
+    char *argv[] = { "memviz", "user", "--plain", 0 };
+    exec("memviz", argv);
+    exit(1);
+  }
+
+  close(fds[1]);
+  int total = 0;
+  while(total < (int)sizeof(render_output) - 1){
+    int count = read(fds[0], render_output + total,
+                     sizeof(render_output) - 1 - total);
+    if(count < 0)
+      fail("render read");
+    if(count == 0)
+      break;
+    total += count;
+  }
+  close(fds[0]);
+  render_output[total] = 0;
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("memviz user execution");
+
+  if(!text_contains(render_output, "MAXVA"))
+    fail("render MAXVA missing");
+  if(!text_contains(render_output, "TRAMPOLINE / supervisor-only RX"))
+    fail("render trampoline block missing");
+  if(!text_contains(render_output, "TRAPFRAME / supervisor-only RW"))
+    fail("render trapframe block missing");
+  if(!text_contains(render_output, "ADDRESS-SPACE BREAK"))
+    fail("render address gap break missing");
+  if(!text_contains(render_output, "not drawn to scale"))
+    fail("render scale warning missing");
+  if(!text_contains(render_output, "TRAMPOLINE PAGE DETAIL"))
+    fail("render trampoline detail missing");
+  if(!text_contains(render_output, "TRAPFRAME PAGE MEMBER ORDER"))
+    fail("render trapframe detail missing");
+  if(!text_contains(render_output, "PA page:"))
+    fail("render physical page range missing");
+  if(!text_contains(render_output, "name=kernel_satp") ||
+     !text_contains(render_output, "name=t6"))
+    fail("render trapframe member boundaries missing");
+
+  printf("memviztest: user renderer OK\n");
 }
 
 /**
@@ -330,9 +467,10 @@ test_pagetable_snapshot(void)
 static int
 run_named(char *name)
 {
-  if(strcmp(name, "user") == 0)
+  if(strcmp(name, "user") == 0){
     test_user_snapshot();
-  else if(strcmp(name, "phys") == 0)
+    test_user_render();
+  } else if(strcmp(name, "phys") == 0)
     test_physical_snapshot();
   else if(strcmp(name, "alloc") == 0)
     test_allocate_and_release();
@@ -347,12 +485,17 @@ run_named(char *name)
 
 /**
  * main 默认运行完整测试；传入一个名称时只运行对应检查。
+ *
+ * @param argc 参数数量。
+ * @param argv 可选具名检查。
+ * @return 所有断言通过时返回 0；失败路径由 fail 终止。
  */
 int
 main(int argc, char **argv)
 {
   if(argc == 1){
     test_user_snapshot();
+    test_user_render();
     test_dynamic_extent();
     test_physical_snapshot();
     test_allocate_and_release();

--- a/user/memviz.c
+++ b/user/memviz.c
@@ -1,8 +1,30 @@
 #include "kernel/types.h"
 #include "kernel/param.h"
+#include "kernel/riscv.h"
 #include "kernel/memviz.h"
 #include "user/user.h"
 #include "user/memvizlib.h"
+
+#define ANSI_RED "\033[31m"
+#define ANSI_GREEN "\033[32m"
+#define ANSI_YELLOW "\033[33m"
+#define ANSI_CYAN "\033[36m"
+#define ANSI_RESET "\033[0m"
+
+#define USER_BAR_CELLS 32
+#define USER_GAP_BREAK_MIN_PAGES 16
+
+// 使用静态缓冲，避免扩展后的快照占满固定一页用户栈。
+static struct memviz_snapshot user_snapshot;
+
+// 名称顺序与 enum memviz_trapframe_slot 以及 struct trapframe ABI 一致。
+static char *trapframe_slot_names[MEMVIZ_TRAPFRAME_SLOT_COUNT] = {
+  "kernel_satp", "kernel_sp", "kernel_trap", "epc", "kernel_hartid",
+  "ra", "sp", "gp", "tp", "t0", "t1", "t2", "s0", "s1",
+  "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
+  "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11",
+  "t3", "t4", "t5", "t6",
+};
 
 /**
  * usage 输出 memviz 支持的视图和纯文本选项。
@@ -11,6 +33,390 @@ static void
 usage(void)
 {
   fprintf(2, "usage: memviz <user|phys|kernel|pagetable|all> [filter] [--plain]\n");
+}
+
+/**
+ * string_length 返回以 NUL 结尾字符串的字节数。
+ *
+ * @param text 非空字符串。
+ * @return 不包含结尾 NUL 的字节数。
+ */
+static int
+string_length(char *text)
+{
+  int length = 0;
+  while(text[length] != 0)
+    length++;
+  return length;
+}
+
+/**
+ * print_glyph 输出一个可选 ANSI 颜色的单字节字符。
+ *
+ * @param glyph 要输出的字符。
+ * @param color ANSI 颜色前缀。
+ * @param plain 非零时禁止输出 ANSI 转义序列。
+ */
+static void
+print_glyph(char glyph, char *color, int plain)
+{
+  if(plain)
+    printf("%c", glyph);
+  else
+    printf("%s%c%s", color, glyph, ANSI_RESET);
+}
+
+/**
+ * print_line 输出带真实地址的字符图边界线。
+ *
+ * @param address 边界虚拟地址。
+ * @param mark 边界标签与横线。
+ */
+static void
+print_line(uint64 address, char *mark)
+{
+  printf("%p %s\n", address, mark);
+}
+
+/**
+ * print_box_text 输出地址空间框内的一行文本并补齐右边界。
+ *
+ * @param text 最长 34 字节的静态标签。
+ */
+static void
+print_box_text(char *text)
+{
+  int length = string_length(text);
+  printf("           | %s", text);
+  for(int i = length; i < 34; i++)
+    printf(" ");
+  printf(" |\n");
+}
+
+/**
+ * scaled_cells 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
+ *
+ * @param used 已使用字节或页数。
+ * @param total 总字节或总页数。
+ * @param cells 条形图字符宽度。
+ * @return 范围为 [0, cells] 的已使用字符数。
+ */
+static int
+scaled_cells(uint64 used, uint64 total, int cells)
+{
+  if(total == 0 || used == 0)
+    return 0;
+  uint64 result = (used * cells + total - 1) / total;
+  if(result > (uint64)cells)
+    result = cells;
+  return (int)result;
+}
+
+/**
+ * print_box_bar 输出低偏移到高偏移方向的页内用量条。
+ *
+ * @param used_cells 已使用字符数。
+ * @param used 已使用区域字符。
+ * @param free 未使用区域字符。
+ * @param plain 非零时禁用 ANSI 颜色。
+ */
+static void
+print_box_bar(int used_cells, char used, char free, int plain)
+{
+  printf("           | [");
+  for(int i = 0; i < USER_BAR_CELLS; i++){
+    if(i < used_cells)
+      print_glyph(used, ANSI_RED, plain);
+    else
+      print_glyph(free, ANSI_GREEN, plain);
+  }
+  printf("] |\n");
+}
+
+/**
+ * print_box_reverse_bar 输出高地址侧已使用的向下增长栈用量条。
+ *
+ * @param used_cells 已使用字符数。
+ * @param plain 非零时禁用 ANSI 颜色。
+ */
+static void
+print_box_reverse_bar(int used_cells, int plain)
+{
+  printf("           | [");
+  for(int i = 0; i < USER_BAR_CELLS; i++){
+    if(i < USER_BAR_CELLS - used_cells)
+      print_glyph('.', ANSI_GREEN, plain);
+    else
+      print_glyph('#', ANSI_RED, plain);
+  }
+  printf("] |\n");
+}
+
+/**
+ * print_pte_flags 输出教学相关的 RISC-V PTE 权限位。
+ *
+ * @param flags PTE 低十位 flags。
+ */
+static void
+print_pte_flags(uint64 flags)
+{
+  printf("%c%c%c%c%c%c",
+         (flags & PTE_V) ? 'V' : '-',
+         (flags & PTE_R) ? 'R' : '-',
+         (flags & PTE_W) ? 'W' : '-',
+         (flags & PTE_X) ? 'X' : '-',
+         (flags & PTE_U) ? 'U' : '-',
+         (flags & PTE_COW) ? 'C' : '-');
+}
+
+/**
+ * dynamic_pages 计算动态起点到 p->sz 已覆盖的页数。
+ *
+ * @param state 当前内存快照。
+ * @return 动态区域向上取整后的页数。
+ */
+static uint64
+dynamic_pages(struct memviz_snapshot *state)
+{
+  if(state->process_size <= state->dynamic_start)
+    return 0;
+  return (state->process_size - state->dynamic_start + PGSIZE - 1) / PGSIZE;
+}
+
+/**
+ * remaining_pages 计算 p->sz 到 USERMAX 之间仍未使用的整页数。
+ *
+ * @param state 当前内存快照。
+ * @return 普通用户 VA 的剩余整页数。
+ */
+static uint64
+remaining_pages(struct memviz_snapshot *state)
+{
+  if(state->user_limit <= state->process_size)
+    return 0;
+  return (state->user_limit - state->process_size) / PGSIZE;
+}
+
+/**
+ * print_user_gap 用明显的断裂线表现 p->sz 到 USERMAX 的巨大地址跨度。
+ *
+ * @param state 当前内存快照。
+ *
+ * 小于阈值时保留紧凑布局；超过阈值时增加纵向留白、断裂符号和
+ * not-drawn-to-scale 提示，避免字符图暗示上下边界物理相邻。
+ */
+static void
+print_user_gap(struct memviz_snapshot *state)
+{
+  uint64 pages = remaining_pages(state);
+  uint64 bytes = state->user_limit > state->process_size ?
+                 state->user_limit - state->process_size : 0;
+
+  print_box_text("AVAILABLE ORDINARY USER VA");
+  printf("           | remaining=%d pages bytes=%p\n", (int)pages, bytes);
+  print_box_text("currently unmapped above p->sz");
+
+  if(pages >= USER_GAP_BREAK_MIN_PAGES){
+    printf("           |                                    |\n");
+    printf("           :                                    :\n");
+    printf("           +====== ADDRESS-SPACE BREAK =========+\n");
+    printf("           :        not drawn to scale           :\n");
+    printf("           :                                    :\n");
+    printf("           |                                    |\n");
+  }
+}
+
+/**
+ * print_trampoline_details 展示 trampoline 页的 VA、PA、权限和代码顺序。
+ *
+ * @param state 当前内存快照。
+ */
+static void
+print_trampoline_details(struct memviz_snapshot *state)
+{
+  printf("\n=== TRAMPOLINE PAGE DETAIL ===\n");
+  printf("  VA page: %p - %p\n", state->trampoline, state->maxva);
+  printf("  PA page: %p - %p\n", state->trampoline_pa,
+         state->trampoline_pa + PGSIZE);
+  printf("  PTE flags: ");
+  print_pte_flags(state->trampoline_flags);
+  printf("  user-access=no\n");
+  printf("  code used=%d B free=%d B\n",
+         (int)state->trampoline_used,
+         (int)(PGSIZE - state->trampoline_used));
+  printf("  logical order, low offset -> high offset:\n");
+
+  if(state->uservec_offset > 0){
+    printf("    [0, %d) alignment/prefix  PA=%p-%p\n",
+           (int)state->uservec_offset,
+           state->trampoline_pa,
+           state->trampoline_pa + state->uservec_offset);
+  }
+  printf("    [%d, %d) uservec  VA=%p PA=%p\n",
+         (int)state->uservec_offset, (int)state->userret_offset,
+         state->trampoline + state->uservec_offset,
+         state->trampoline_pa + state->uservec_offset);
+  printf("    [%d, %d) userret  VA=%p PA=%p\n",
+         (int)state->userret_offset, (int)state->trampoline_used,
+         state->trampoline + state->userret_offset,
+         state->trampoline_pa + state->userret_offset);
+  printf("    [%d, %d) unused by trampoline code  PA=%p-%p\n",
+         (int)state->trampoline_used, PGSIZE,
+         state->trampoline_pa + state->trampoline_used,
+         state->trampoline_pa + PGSIZE);
+}
+
+/**
+ * print_trapframe_details 按真实 ABI 顺序展开 trapframe 页内全部成员。
+ *
+ * @param state 当前内存快照。
+ *
+ * 每个槽位同时展示页内 offset、对应 VA、对应 PA 和 memsnapshot 系统调用
+ * 入口时保存的值；该值不是任意时刻的实时寄存器。
+ */
+static void
+print_trapframe_details(struct memviz_snapshot *state)
+{
+  printf("\n=== TRAPFRAME PAGE MEMBER ORDER ===\n");
+  printf("  VA page: %p - %p\n", state->trapframe, state->trampoline);
+  printf("  PA page: %p - %p\n", state->trapframe_pa,
+         state->trapframe_pa + PGSIZE);
+  printf("  PTE flags: ");
+  print_pte_flags(state->trapframe_flags);
+  printf("  user-access=no\n");
+  printf("  struct used=%d B free-tail=%d B\n",
+         (int)state->trapframe_used,
+         (int)(PGSIZE - state->trapframe_used));
+  printf("  values are captured inside memsnapshot before syscall a0 is replaced\n");
+
+  for(int slot = 0; slot < MEMVIZ_TRAPFRAME_SLOT_COUNT; slot++){
+    if(slot == MEMVIZ_TF_KERNEL_SATP)
+      printf("  -- kernel entry/return context --\n");
+    if(slot == MEMVIZ_TF_RA)
+      printf("  -- saved user registers in ABI storage order --\n");
+
+    uint64 offset = (uint64)slot * sizeof(uint64);
+    printf("  [%d] offset=%d name=%s VA=%p PA=%p value=%p\n",
+           slot, (int)offset, trapframe_slot_names[slot],
+           state->trapframe + offset,
+           state->trapframe_pa + offset,
+           state->trapframe_values[slot]);
+  }
+
+  printf("  unused tail: offset=%d..%d VA=%p PA=%p bytes=%d\n",
+         (int)state->trapframe_used, PGSIZE,
+         state->trapframe + state->trapframe_used,
+         state->trapframe_pa + state->trapframe_used,
+         (int)(PGSIZE - state->trapframe_used));
+}
+
+/**
+ * print_user_view 输出包含顶端固定页、巨大 VA 空洞和低地址进程区域的完整视图。
+ *
+ * @param plain 非零时禁用 ANSI 颜色。
+ * @return 采样成功返回 0，系统调用失败返回 -1。
+ */
+static int
+print_user_view(int plain)
+{
+  if(memsnapshot(MEMVIZ_VIEW_USER, &user_snapshot) < 0)
+    return -1;
+
+  uint64 used_pages = dynamic_pages(&user_snapshot);
+  int dynamic_cells = scaled_cells(used_pages,
+                                   remaining_pages(&user_snapshot) + used_pages,
+                                   USER_BAR_CELLS);
+  int trampoline_cells = scaled_cells(user_snapshot.trampoline_used,
+                                      PGSIZE, USER_BAR_CELLS);
+  int trapframe_cells = scaled_cells(user_snapshot.trapframe_used,
+                                     PGSIZE, USER_BAR_CELLS);
+
+  printf("\n%s=== CURRENT PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
+         plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  printf("\n       HIGH ADDRESS\n");
+  print_line(user_snapshot.maxva, "+--------------- MAXVA ---------------+");
+  print_box_text("TRAMPOLINE / supervisor-only RX");
+  print_box_bar(trampoline_cells, '#', '.', plain);
+  print_box_text("one physical page; no PTE_U");
+  print_line(user_snapshot.trampoline, "+------------ TRAMPOLINE -------------+");
+  print_box_text("TRAPFRAME / supervisor-only RW");
+  print_box_bar(trapframe_cells, '#', '.', plain);
+  print_box_text("one physical page; no PTE_U");
+  print_line(user_snapshot.trapframe, "+------ USERMAX / TRAPFRAME -----------+");
+
+  print_user_gap(&user_snapshot);
+  print_line(user_snapshot.process_size, "+--------------- p->sz ----------------+");
+  print_box_text("DYNAMIC EXTENT");
+  print_box_bar(dynamic_cells, '#', '.', plain);
+  printf("           | pages=%d\n", (int)used_pages);
+  print_line(user_snapshot.dynamic_start, "+----------- dynamic start ------------+");
+
+  if(user_snapshot.user_stack_valid){
+    uint64 stack_total = user_snapshot.stack_top - user_snapshot.stack_bottom;
+    int stack_cells = scaled_cells(user_snapshot.stack_used,
+                                   stack_total, USER_BAR_CELLS);
+    print_box_text("USER STACK / grows downward");
+    print_box_reverse_bar(stack_cells, plain);
+    printf("           | used=%d B free=%d B\n",
+           (int)user_snapshot.stack_used, (int)user_snapshot.stack_free);
+  } else {
+    print_box_text("USER STACK: invalid SP");
+  }
+
+  print_line(user_snapshot.stack_bottom, "+--------------------------------------+");
+  print_box_text("GUARD PAGE / mapped without PTE_U");
+  print_box_bar(USER_BAR_CELLS, 'X', 'X', plain);
+  print_line(user_snapshot.stack_guard_start, "+--------------------------------------+");
+  print_box_text("ELF IMAGE");
+  print_box_bar(USER_BAR_CELLS, '#', '#', plain);
+  print_line(user_snapshot.image_start, "+--------------------------------------+");
+  printf("       LOW ADDRESS\n");
+
+  printf("\nsummary:\n");
+  printf("  ordinary user limit: %p (USERMAX/TRAPFRAME)\n",
+         user_snapshot.user_limit);
+  printf("  architectural low-half limit: %p (MAXVA)\n", user_snapshot.maxva);
+  printf("  trampoline: VA=%p PA=%p used=%d/%d flags=",
+         user_snapshot.trampoline, user_snapshot.trampoline_pa,
+         (int)user_snapshot.trampoline_used, PGSIZE);
+  print_pte_flags(user_snapshot.trampoline_flags);
+  printf("\n");
+  printf("  trapframe: VA=%p PA=%p used=%d/%d flags=",
+         user_snapshot.trapframe, user_snapshot.trapframe_pa,
+         (int)user_snapshot.trapframe_used, PGSIZE);
+  print_pte_flags(user_snapshot.trapframe_flags);
+  printf("\n");
+  printf("  p->sz to USERMAX: pages=%d bytes=%p\n",
+         (int)remaining_pages(&user_snapshot),
+         user_snapshot.user_limit - user_snapshot.process_size);
+  printf("  stack: used=%d free=%d\n",
+         (int)user_snapshot.stack_used, (int)user_snapshot.stack_free);
+  printf("  dynamic pages: %d\n", (int)used_pages);
+  printf("  physical pages: free=%d used=%d total=%d\n",
+         (int)user_snapshot.free_pages, (int)user_snapshot.used_pages,
+         (int)user_snapshot.total_pages);
+
+  print_trampoline_details(&user_snapshot);
+  print_trapframe_details(&user_snapshot);
+  return 0;
+}
+
+/**
+ * print_all_views 依次输出增强用户视图和其余已有视图。
+ *
+ * @param plain 非零时禁用 ANSI 颜色。
+ * @return 全部视图成功返回 0；任一采样失败返回 -1。
+ */
+static int
+print_all_views(int plain)
+{
+  if(print_user_view(plain) < 0)
+    return -1;
+  if(memviz_print(MEMVIZ_VIEW_PHYS, plain) < 0)
+    return -1;
+  if(memviz_print(MEMVIZ_VIEW_KERNEL, plain) < 0)
+    return -1;
+  return memviz_print(MEMVIZ_VIEW_PAGETABLE, plain);
 }
 
 /**
@@ -48,7 +454,7 @@ main(int argc, char **argv)
   }
 
   if(strcmp(argv[1], "user") == 0)
-    result = memviz_print(MEMVIZ_VIEW_USER, plain);
+    result = print_user_view(plain);
   else if(strcmp(argv[1], "phys") == 0)
     result = memviz_print(MEMVIZ_VIEW_PHYS, plain);
   else if(strcmp(argv[1], "kernel") == 0)
@@ -56,7 +462,7 @@ main(int argc, char **argv)
   else if(strcmp(argv[1], "pagetable") == 0)
     result = memviz_print_filtered(MEMVIZ_VIEW_PAGETABLE, plain, filter);
   else if(strcmp(argv[1], "all") == 0)
-    result = memviz_print_all(plain);
+    result = print_all_views(plain);
   else {
     usage();
     exit(1);


### PR DESCRIPTION
## 中心认知与范围

普通用户可分配地址空间在 `USERMAX` 结束，但当前进程的用户页表在 `[USERMAX, MAXVA)` 仍固定映射两个 supervisor-only 页面：

- `TRAPFRAME`：RW、无 `PTE_U`，保存内核返回上下文和完整用户寄存器现场；
- `TRAMPOLINE`：RX、无 `PTE_U`，保存 `uservec` / `userret` 跳板代码。

本 PR 只增强 `memviz` 观察能力和回归测试，不改变页表、trap 或内存分配语义。

Closes #113

## 基线

- 开工基线：`4a6c10fb61cd5e7bf9a99b01778d019b12f37676`
- 同步后的最新 `main`：`f89cc05ee972cd4130f4ffc4f6a2b697a70721f3`
- 分支状态：相对 `main` ahead 6 / behind 0

## 关键改动

- 在 `memviz_snapshot` 中记录 `MAXVA`、两个固定页的 VA/PA/PTE flags、页内使用量和关键汇编符号偏移。
- 逐槽复制 `struct trapframe` 的 36 个 `uint64` 成员，并以 `_Static_assert` 固定每个成员的 ABI offset。
- 使用真实 `trampoline_end` 汇编标签计算 trampoline 代码占用，避免手写指令长度。
- `memviz user` 从 `MAXVA` 向低地址展示：
  - TRAMPOLINE 页及其物理页；
  - TRAPFRAME 页及其物理页；
  - `uservec`、`userret`、未使用尾部的页内顺序；
  - trapframe 每个成员的 slot、offset、VA、PA 和采样值；
  - `p->sz` 到 `USERMAX` 的页数/字节数。
- 当普通用户 VA 空洞超过阈值时增加 `ADDRESS-SPACE BREAK`、纵向留白和 `not drawn to scale`，避免字符图比例误导。
- 扩展 `memviztest`：既验证快照不变量，也通过 `fork + pipe + exec` 黑盒检查真实字符图。

## 关键文件

- `kernel/memviz.h`
- `kernel/sysmemviz.c`
- `kernel/trampoline.S`
- `user/memviz.c`
- `tests/guest/memviztest.c`

## 验证结果

### 本地静态验证

- `clang --target=riscv64` 汇编 `trampoline.S`：通过。
  - `uservec=0x0`
  - `userret=0x90`
  - `trampoline_end=0x112`
- freestanding mock headers 下执行 `clang -Wall -Werror -fsyntax-only`：
  - `kernel/sysmemviz.c`：通过
  - `user/memviz.c`：通过
  - `tests/guest/memviztest.c`：通过
- `sizeof(struct memviz_snapshot)=14024` 字节，继续使用静态 BSS 缓冲，不进入一页内核栈或用户栈。

### GitHub Actions：xv6 CI #305

- regression grader/unit tests：通过
- `make clean && make -j2`：通过
- 选中的 QEMU `lab-vm`，`CPUS=3`：通过
- QEMU `lab-vm`，`CPUS=1`：通过

### 其他 PR checks

- uthread debug #84：通过
- Scheduler family CI #104：通过
  - PR regression：通过
  - complete usertests：通过
  - reparent cleanup，`CPUS=1`：通过
  - RR/FIFO/SJF/STCF/MLFQ/CFS 单核行为与多核 smoke：通过

## 教学边界

- trapframe 值是 `memsnapshot` 系统调用入口保存的现场，不是任意时刻的实时寄存器。
- VA 与 PA 同时显示，但字符图明确不按地址跨度比例绘制。
- `TRAPFRAME` 与 `TRAMPOLINE` 存在于用户页表中，不代表用户态拥有访问权限。
- 本 PR 不增加新的内核机制，不改变 `TRAPFRAME`/`TRAMPOLINE` 映射权限和生命周期。