### PR TITLE
chore: 同步最新 main 到目录布局分支

### DIFF
--- a/.github/workflows/scheduler-ci.yml
+++ b/.github/workflows/scheduler-ci.yml
@@ -108,8 +108,13 @@ jobs:
           make clean
           make -j2 SCHED_POLICY=rr
 
-      - name: Run pull-request regression
-        run: make test-integration CPUS=3 SCHED_POLICY=rr
+      # 将交互式 Shell 与通用 suite 分成独立步骤，使提示符、行编辑或作业控制失败
+      # 能直接定位，同时仍复用同一份已构建的 kernel 与 fs.img。
+      - name: Run shell interaction regression
+        run: python3 tests/shell_history_interactive.py --cpus 3
+
+      - name: Run pull-request regression suites
+        run: python3 tests/run.py --suite pr --cpus 3
 
       - name: Run complete usertests
         run: python3 tests/run_usertests.py --cpus 3
@@ -124,3 +129,11 @@ jobs:
             --cpus 1 \
             --case reparent2 \
             --case reparent
+
+      - name: Upload regression logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scheduler-regression-${{ github.run_id }}
+          path: test-results/
+          if-no-files-found: ignore

--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -39,6 +39,47 @@ enum memviz_pte_role {
   MEMVIZ_PTE_ROLE_PLIC = 15,
 };
 
+// trapframe 从页内低偏移到高偏移的稳定 ABI 槽位次序。
+enum memviz_trapframe_slot {
+  MEMVIZ_TF_KERNEL_SATP = 0,
+  MEMVIZ_TF_KERNEL_SP,
+  MEMVIZ_TF_KERNEL_TRAP,
+  MEMVIZ_TF_EPC,
+  MEMVIZ_TF_KERNEL_HARTID,
+  MEMVIZ_TF_RA,
+  MEMVIZ_TF_SP,
+  MEMVIZ_TF_GP,
+  MEMVIZ_TF_TP,
+  MEMVIZ_TF_T0,
+  MEMVIZ_TF_T1,
+  MEMVIZ_TF_T2,
+  MEMVIZ_TF_S0,
+  MEMVIZ_TF_S1,
+  MEMVIZ_TF_A0,
+  MEMVIZ_TF_A1,
+  MEMVIZ_TF_A2,
+  MEMVIZ_TF_A3,
+  MEMVIZ_TF_A4,
+  MEMVIZ_TF_A5,
+  MEMVIZ_TF_A6,
+  MEMVIZ_TF_A7,
+  MEMVIZ_TF_S2,
+  MEMVIZ_TF_S3,
+  MEMVIZ_TF_S4,
+  MEMVIZ_TF_S5,
+  MEMVIZ_TF_S6,
+  MEMVIZ_TF_S7,
+  MEMVIZ_TF_S8,
+  MEMVIZ_TF_S9,
+  MEMVIZ_TF_S10,
+  MEMVIZ_TF_S11,
+  MEMVIZ_TF_T3,
+  MEMVIZ_TF_T4,
+  MEMVIZ_TF_T5,
+  MEMVIZ_TF_T6,
+  MEMVIZ_TRAPFRAME_SLOT_COUNT,
+};
+
 // 一个字符单元覆盖连续物理页，并记录其中可立即分配的页数。
 struct memviz_cell {
   uint total_pages;
@@ -119,6 +160,19 @@ struct memviz_snapshot {
   uint64 stack_used;
   uint64 stack_free;
   uint64 dynamic_start;
+
+  // 用户页表顶端两个 supervisor-only 固定页及其页内逻辑布局。
+  uint64 maxva;
+  uint64 trapframe;
+  uint64 trapframe_pa;
+  uint64 trapframe_flags;
+  uint64 trapframe_used;
+  uint64 trampoline_pa;
+  uint64 trampoline_flags;
+  uint64 trampoline_used;
+  uint64 uservec_offset;
+  uint64 userret_offset;
+  uint64 trapframe_values[MEMVIZ_TRAPFRAME_SLOT_COUNT];
 
   uint64 kalloc_start;
   uint64 kalloc_end;

--- a/kernel/sysmemviz.c
+++ b/kernel/sysmemviz.c
@@ -7,6 +7,59 @@
 #include "memviz.h"
 #include "defs.h"
 
+extern char trampoline[];
+extern char uservec[];
+extern char userret[];
+extern char trampoline_end[];
+
+_Static_assert(sizeof(struct trapframe) ==
+               MEMVIZ_TRAPFRAME_SLOT_COUNT * sizeof(uint64),
+               "memviz trapframe slots must match struct trapframe ABI");
+
+#define ASSERT_TRAPFRAME_SLOT(member, slot) \
+  _Static_assert(__builtin_offsetof(struct trapframe, member) == \
+                 (slot) * sizeof(uint64), \
+                 "memviz trapframe slot mismatch: " #member)
+
+ASSERT_TRAPFRAME_SLOT(kernel_satp, MEMVIZ_TF_KERNEL_SATP);
+ASSERT_TRAPFRAME_SLOT(kernel_sp, MEMVIZ_TF_KERNEL_SP);
+ASSERT_TRAPFRAME_SLOT(kernel_trap, MEMVIZ_TF_KERNEL_TRAP);
+ASSERT_TRAPFRAME_SLOT(epc, MEMVIZ_TF_EPC);
+ASSERT_TRAPFRAME_SLOT(kernel_hartid, MEMVIZ_TF_KERNEL_HARTID);
+ASSERT_TRAPFRAME_SLOT(ra, MEMVIZ_TF_RA);
+ASSERT_TRAPFRAME_SLOT(sp, MEMVIZ_TF_SP);
+ASSERT_TRAPFRAME_SLOT(gp, MEMVIZ_TF_GP);
+ASSERT_TRAPFRAME_SLOT(tp, MEMVIZ_TF_TP);
+ASSERT_TRAPFRAME_SLOT(t0, MEMVIZ_TF_T0);
+ASSERT_TRAPFRAME_SLOT(t1, MEMVIZ_TF_T1);
+ASSERT_TRAPFRAME_SLOT(t2, MEMVIZ_TF_T2);
+ASSERT_TRAPFRAME_SLOT(s0, MEMVIZ_TF_S0);
+ASSERT_TRAPFRAME_SLOT(s1, MEMVIZ_TF_S1);
+ASSERT_TRAPFRAME_SLOT(a0, MEMVIZ_TF_A0);
+ASSERT_TRAPFRAME_SLOT(a1, MEMVIZ_TF_A1);
+ASSERT_TRAPFRAME_SLOT(a2, MEMVIZ_TF_A2);
+ASSERT_TRAPFRAME_SLOT(a3, MEMVIZ_TF_A3);
+ASSERT_TRAPFRAME_SLOT(a4, MEMVIZ_TF_A4);
+ASSERT_TRAPFRAME_SLOT(a5, MEMVIZ_TF_A5);
+ASSERT_TRAPFRAME_SLOT(a6, MEMVIZ_TF_A6);
+ASSERT_TRAPFRAME_SLOT(a7, MEMVIZ_TF_A7);
+ASSERT_TRAPFRAME_SLOT(s2, MEMVIZ_TF_S2);
+ASSERT_TRAPFRAME_SLOT(s3, MEMVIZ_TF_S3);
+ASSERT_TRAPFRAME_SLOT(s4, MEMVIZ_TF_S4);
+ASSERT_TRAPFRAME_SLOT(s5, MEMVIZ_TF_S5);
+ASSERT_TRAPFRAME_SLOT(s6, MEMVIZ_TF_S6);
+ASSERT_TRAPFRAME_SLOT(s7, MEMVIZ_TF_S7);
+ASSERT_TRAPFRAME_SLOT(s8, MEMVIZ_TF_S8);
+ASSERT_TRAPFRAME_SLOT(s9, MEMVIZ_TF_S9);
+ASSERT_TRAPFRAME_SLOT(s10, MEMVIZ_TF_S10);
+ASSERT_TRAPFRAME_SLOT(s11, MEMVIZ_TF_S11);
+ASSERT_TRAPFRAME_SLOT(t3, MEMVIZ_TF_T3);
+ASSERT_TRAPFRAME_SLOT(t4, MEMVIZ_TF_T4);
+ASSERT_TRAPFRAME_SLOT(t5, MEMVIZ_TF_T5);
+ASSERT_TRAPFRAME_SLOT(t6, MEMVIZ_TF_T6);
+
+#undef ASSERT_TRAPFRAME_SLOT
+
 static struct spinlock memvizsys_lock;
 static int memvizsys_lock_ready;
 static struct memviz_snapshot memvizsys_snapshot;
@@ -25,6 +78,63 @@ ensure_memvizsys_lock(void)
     initlock(&memvizsys_lock, "memvizsys");
     memvizsys_lock_ready = 1;
   }
+}
+
+/**
+ * fill_user_leaf_mapping 读取用户页表中一个固定页的叶子映射。
+ *
+ * @param pagetable 当前进程用户页表，只读访问。
+ * @param va 要查询的页对齐虚拟地址。
+ * @param pa 接收页对齐物理地址；未映射时写 0。
+ * @param flags 接收 PTE 低十位 flags；未映射时写 0。
+ */
+static void
+fill_user_leaf_mapping(pagetable_t pagetable, uint64 va,
+                       uint64 *pa, uint64 *flags)
+{
+  *pa = 0;
+  *flags = 0;
+
+  pte_t *pte = walk(pagetable, va, 0);
+  if(pte == 0 || (*pte & PTE_V) == 0)
+    return;
+  if((*pte & (PTE_R | PTE_W | PTE_X)) == 0)
+    return;
+
+  *pa = PTE2PA(*pte);
+  *flags = PTE_FLAGS(*pte);
+}
+
+/**
+ * fill_user_top_snapshot 补充用户页表顶端两个 supervisor-only 固定页。
+ *
+ * @param p 当前进程；调用期间页表、trapframe 与 trampoline 映射保持有效。
+ * @param snapshot 已由 memviz_snapshot 填写的快照，函数在原地补充顶端布局。
+ *
+ * TRAPFRAME 的 36 个连续 uint64 槽按真实 ABI 原样复制，使用户态 renderer
+ * 能同时展示页内偏移、虚拟地址、物理地址和采样值。TRAMPOLINE 的代码范围
+ * 由汇编标签计算，不依赖手写指令长度。
+ */
+static void
+fill_user_top_snapshot(struct proc *p, struct memviz_snapshot *snapshot)
+{
+  snapshot->maxva = MAXVA;
+  snapshot->trapframe = TRAPFRAME;
+  snapshot->trampoline = TRAMPOLINE;
+  snapshot->trapframe_used = sizeof(struct trapframe);
+  snapshot->uservec_offset = (uint64)uservec - (uint64)trampoline;
+  snapshot->userret_offset = (uint64)userret - (uint64)trampoline;
+  snapshot->trampoline_used = (uint64)trampoline_end - (uint64)trampoline;
+
+  memmove(snapshot->trapframe_values, p->trapframe,
+          sizeof(snapshot->trapframe_values));
+
+  fill_user_leaf_mapping(p->pagetable, TRAPFRAME,
+                         &snapshot->trapframe_pa,
+                         &snapshot->trapframe_flags);
+  fill_user_leaf_mapping(p->pagetable, TRAMPOLINE,
+                         &snapshot->trampoline_pa,
+                         &snapshot->trampoline_flags);
 }
 
 /**
@@ -54,6 +164,7 @@ sys_memsnapshot(void)
   }
 
   struct proc *p = myproc();
+  fill_user_top_snapshot(p, &memvizsys_snapshot);
   if(copyout(p->pagetable, address, (char *)&memvizsys_snapshot,
              sizeof(memvizsys_snapshot)) < 0){
     release(&memvizsys_lock);

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -5,7 +5,7 @@
         # (TRAMPOLINE) in user and kernel space so that
         # it continues to work when it switches page tables.
 	#
-	# kernel.ld causes this to be aligned
+        # kernel.ld causes this to be aligned
         # to a page boundary.
         #
 	.section trampsec
@@ -139,3 +139,7 @@ userret:
         # return to user mode and user pc.
         # usertrapret() set up sstatus and sepc.
         sret
+
+        # memviz 通过该标签计算 trampoline 页内真实代码占用，不手写指令长度。
+.globl trampoline_end
+trampoline_end:

--- a/tests/guest/memviztest.c
+++ b/tests/guest/memviztest.c
@@ -8,6 +8,7 @@
 static struct memviz_snapshot before;
 static struct memviz_snapshot after_alloc;
 static struct memviz_snapshot after_free;
+static char render_output[32768];
 
 /**
  * fail 输出失败原因并以非零状态终止测试。
@@ -19,6 +20,26 @@ fail(char *message)
 {
   printf("memviztest: FAIL: %s\n", message);
   exit(1);
+}
+
+/**
+ * text_contains 判断完整输出中是否包含指定稳定片段。
+ *
+ * @param text 以 NUL 结尾的完整输出。
+ * @param pattern 非空匹配片段。
+ * @return 找到返回 1，否则返回 0。
+ */
+static int
+text_contains(char *text, char *pattern)
+{
+  for(int i = 0; text[i] != 0; i++){
+    int j = 0;
+    while(pattern[j] != 0 && text[i + j] == pattern[j])
+      j++;
+    if(pattern[j] == 0)
+      return 1;
+  }
+  return 0;
 }
 
 /**
@@ -43,7 +64,7 @@ cell_page_count(uint64 total_pages, int cell)
 }
 
 /**
- * test_user_snapshot 验证用户栈、动态边界和物理计数的基本不变量。
+ * test_user_snapshot 验证用户栈、顶端固定页和物理计数的基本不变量。
  */
 static void
 test_user_snapshot(void)
@@ -54,12 +75,59 @@ test_user_snapshot(void)
     fail("user snapshot syscall");
   if(before.user_limit != USERMAX)
     fail("user limit mismatch");
+  if(before.maxva != MAXVA)
+    fail("MAXVA mismatch");
+  if(before.trapframe != TRAPFRAME || before.trapframe != before.user_limit)
+    fail("trapframe VA mismatch");
+  if(before.trampoline != TRAMPOLINE)
+    fail("trampoline VA mismatch");
+  if(before.trapframe + PGSIZE != before.trampoline ||
+     before.trampoline + PGSIZE != before.maxva)
+    fail("top fixed pages are not adjacent");
+
+  if(before.trapframe_pa == 0 || before.trampoline_pa == 0)
+    fail("top fixed page PA missing");
+  if((before.trapframe_pa % PGSIZE) != 0 ||
+     (before.trampoline_pa % PGSIZE) != 0)
+    fail("top fixed page PA alignment");
+  if(before.trapframe_pa == before.trampoline_pa)
+    fail("top fixed pages share PA");
+
+  uint64 trapframe_required = PTE_V | PTE_R | PTE_W;
+  if((before.trapframe_flags & trapframe_required) != trapframe_required)
+    fail("trapframe PTE permissions");
+  if(before.trapframe_flags & (PTE_X | PTE_U))
+    fail("trapframe executable or user-accessible");
+
+  uint64 trampoline_required = PTE_V | PTE_R | PTE_X;
+  if((before.trampoline_flags & trampoline_required) != trampoline_required)
+    fail("trampoline PTE permissions");
+  if(before.trampoline_flags & (PTE_W | PTE_U))
+    fail("trampoline writable or user-accessible");
+
+  if(before.trapframe_used !=
+     MEMVIZ_TRAPFRAME_SLOT_COUNT * sizeof(uint64))
+    fail("trapframe used bytes");
+  if(before.trapframe_used >= PGSIZE)
+    fail("trapframe does not fit one page");
+  if(before.uservec_offset > before.userret_offset ||
+     before.userret_offset >= before.trampoline_used ||
+     before.trampoline_used >= PGSIZE)
+    fail("trampoline symbol order");
+
   if(!before.user_stack_valid)
     fail("user stack invalid");
   if(before.stack_used + before.stack_free != PGSIZE)
     fail("user stack accounting");
   if(before.user_sp < before.stack_bottom || before.user_sp > before.stack_top)
     fail("user sp outside stack bounds");
+  if(before.trapframe_values[MEMVIZ_TF_SP] != before.user_sp)
+    fail("trapframe SP snapshot mismatch");
+  if(before.trapframe_values[MEMVIZ_TF_KERNEL_SATP] == 0 ||
+     before.trapframe_values[MEMVIZ_TF_KERNEL_SP] == 0 ||
+     before.trapframe_values[MEMVIZ_TF_KERNEL_TRAP] == 0)
+    fail("trapframe kernel entry context missing");
+
   if(before.dynamic_start != before.stack_top)
     fail("dynamic start mismatch");
   if(before.process_size < before.dynamic_start)
@@ -75,6 +143,75 @@ test_user_snapshot(void)
     fail("physical total in user view");
 
   printf("memviztest: user invariants OK\n");
+}
+
+/**
+ * test_user_render 黑盒验证增强字符图确实显示固定页、物理页和比例断裂。
+ *
+ * 子进程通过 pipe 重定向 stdout 后 exec 真实 memviz 命令；父进程只断言稳定
+ * 教学标签，不复制 renderer 的地址或布局计算。
+ */
+static void
+test_user_render(void)
+{
+  int fds[2];
+  if(pipe(fds) < 0)
+    fail("render pipe");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("render fork");
+  if(pid == 0){
+    close(fds[0]);
+    close(1);
+    if(dup(fds[1]) != 1)
+      exit(1);
+    close(fds[1]);
+
+    char *argv[] = { "memviz", "user", "--plain", 0 };
+    exec("memviz", argv);
+    exit(1);
+  }
+
+  close(fds[1]);
+  int total = 0;
+  while(total < (int)sizeof(render_output) - 1){
+    int count = read(fds[0], render_output + total,
+                     sizeof(render_output) - 1 - total);
+    if(count < 0)
+      fail("render read");
+    if(count == 0)
+      break;
+    total += count;
+  }
+  close(fds[0]);
+  render_output[total] = 0;
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("memviz user execution");
+
+  if(!text_contains(render_output, "MAXVA"))
+    fail("render MAXVA missing");
+  if(!text_contains(render_output, "TRAMPOLINE / supervisor-only RX"))
+    fail("render trampoline block missing");
+  if(!text_contains(render_output, "TRAPFRAME / supervisor-only RW"))
+    fail("render trapframe block missing");
+  if(!text_contains(render_output, "ADDRESS-SPACE BREAK"))
+    fail("render address gap break missing");
+  if(!text_contains(render_output, "not drawn to scale"))
+    fail("render scale warning missing");
+  if(!text_contains(render_output, "TRAMPOLINE PAGE DETAIL"))
+    fail("render trampoline detail missing");
+  if(!text_contains(render_output, "TRAPFRAME PAGE MEMBER ORDER"))
+    fail("render trapframe detail missing");
+  if(!text_contains(render_output, "PA page:"))
+    fail("render physical page range missing");
+  if(!text_contains(render_output, "name=kernel_satp") ||
+     !text_contains(render_output, "name=t6"))
+    fail("render trapframe member boundaries missing");
+
+  printf("memviztest: user renderer OK\n");
 }
 
 /**
@@ -330,9 +467,10 @@ test_pagetable_snapshot(void)
 static int
 run_named(char *name)
 {
-  if(strcmp(name, "user") == 0)
+  if(strcmp(name, "user") == 0){
     test_user_snapshot();
-  else if(strcmp(name, "phys") == 0)
+    test_user_render();
+  } else if(strcmp(name, "phys") == 0)
     test_physical_snapshot();
   else if(strcmp(name, "alloc") == 0)
     test_allocate_and_release();
@@ -347,12 +485,17 @@ run_named(char *name)
 
 /**
  * main 默认运行完整测试；传入一个名称时只运行对应检查。
+ *
+ * @param argc 参数数量。
+ * @param argv 可选具名检查。
+ * @return 所有断言通过时返回 0；失败路径由 fail 终止。
  */
 int
 main(int argc, char **argv)
 {
   if(argc == 1){
     test_user_snapshot();
+    test_user_render();
     test_dynamic_extent();
     test_physical_snapshot();
     test_allocate_and_release();

--- a/tests/host/scheduler_smoke.c
+++ b/tests/host/scheduler_smoke.c
@@ -15,6 +15,10 @@
 #define DEFAULT_TIMEOUT_SECONDS 180
 #define READ_CHUNK_SIZE 4096
 
+/** 登录 Shell 根目录下的完整 ANSI 提示符，用作 QEMU 输入同步边界。 */
+static const char root_shell_prompt[] =
+  "\033[1;32mroot@xv6\033[0m:\033[1;34m/\033[0m# ";
+
 struct smoke_options {
   const char *policy;
   int cpus;
@@ -270,7 +274,6 @@ terminate_process_group(pid_t pid)
 static int
 run_smoke(const struct smoke_options *options)
 {
-  static const char shell_prompt[] = "$ ";
   static const char qemu_quit[] = {1, 'x'};
   struct output_buffer output = {0};
   char expected_banner[64];
@@ -350,7 +353,7 @@ run_smoke(const struct smoke_options *options)
         break;
       }
 
-      if(!command_sent && strstr(output.data, shell_prompt) != 0){
+      if(!command_sent && strstr(output.data, root_shell_prompt) != 0){
         if(strstr(output.data, expected_banner) == 0){
           fprintf(stderr, "scheduler_smoke: missing banner '%s'\n", expected_banner);
           break;
@@ -366,7 +369,7 @@ run_smoke(const struct smoke_options *options)
       if(command_sent && !quit_sent && output.length > command_output_offset){
         char *test_output = output.data + command_output_offset;
         char *success = strstr(test_output, expected_result);
-        if(success != 0 && strstr(success, shell_prompt) != 0){
+        if(success != 0 && strstr(success, root_shell_prompt) != 0){
           if(write_all(input_fd, qemu_quit, sizeof(qemu_quit)) < 0){
             perror("scheduler_smoke: quit qemu");
             break;

--- a/tests/host/scheduler_visualizer.c
+++ b/tests/host/scheduler_visualizer.c
@@ -18,6 +18,10 @@
 #define MAX_SEGMENTS 2048
 #define MAX_CPUS 64
 
+/** 登录 Shell 根目录下的完整 ANSI 提示符，用作 QEMU 输入同步边界。 */
+static const char root_shell_prompt[] =
+  "\033[1;32mroot@xv6\033[0m:\033[1;34m/\033[0m# ";
+
 struct options {
   const char *policy;
   const char *trace_path;
@@ -115,7 +119,7 @@ parse_options(int argc, char **argv, struct options *options)
  *
  * @param output 累积输出缓冲。
  * @param data 本次读取内容。
- * @param size 本次读取字节数。
+ * @param size 本次数据字节数。
  * @return 成功返回 0，内存分配失败返回 -1。
  */
 static int
@@ -487,7 +491,7 @@ run_session(const struct options *options)
         break;
       if(strstr(output.data, "panic:") || strstr(output.data, "kerneltrap"))
         break;
-      if(!command_sent && strstr(output.data, "$ ")){
+      if(!command_sent && strstr(output.data, root_shell_prompt)){
         if(write_all(input_fd, command, strlen(command)) < 0)
           break;
         command_sent = true;

--- a/tests/run.py
+++ b/tests/run.py
@@ -17,7 +17,15 @@ import pexpect
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RESULT_ROOT = REPO_ROOT / "test-results"
-QEMU_SHELL_PROMPT = "$ "
+ANSI_GREEN_BOLD = "\x1b[1;32m"
+ANSI_BLUE_BOLD = "\x1b[1;34m"
+ANSI_RESET = "\x1b[0m"
+# QEMU 回归从根目录登录 Shell 开始；精确匹配完整 ANSI 提示符，避免命令输出中的
+# 普通 `# ` 或颜色复位序列被误判为下一次输入边界。
+QEMU_SHELL_PROMPT = (
+    f"{ANSI_GREEN_BOLD}root@xv6{ANSI_RESET}:"
+    f"{ANSI_BLUE_BOLD}/{ANSI_RESET}# "
+)
 QEMU_FATAL_OUTPUTS = (
     "panic:",
     "kerneltrap",

--- a/tests/shell_history_interactive.py
+++ b/tests/shell_history_interactive.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""通过真实 QEMU 串口输入验证 xv6 Shell 行编辑、历史与作业控制。"""
+"""通过真实 QEMU 串口输入验证 xv6 Shell 提示符、行编辑、历史与作业控制。"""
 
 from __future__ import annotations
 
@@ -14,7 +14,28 @@ import pexpect
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RESULT_ROOT = REPO_ROOT / "test-results"
 TRANSCRIPT_PATH = RESULT_ROOT / "shell-history-interactive.log"
-PROMPT = "$ "
+ANSI_GREEN_BOLD = "\x1b[1;32m"
+ANSI_BLUE_BOLD = "\x1b[1;34m"
+ANSI_RESET = "\x1b[0m"
+
+
+def shell_prompt(path: str) -> str:
+    """构造固定 root 身份与指定逻辑目录对应的精确终端提示符。
+
+    Args:
+        path: Shell 应显示的绝对逻辑目录，或目录未知时的 ``?``。
+
+    Returns:
+        包含 ANSI 样式与 root ``#`` 结尾的完整提示符。
+    """
+
+    return (
+        f"{ANSI_GREEN_BOLD}root@xv6{ANSI_RESET}:"
+        f"{ANSI_BLUE_BOLD}{path}{ANSI_RESET}# "
+    )
+
+
+PROMPT = shell_prompt("/")
 
 
 class ShellHistoryFailure(RuntimeError):
@@ -63,13 +84,19 @@ def stop_qemu(child: pexpect.spawn) -> None:
         child.terminate(force=True)
 
 
-def submit(child: pexpect.spawn, text: str, timeout: int = 30) -> str:
+def submit(
+    child: pexpect.spawn,
+    text: str,
+    timeout: int = 30,
+    expected_prompt: str = PROMPT,
+) -> str:
     """向当前提示符提交一条命令并返回下一提示符前的原始输出。
 
     Args:
         child: 已处于 Shell 提示符的 QEMU 子进程。
         text: 不含 Enter 的命令文本。
         timeout: 等待下一提示符的秒数。
+        expected_prompt: 命令完成后必须出现的精确提示符。
 
     Returns:
         从命令输入到下一提示符之间捕获的原始终端输出。
@@ -78,7 +105,7 @@ def submit(child: pexpect.spawn, text: str, timeout: int = 30) -> str:
     child.timeout = timeout
     child.send(text)
     child.send("\r")
-    child.expect_exact(PROMPT)
+    child.expect_exact(expected_prompt)
     return child.before or ""
 
 
@@ -181,8 +208,43 @@ def run_job_control_checks(child: pexpect.spawn) -> None:
     reject(r"Running\s+cat &", output, "后台 console read 失败后作业未退出")
 
 
+def run_prompt_checks(child: pexpect.spawn) -> None:
+    """验证提示符颜色、逻辑目录规范化与失败 cd 的提交边界。
+
+    Args:
+        child: 已处于根目录提示符的 QEMU 子进程。
+    """
+
+    submit(child, "mkdir promptdir")
+    submit(child, "cd promptdir", expected_prompt=shell_prompt("/promptdir"))
+    # xv6 Shell 不实现 PATH 搜索；离开根目录后必须显式引用根目录中的用户程序。
+    submit(
+        child,
+        "/mkdir nested",
+        expected_prompt=shell_prompt("/promptdir"),
+    )
+    submit(
+        child,
+        "cd ./nested",
+        expected_prompt=shell_prompt("/promptdir/nested"),
+    )
+    submit(child, "cd .././..", expected_prompt=PROMPT)
+    submit(
+        child,
+        "cd /promptdir//nested/..",
+        expected_prompt=shell_prompt("/promptdir"),
+    )
+    output = submit(
+        child,
+        "cd /missing",
+        expected_prompt=shell_prompt("/promptdir"),
+    )
+    require(r"cannot cd /missing", output, "失败 cd 错误缺失或错误提交了目录状态")
+    submit(child, "cd /", expected_prompt=PROMPT)
+
+
 def run_checks(child: pexpect.spawn) -> None:
-    """执行历史、方向键、编辑边界、作业控制及兼容性验收。
+    """执行提示符、历史、方向键、编辑边界、作业控制及兼容性验收。
 
     Args:
         child: 已进入全新登录 Shell 的 QEMU 子进程。
@@ -244,6 +306,7 @@ def run_checks(child: pexpect.spawn) -> None:
     require(r"ALL TESTS PASSED", output, "PR #49 pipe-driven jobctl 回归失败")
 
     run_job_control_checks(child)
+    run_prompt_checks(child)
 
     child.send("echo ctrl-d")
     child.sendcontrol("d")

--- a/user/memviz.c
+++ b/user/memviz.c
@@ -1,8 +1,30 @@
 #include "kernel/types.h"
 #include "kernel/param.h"
+#include "kernel/riscv.h"
 #include "kernel/memviz.h"
 #include "user/user.h"
 #include "user/memvizlib.h"
+
+#define ANSI_RED "\033[31m"
+#define ANSI_GREEN "\033[32m"
+#define ANSI_YELLOW "\033[33m"
+#define ANSI_CYAN "\033[36m"
+#define ANSI_RESET "\033[0m"
+
+#define USER_BAR_CELLS 32
+#define USER_GAP_BREAK_MIN_PAGES 16
+
+// 使用静态缓冲，避免扩展后的快照占满固定一页用户栈。
+static struct memviz_snapshot user_snapshot;
+
+// 名称顺序与 enum memviz_trapframe_slot 以及 struct trapframe ABI 一致。
+static char *trapframe_slot_names[MEMVIZ_TRAPFRAME_SLOT_COUNT] = {
+  "kernel_satp", "kernel_sp", "kernel_trap", "epc", "kernel_hartid",
+  "ra", "sp", "gp", "tp", "t0", "t1", "t2", "s0", "s1",
+  "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
+  "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11",
+  "t3", "t4", "t5", "t6",
+};
 
 /**
  * usage 输出 memviz 支持的视图和纯文本选项。
@@ -11,6 +33,390 @@ static void
 usage(void)
 {
   fprintf(2, "usage: memviz <user|phys|kernel|pagetable|all> [filter] [--plain]\n");
+}
+
+/**
+ * string_length 返回以 NUL 结尾字符串的字节数。
+ *
+ * @param text 非空字符串。
+ * @return 不包含结尾 NUL 的字节数。
+ */
+static int
+string_length(char *text)
+{
+  int length = 0;
+  while(text[length] != 0)
+    length++;
+  return length;
+}
+
+/**
+ * print_glyph 输出一个可选 ANSI 颜色的单字节字符。
+ *
+ * @param glyph 要输出的字符。
+ * @param color ANSI 颜色前缀。
+ * @param plain 非零时禁止输出 ANSI 转义序列。
+ */
+static void
+print_glyph(char glyph, char *color, int plain)
+{
+  if(plain)
+    printf("%c", glyph);
+  else
+    printf("%s%c%s", color, glyph, ANSI_RESET);
+}
+
+/**
+ * print_line 输出带真实地址的字符图边界线。
+ *
+ * @param address 边界虚拟地址。
+ * @param mark 边界标签与横线。
+ */
+static void
+print_line(uint64 address, char *mark)
+{
+  printf("%p %s\n", address, mark);
+}
+
+/**
+ * print_box_text 输出地址空间框内的一行文本并补齐右边界。
+ *
+ * @param text 最长 34 字节的静态标签。
+ */
+static void
+print_box_text(char *text)
+{
+  int length = string_length(text);
+  printf("           | %s", text);
+  for(int i = length; i < 34; i++)
+    printf(" ");
+  printf(" |\n");
+}
+
+/**
+ * scaled_cells 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
+ *
+ * @param used 已使用字节或页数。
+ * @param total 总字节或总页数。
+ * @param cells 条形图字符宽度。
+ * @return 范围为 [0, cells] 的已使用字符数。
+ */
+static int
+scaled_cells(uint64 used, uint64 total, int cells)
+{
+  if(total == 0 || used == 0)
+    return 0;
+  uint64 result = (used * cells + total - 1) / total;
+  if(result > (uint64)cells)
+    result = cells;
+  return (int)result;
+}
+
+/**
+ * print_box_bar 输出低偏移到高偏移方向的页内用量条。
+ *
+ * @param used_cells 已使用字符数。
+ * @param used 已使用区域字符。
+ * @param free 未使用区域字符。
+ * @param plain 非零时禁用 ANSI 颜色。
+ */
+static void
+print_box_bar(int used_cells, char used, char free, int plain)
+{
+  printf("           | [");
+  for(int i = 0; i < USER_BAR_CELLS; i++){
+    if(i < used_cells)
+      print_glyph(used, ANSI_RED, plain);
+    else
+      print_glyph(free, ANSI_GREEN, plain);
+  }
+  printf("] |\n");
+}
+
+/**
+ * print_box_reverse_bar 输出高地址侧已使用的向下增长栈用量条。
+ *
+ * @param used_cells 已使用字符数。
+ * @param plain 非零时禁用 ANSI 颜色。
+ */
+static void
+print_box_reverse_bar(int used_cells, int plain)
+{
+  printf("           | [");
+  for(int i = 0; i < USER_BAR_CELLS; i++){
+    if(i < USER_BAR_CELLS - used_cells)
+      print_glyph('.', ANSI_GREEN, plain);
+    else
+      print_glyph('#', ANSI_RED, plain);
+  }
+  printf("] |\n");
+}
+
+/**
+ * print_pte_flags 输出教学相关的 RISC-V PTE 权限位。
+ *
+ * @param flags PTE 低十位 flags。
+ */
+static void
+print_pte_flags(uint64 flags)
+{
+  printf("%c%c%c%c%c%c",
+         (flags & PTE_V) ? 'V' : '-',
+         (flags & PTE_R) ? 'R' : '-',
+         (flags & PTE_W) ? 'W' : '-',
+         (flags & PTE_X) ? 'X' : '-',
+         (flags & PTE_U) ? 'U' : '-',
+         (flags & PTE_COW) ? 'C' : '-');
+}
+
+/**
+ * dynamic_pages 计算动态起点到 p->sz 已覆盖的页数。
+ *
+ * @param state 当前内存快照。
+ * @return 动态区域向上取整后的页数。
+ */
+static uint64
+dynamic_pages(struct memviz_snapshot *state)
+{
+  if(state->process_size <= state->dynamic_start)
+    return 0;
+  return (state->process_size - state->dynamic_start + PGSIZE - 1) / PGSIZE;
+}
+
+/**
+ * remaining_pages 计算 p->sz 到 USERMAX 之间仍未使用的整页数。
+ *
+ * @param state 当前内存快照。
+ * @return 普通用户 VA 的剩余整页数。
+ */
+static uint64
+remaining_pages(struct memviz_snapshot *state)
+{
+  if(state->user_limit <= state->process_size)
+    return 0;
+  return (state->user_limit - state->process_size) / PGSIZE;
+}
+
+/**
+ * print_user_gap 用明显的断裂线表现 p->sz 到 USERMAX 的巨大地址跨度。
+ *
+ * @param state 当前内存快照。
+ *
+ * 小于阈值时保留紧凑布局；超过阈值时增加纵向留白、断裂符号和
+ * not-drawn-to-scale 提示，避免字符图暗示上下边界物理相邻。
+ */
+static void
+print_user_gap(struct memviz_snapshot *state)
+{
+  uint64 pages = remaining_pages(state);
+  uint64 bytes = state->user_limit > state->process_size ?
+                 state->user_limit - state->process_size : 0;
+
+  print_box_text("AVAILABLE ORDINARY USER VA");
+  printf("           | remaining=%d pages bytes=%p\n", (int)pages, bytes);
+  print_box_text("currently unmapped above p->sz");
+
+  if(pages >= USER_GAP_BREAK_MIN_PAGES){
+    printf("           |                                    |\n");
+    printf("           :                                    :\n");
+    printf("           +====== ADDRESS-SPACE BREAK =========+\n");
+    printf("           :        not drawn to scale           :\n");
+    printf("           :                                    :\n");
+    printf("           |                                    |\n");
+  }
+}
+
+/**
+ * print_trampoline_details 展示 trampoline 页的 VA、PA、权限和代码顺序。
+ *
+ * @param state 当前内存快照。
+ */
+static void
+print_trampoline_details(struct memviz_snapshot *state)
+{
+  printf("\n=== TRAMPOLINE PAGE DETAIL ===\n");
+  printf("  VA page: %p - %p\n", state->trampoline, state->maxva);
+  printf("  PA page: %p - %p\n", state->trampoline_pa,
+         state->trampoline_pa + PGSIZE);
+  printf("  PTE flags: ");
+  print_pte_flags(state->trampoline_flags);
+  printf("  user-access=no\n");
+  printf("  code used=%d B free=%d B\n",
+         (int)state->trampoline_used,
+         (int)(PGSIZE - state->trampoline_used));
+  printf("  logical order, low offset -> high offset:\n");
+
+  if(state->uservec_offset > 0){
+    printf("    [0, %d) alignment/prefix  PA=%p-%p\n",
+           (int)state->uservec_offset,
+           state->trampoline_pa,
+           state->trampoline_pa + state->uservec_offset);
+  }
+  printf("    [%d, %d) uservec  VA=%p PA=%p\n",
+         (int)state->uservec_offset, (int)state->userret_offset,
+         state->trampoline + state->uservec_offset,
+         state->trampoline_pa + state->uservec_offset);
+  printf("    [%d, %d) userret  VA=%p PA=%p\n",
+         (int)state->userret_offset, (int)state->trampoline_used,
+         state->trampoline + state->userret_offset,
+         state->trampoline_pa + state->userret_offset);
+  printf("    [%d, %d) unused by trampoline code  PA=%p-%p\n",
+         (int)state->trampoline_used, PGSIZE,
+         state->trampoline_pa + state->trampoline_used,
+         state->trampoline_pa + PGSIZE);
+}
+
+/**
+ * print_trapframe_details 按真实 ABI 顺序展开 trapframe 页内全部成员。
+ *
+ * @param state 当前内存快照。
+ *
+ * 每个槽位同时展示页内 offset、对应 VA、对应 PA 和 memsnapshot 系统调用
+ * 入口时保存的值；该值不是任意时刻的实时寄存器。
+ */
+static void
+print_trapframe_details(struct memviz_snapshot *state)
+{
+  printf("\n=== TRAPFRAME PAGE MEMBER ORDER ===\n");
+  printf("  VA page: %p - %p\n", state->trapframe, state->trampoline);
+  printf("  PA page: %p - %p\n", state->trapframe_pa,
+         state->trapframe_pa + PGSIZE);
+  printf("  PTE flags: ");
+  print_pte_flags(state->trapframe_flags);
+  printf("  user-access=no\n");
+  printf("  struct used=%d B free-tail=%d B\n",
+         (int)state->trapframe_used,
+         (int)(PGSIZE - state->trapframe_used));
+  printf("  values are captured inside memsnapshot before syscall a0 is replaced\n");
+
+  for(int slot = 0; slot < MEMVIZ_TRAPFRAME_SLOT_COUNT; slot++){
+    if(slot == MEMVIZ_TF_KERNEL_SATP)
+      printf("  -- kernel entry/return context --\n");
+    if(slot == MEMVIZ_TF_RA)
+      printf("  -- saved user registers in ABI storage order --\n");
+
+    uint64 offset = (uint64)slot * sizeof(uint64);
+    printf("  [%d] offset=%d name=%s VA=%p PA=%p value=%p\n",
+           slot, (int)offset, trapframe_slot_names[slot],
+           state->trapframe + offset,
+           state->trapframe_pa + offset,
+           state->trapframe_values[slot]);
+  }
+
+  printf("  unused tail: offset=%d..%d VA=%p PA=%p bytes=%d\n",
+         (int)state->trapframe_used, PGSIZE,
+         state->trapframe + state->trapframe_used,
+         state->trapframe_pa + state->trapframe_used,
+         (int)(PGSIZE - state->trapframe_used));
+}
+
+/**
+ * print_user_view 输出包含顶端固定页、巨大 VA 空洞和低地址进程区域的完整视图。
+ *
+ * @param plain 非零时禁用 ANSI 颜色。
+ * @return 采样成功返回 0，系统调用失败返回 -1。
+ */
+static int
+print_user_view(int plain)
+{
+  if(memsnapshot(MEMVIZ_VIEW_USER, &user_snapshot) < 0)
+    return -1;
+
+  uint64 used_pages = dynamic_pages(&user_snapshot);
+  int dynamic_cells = scaled_cells(used_pages,
+                                   remaining_pages(&user_snapshot) + used_pages,
+                                   USER_BAR_CELLS);
+  int trampoline_cells = scaled_cells(user_snapshot.trampoline_used,
+                                      PGSIZE, USER_BAR_CELLS);
+  int trapframe_cells = scaled_cells(user_snapshot.trapframe_used,
+                                     PGSIZE, USER_BAR_CELLS);
+
+  printf("\n%s=== CURRENT PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
+         plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  printf("\n       HIGH ADDRESS\n");
+  print_line(user_snapshot.maxva, "+--------------- MAXVA ---------------+");
+  print_box_text("TRAMPOLINE / supervisor-only RX");
+  print_box_bar(trampoline_cells, '#', '.', plain);
+  print_box_text("one physical page; no PTE_U");
+  print_line(user_snapshot.trampoline, "+------------ TRAMPOLINE -------------+");
+  print_box_text("TRAPFRAME / supervisor-only RW");
+  print_box_bar(trapframe_cells, '#', '.', plain);
+  print_box_text("one physical page; no PTE_U");
+  print_line(user_snapshot.trapframe, "+------ USERMAX / TRAPFRAME -----------+");
+
+  print_user_gap(&user_snapshot);
+  print_line(user_snapshot.process_size, "+--------------- p->sz ----------------+");
+  print_box_text("DYNAMIC EXTENT");
+  print_box_bar(dynamic_cells, '#', '.', plain);
+  printf("           | pages=%d\n", (int)used_pages);
+  print_line(user_snapshot.dynamic_start, "+----------- dynamic start ------------+");
+
+  if(user_snapshot.user_stack_valid){
+    uint64 stack_total = user_snapshot.stack_top - user_snapshot.stack_bottom;
+    int stack_cells = scaled_cells(user_snapshot.stack_used,
+                                   stack_total, USER_BAR_CELLS);
+    print_box_text("USER STACK / grows downward");
+    print_box_reverse_bar(stack_cells, plain);
+    printf("           | used=%d B free=%d B\n",
+           (int)user_snapshot.stack_used, (int)user_snapshot.stack_free);
+  } else {
+    print_box_text("USER STACK: invalid SP");
+  }
+
+  print_line(user_snapshot.stack_bottom, "+--------------------------------------+");
+  print_box_text("GUARD PAGE / mapped without PTE_U");
+  print_box_bar(USER_BAR_CELLS, 'X', 'X', plain);
+  print_line(user_snapshot.stack_guard_start, "+--------------------------------------+");
+  print_box_text("ELF IMAGE");
+  print_box_bar(USER_BAR_CELLS, '#', '#', plain);
+  print_line(user_snapshot.image_start, "+--------------------------------------+");
+  printf("       LOW ADDRESS\n");
+
+  printf("\nsummary:\n");
+  printf("  ordinary user limit: %p (USERMAX/TRAPFRAME)\n",
+         user_snapshot.user_limit);
+  printf("  architectural low-half limit: %p (MAXVA)\n", user_snapshot.maxva);
+  printf("  trampoline: VA=%p PA=%p used=%d/%d flags=",
+         user_snapshot.trampoline, user_snapshot.trampoline_pa,
+         (int)user_snapshot.trampoline_used, PGSIZE);
+  print_pte_flags(user_snapshot.trampoline_flags);
+  printf("\n");
+  printf("  trapframe: VA=%p PA=%p used=%d/%d flags=",
+         user_snapshot.trapframe, user_snapshot.trapframe_pa,
+         (int)user_snapshot.trapframe_used, PGSIZE);
+  print_pte_flags(user_snapshot.trapframe_flags);
+  printf("\n");
+  printf("  p->sz to USERMAX: pages=%d bytes=%p\n",
+         (int)remaining_pages(&user_snapshot),
+         user_snapshot.user_limit - user_snapshot.process_size);
+  printf("  stack: used=%d free=%d\n",
+         (int)user_snapshot.stack_used, (int)user_snapshot.stack_free);
+  printf("  dynamic pages: %d\n", (int)used_pages);
+  printf("  physical pages: free=%d used=%d total=%d\n",
+         (int)user_snapshot.free_pages, (int)user_snapshot.used_pages,
+         (int)user_snapshot.total_pages);
+
+  print_trampoline_details(&user_snapshot);
+  print_trapframe_details(&user_snapshot);
+  return 0;
+}
+
+/**
+ * print_all_views 依次输出增强用户视图和其余已有视图。
+ *
+ * @param plain 非零时禁用 ANSI 颜色。
+ * @return 全部视图成功返回 0；任一采样失败返回 -1。
+ */
+static int
+print_all_views(int plain)
+{
+  if(print_user_view(plain) < 0)
+    return -1;
+  if(memviz_print(MEMVIZ_VIEW_PHYS, plain) < 0)
+    return -1;
+  if(memviz_print(MEMVIZ_VIEW_KERNEL, plain) < 0)
+    return -1;
+  return memviz_print(MEMVIZ_VIEW_PAGETABLE, plain);
 }
 
 /**
@@ -48,7 +454,7 @@ main(int argc, char **argv)
   }
 
   if(strcmp(argv[1], "user") == 0)
-    result = memviz_print(MEMVIZ_VIEW_USER, plain);
+    result = print_user_view(plain);
   else if(strcmp(argv[1], "phys") == 0)
     result = memviz_print(MEMVIZ_VIEW_PHYS, plain);
   else if(strcmp(argv[1], "kernel") == 0)
@@ -56,7 +462,7 @@ main(int argc, char **argv)
   else if(strcmp(argv[1], "pagetable") == 0)
     result = memviz_print_filtered(MEMVIZ_VIEW_PAGETABLE, plain, filter);
   else if(strcmp(argv[1], "all") == 0)
-    result = memviz_print_all(plain);
+    result = print_all_views(plain);
   else {
     usage();
     exit(1);

--- a/user/sh.c
+++ b/user/sh.c
@@ -18,6 +18,11 @@
 #define MAXARGS 10
 #define MAXJOBS 16
 #define MAXCMD  100
+#define SHELL_CWD_SIZE 256
+
+#define ANSI_GREEN_BOLD "\033[1;32m"
+#define ANSI_BLUE_BOLD  "\033[1;34m"
+#define ANSI_RESET      "\033[0m"
 
 /** Shell 只跟踪顶层 supervisor；其 pipeline 后代通过 PGID 统一受控。 */
 enum jobstate { JOB_UNUSED, JOB_RUNNING, JOB_STOPPED };
@@ -35,6 +40,8 @@ static struct job jobs[MAXJOBS];
 static int nextjid = 1;
 static int shell_pgid;
 static struct shell_history command_history;
+static char shell_cwd[SHELL_CWD_SIZE] = "/";
+static int shell_cwd_known = 1;
 
 struct cmd {
   int type;
@@ -96,6 +103,134 @@ appendtext(char *dst, int *length, int size, char *text)
   while(*text && *length + 1 < size)
     dst[(*length)++] = *text++;
   dst[*length] = 0;
+}
+
+/**
+ * 从逻辑目录中移除最后一个路径分量，根目录保持不变。
+ *
+ * @param path NUL 结尾的绝对逻辑路径，会被原地修改。
+ * @param length 路径当前长度，返回时同步为截断后的长度。
+ */
+static void
+popcwd(char *path, int *length)
+{
+  while(*length > 1 && path[*length - 1] != '/')
+    (*length)--;
+  if(*length > 1)
+    (*length)--;
+  path[*length] = 0;
+}
+
+/**
+ * 将一次 cd 参数合并到当前逻辑目录并消除重复斜杠、`.` 与 `..`。
+ *
+ * @param base 当前绝对逻辑目录；相对路径以它为起点。
+ * @param path 传给 chdir() 的用户路径。
+ * @param dst 接收规范化后的绝对逻辑路径。
+ * @param size dst 容量，包含结尾 NUL。
+ * @return 能完整表示结果时返回 0；容量不足时返回 -1。
+ *
+ * 该函数只维护 Bash 默认的逻辑路径语义，不解析符号链接对应的物理路径。
+ */
+static int
+normalizecwd(char *base, char *path, char *dst, int size)
+{
+  int length;
+  char *cursor;
+
+  if(size < 2)
+    return -1;
+
+  if(path[0] == '/'){
+    dst[0] = '/';
+    dst[1] = 0;
+    length = 1;
+  } else {
+    length = strlen(base);
+    if(length < 1 || length >= size)
+      return -1;
+    memmove(dst, base, length + 1);
+  }
+
+  cursor = path;
+  while(*cursor){
+    char *component;
+    int component_length;
+    int separator_length;
+
+    while(*cursor == '/')
+      cursor++;
+    if(*cursor == 0)
+      break;
+
+    component = cursor;
+    while(*cursor && *cursor != '/')
+      cursor++;
+    component_length = cursor - component;
+
+    if(component_length == 1 && component[0] == '.')
+      continue;
+    if(component_length == 2 && component[0] == '.' && component[1] == '.'){
+      popcwd(dst, &length);
+      continue;
+    }
+
+    separator_length = length > 1 ? 1 : 0;
+    if(length + separator_length + component_length + 1 > size)
+      return -1;
+    if(separator_length)
+      dst[length++] = '/';
+    memmove(dst + length, component, component_length);
+    length += component_length;
+    dst[length] = 0;
+  }
+
+  return 0;
+}
+
+/**
+ * 在 chdir() 成功后提交新的 Shell 逻辑目录。
+ *
+ * @param path 本次成功切换所使用的原始路径。
+ *
+ * 已知目录可处理绝对和相对路径；状态未知时只有绝对路径能够恢复。若实际 cwd
+ * 无法装入固定缓冲区，提示符退化为 `?`，但不会影响内核已经完成的目录切换。
+ */
+static void
+updatecwd(char *path)
+{
+  char next[SHELL_CWD_SIZE];
+
+  if((path[0] != '/' && !shell_cwd_known) ||
+     normalizecwd(shell_cwd, path, next, sizeof(next)) < 0){
+    shell_cwd[0] = '?';
+    shell_cwd[1] = 0;
+    shell_cwd_known = 0;
+    return;
+  }
+
+  memmove(shell_cwd, next, strlen(next) + 1);
+  shell_cwd_known = 1;
+}
+
+/**
+ * 通过一次 console write 输出完整提示符，避免后台作业逐字符穿插 ANSI 序列。
+ *
+ * 用户态 printf() 会为每个字符单独调用 write()；若后台进程同时打印错误，提示符
+ * 的颜色控制序列和路径可能被拆散。这里先构造固定上限缓冲区，再以一次系统调用
+ * 提交，使 console 锁覆盖完整提示符。
+ */
+static void
+printprompt(void)
+{
+  char prompt[SHELL_CWD_SIZE + 64] = {0};
+  int length = 0;
+
+  appendtext(prompt, &length, sizeof(prompt),
+             ANSI_GREEN_BOLD "root@xv6" ANSI_RESET ":" ANSI_BLUE_BOLD);
+  appendtext(prompt, &length, sizeof(prompt), shell_cwd);
+  appendtext(prompt, &length, sizeof(prompt), ANSI_RESET "# ");
+  write(2, prompt, length);
 }
 
 /** 将命令树压缩成 jobs 可显示的单行文本。 */
@@ -245,9 +380,7 @@ reapjobs(void)
   }
 }
 
-/**
- * 创建后台 supervisor 并让父子双方尝试设置 PGID，缩小 fork/exec 启动竞态。
- */
+/** 创建后台 supervisor 并让父子双方尝试设置 PGID，缩小 fork/exec 启动竞态。 */
 static void
 startjob(struct cmd *cmd, char *command)
 {
@@ -314,7 +447,7 @@ waitforeground(struct job *job, int pid, int pgid, char *command)
   }
 
   if(job != 0 && job->state == JOB_STOPPED){
-    if(procctl(pgid, JOBCTL_CONT) < 0){
+    if(procctl(job->pgid, JOBCTL_CONT) < 0){
       fprintf(2, "fg: cannot continue job %d\n", job->jid);
       tcsetpgrp(shell_pgid);
       return;
@@ -460,6 +593,8 @@ runbuiltin(char *buf)
   if(startswith(buf, "cd ")){
     if(chdir(buf + 3) < 0)
       fprintf(2, "cannot cd %s\n", buf + 3);
+    else
+      updatecwd(buf + 3);
     return 1;
   }
   return 0;
@@ -544,7 +679,7 @@ runcmd(struct cmd *cmd)
 }
 
 /**
- * 输出提示符并读取一条命令。
+ * 输出上下文提示符并读取一条命令。
  *
  * @param buf 命令缓冲区。
  * @param nbuf 缓冲区容量。
@@ -553,7 +688,7 @@ runcmd(struct cmd *cmd)
 int
 getcmd(char *buf, int nbuf)
 {
-  fprintf(2, "$ ");
+  printprompt();
   memset(buf, 0, nbuf);
   return shell_readline(buf, nbuf, &command_history);
 }
@@ -600,9 +735,7 @@ main(void)
   exit(0);
 }
 
-/**
- * 在父 Shell 中展开顶层列表，并为每个前台或后台命令创建独立进程组。
- */
+/** 在父 Shell 中展开顶层列表，并为每个前台或后台命令创建独立进程组。 */
 void
 runline(struct cmd *cmd)
 {


### PR DESCRIPTION
将 `main` 的以下已合入改动同步到 `concept/115-linux-directory-layout`：

- Bash 风格上下文提示符（#112）；
- 用户页表顶端固定映射展示（#114）。

目录布局分支已先手工合并 `tests/run.py` 与 `tests/shell_history_interactive.py` 的重叠语义：启动提示符以 `/root` 为初始目录，同时 guest 外部程序继续使用绝对路径。

该 PR 只用于更新功能分支基线，不合入 `main`。