### PR TITLE
chore: 同步最新 main 到目录布局分支

### DIFF
--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -5,6 +5,7 @@
 #define MEMVIZ_PTE_ENTRIES 24
 #define MEMVIZ_PT_USAGE_PAGES 16
 #define MEMVIZ_PT_USAGE_CELLS 64
+#define MEMVIZ_USER_STATE_CELLS 32
 
 // memsnapshot() 支持的只读视图类型。
 enum memviz_view {
@@ -86,6 +87,15 @@ struct memviz_cell {
   uint free_pages;
 };
 
+// 一个动态地址压缩单元记录连续逻辑页的最终可视状态分布。
+struct memviz_user_state_cell {
+  uint total_pages;
+  uint resident_pages;
+  uint cow_pages;
+  uint lazy_pages;
+  uint mmap_pages;
+};
+
 // 一个页表观察行记录一个代表性 VA 的叶子 PTE。
 struct memviz_pte_level {
   int level;
@@ -160,6 +170,15 @@ struct memviz_snapshot {
   uint64 stack_used;
   uint64 stack_free;
   uint64 dynamic_start;
+
+  // 动态逻辑范围的页级状态。小范围一页一格，大范围压缩到固定格数。
+  uint64 dynamic_page_count;
+  uint64 dynamic_resident_pages;
+  uint64 dynamic_cow_pages;
+  uint64 dynamic_lazy_pages;
+  uint64 dynamic_mmap_pages;
+  uint64 dynamic_state_cell_count;
+  struct memviz_user_state_cell dynamic_state[MEMVIZ_USER_STATE_CELLS];
 
   // 用户页表顶端两个 supervisor-only 固定页及其页内逻辑布局。
   uint64 maxva;

--- a/kernel/sysmemviz.c
+++ b/kernel/sysmemviz.c
@@ -4,6 +4,7 @@
 #include "riscv.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "vma.h"
 #include "memviz.h"
 #include "defs.h"
 
@@ -138,6 +139,259 @@ fill_user_top_snapshot(struct proc *p, struct memviz_snapshot *snapshot)
 }
 
 /**
+ * dynamic_cell_bounds 返回一个压缩单元覆盖的页下标半开区间。
+ *
+ * @param snapshot 已初始化动态页总数和单元数量的快照。
+ * @param cell 单元下标，范围为 [0, dynamic_state_cell_count)。
+ * @param first 接收首个页下标。
+ * @param end 接收末尾后一页下标。
+ */
+static void
+dynamic_cell_bounds(struct memviz_snapshot *snapshot, int cell,
+                    uint64 *first, uint64 *end)
+{
+  uint64 cells = snapshot->dynamic_state_cell_count;
+  uint64 pages = snapshot->dynamic_page_count;
+  *first = (uint64)cell * pages / cells;
+  *end = (uint64)(cell + 1) * pages / cells;
+}
+
+/**
+ * interval_overlap_pages 计算两个页下标半开区间的交集页数。
+ *
+ * @param first_a 第一个区间起点。
+ * @param end_a 第一个区间终点。
+ * @param first_b 第二个区间起点。
+ * @param end_b 第二个区间终点。
+ * @return 两区间重叠的页数。
+ */
+static uint64
+interval_overlap_pages(uint64 first_a, uint64 end_a,
+                       uint64 first_b, uint64 end_b)
+{
+  uint64 first = first_a > first_b ? first_a : first_b;
+  uint64 end = end_a < end_b ? end_a : end_b;
+  return end > first ? end - first : 0;
+}
+
+/**
+ * initialize_dynamic_cells 建立动态范围的固定宽度压缩桶，初始均视为 lazy。
+ *
+ * @param snapshot 已包含 dynamic_start 和 process_size 的快照。
+ *
+ * 当动态范围不超过 32 页时，每个单元恰好覆盖一页；更大范围按连续地址
+ * 等比例压缩。初始 lazy 只是“尚未观察到 VMA 或有效叶子”的默认状态，
+ * 后续步骤会按 VMA 和 PTE 事实覆盖它。
+ */
+static void
+initialize_dynamic_cells(struct memviz_snapshot *snapshot)
+{
+  if(snapshot->process_size <= snapshot->dynamic_start)
+    return;
+
+  uint64 end = PGROUNDUP(snapshot->process_size);
+  snapshot->dynamic_page_count =
+    (end - snapshot->dynamic_start) / PGSIZE;
+  snapshot->dynamic_state_cell_count = snapshot->dynamic_page_count;
+  if(snapshot->dynamic_state_cell_count > MEMVIZ_USER_STATE_CELLS)
+    snapshot->dynamic_state_cell_count = MEMVIZ_USER_STATE_CELLS;
+
+  for(int cell = 0; cell < (int)snapshot->dynamic_state_cell_count; cell++){
+    uint64 first;
+    uint64 cell_end;
+    dynamic_cell_bounds(snapshot, cell, &first, &cell_end);
+    struct memviz_user_state_cell *state = &snapshot->dynamic_state[cell];
+    state->total_pages = cell_end - first;
+    state->lazy_pages = state->total_pages;
+  }
+}
+
+/**
+ * overlay_vma_ranges 将活动 VMA 覆盖的逻辑页从 lazy 改记为 mmap。
+ *
+ * @param p 当前进程；函数只读 p->vma[] 和 VMA 边界。
+ * @param snapshot 已初始化动态压缩单元的快照。
+ *
+ * 这里只根据 VMA 元数据标记整段逻辑区域，不读取文件、不建立 PTE。后续扫描
+ * 有效叶子时，带 PTE_COW 的 mmap 页会再次提升为 COW，保持最终优先级。
+ */
+static void
+overlay_vma_ranges(struct proc *p, struct memviz_snapshot *snapshot)
+{
+  if(snapshot->dynamic_page_count == 0)
+    return;
+
+  uint64 range_start = snapshot->dynamic_start;
+  uint64 range_end = PGROUNDUP(snapshot->process_size);
+
+  for(int index = 0; index < NOFILE; index++){
+    struct VMA *v = p->vma[index];
+    if(v == 0 || !v->used || v->length == 0)
+      continue;
+
+    uint64 vma_end_raw = v->addr + v->length;
+    if(vma_end_raw < v->addr)
+      continue;
+    uint64 vma_start = PGROUNDDOWN(v->addr);
+    uint64 vma_end = PGROUNDUP(vma_end_raw);
+    if(vma_start < range_start)
+      vma_start = range_start;
+    if(vma_end > range_end)
+      vma_end = range_end;
+    if(vma_end <= vma_start)
+      continue;
+
+    uint64 first_page = (vma_start - range_start) / PGSIZE;
+    uint64 end_page = (vma_end - range_start) / PGSIZE;
+    for(int cell = 0; cell < (int)snapshot->dynamic_state_cell_count; cell++){
+      uint64 cell_first;
+      uint64 cell_end;
+      dynamic_cell_bounds(snapshot, cell, &cell_first, &cell_end);
+      uint64 overlap = interval_overlap_pages(first_page, end_page,
+                                              cell_first, cell_end);
+      if(overlap == 0)
+        continue;
+
+      struct memviz_user_state_cell *state = &snapshot->dynamic_state[cell];
+      if(overlap > state->lazy_pages)
+        overlap = state->lazy_pages;
+      state->lazy_pages -= overlap;
+      state->mmap_pages += overlap;
+    }
+  }
+}
+
+/**
+ * classify_dynamic_leaf 将一个有效 L0 用户叶子覆盖到对应动态压缩单元。
+ *
+ * @param p 当前进程，用于判断该 VA 是否仍属于活动 VMA。
+ * @param snapshot 已完成默认 lazy 和 VMA 覆盖的快照。
+ * @param va 页对齐用户虚拟地址。
+ * @param pte 该地址的有效叶子 PTE。
+ *
+ * 最终优先级为 COW > mmap > resident > lazy。普通 mmap 驻留页仍显示为
+ * mmap，以表达区域来源；只有其 PTE 被 fork 转换为 COW 时才提升为 COW。
+ */
+static void
+classify_dynamic_leaf(struct proc *p, struct memviz_snapshot *snapshot,
+                      uint64 va, pte_t pte)
+{
+  if(va < snapshot->dynamic_start || va >= PGROUNDUP(snapshot->process_size))
+    return;
+  if((pte & PTE_V) == 0 || (pte & PTE_U) == 0)
+    return;
+
+  uint64 page = (va - snapshot->dynamic_start) / PGSIZE;
+  uint64 cell = page * snapshot->dynamic_state_cell_count /
+                snapshot->dynamic_page_count;
+  if(cell >= snapshot->dynamic_state_cell_count)
+    return;
+
+  struct memviz_user_state_cell *state = &snapshot->dynamic_state[cell];
+  int is_mmap = vma_find(p, va) != 0;
+  if(pte & PTE_COW){
+    if(is_mmap){
+      if(state->mmap_pages > 0)
+        state->mmap_pages--;
+    } else if(state->lazy_pages > 0){
+      state->lazy_pages--;
+    }
+    state->cow_pages++;
+    return;
+  }
+
+  if(is_mmap)
+    return;
+  if(state->lazy_pages > 0)
+    state->lazy_pages--;
+  state->resident_pages++;
+}
+
+/**
+ * scan_dynamic_leaves 只遍历与动态范围相交的有效页表子树。
+ *
+ * @param p 当前进程。
+ * @param snapshot 动态页状态快照。
+ * @param pagetable 当前页表页。
+ * @param level 当前 Sv39 层级，根为 2、叶为 0。
+ * @param base 当前页表页下标 0 对应的虚拟地址。
+ *
+ * xv6 用户映射由 mappages() 建立在 L0。本观察器遇到高层 leaf 时跳过，避免
+ * 为未来可能出现的大页映射逐页展开巨量范围；当前实现不会产生这种用户大页。
+ */
+static void
+scan_dynamic_leaves(struct proc *p, struct memviz_snapshot *snapshot,
+                    pagetable_t pagetable, int level, uint64 base)
+{
+  uint64 span = PGSIZE;
+  for(int current = 0; current < level; current++)
+    span *= 512;
+
+  uint64 range_start = snapshot->dynamic_start;
+  uint64 range_end = PGROUNDUP(snapshot->process_size);
+  for(int index = 0; index < 512; index++){
+    uint64 va = base + (uint64)index * span;
+    if(va >= range_end)
+      break;
+    if(va + span <= range_start)
+      continue;
+
+    pte_t pte = pagetable[index];
+    if((pte & PTE_V) == 0)
+      continue;
+    if(pte & (PTE_R | PTE_W | PTE_X)){
+      if(level == 0)
+        classify_dynamic_leaf(p, snapshot, va, pte);
+      continue;
+    }
+    if(level > 0)
+      scan_dynamic_leaves(p, snapshot, (pagetable_t)PTE2PA(pte),
+                          level - 1, va);
+  }
+}
+
+/**
+ * finish_dynamic_totals 汇总压缩单元并验证每个单元仍覆盖相同页数。
+ *
+ * @param snapshot 已完成 VMA 与 PTE 覆盖的快照。
+ */
+static void
+finish_dynamic_totals(struct memviz_snapshot *snapshot)
+{
+  for(int cell = 0; cell < (int)snapshot->dynamic_state_cell_count; cell++){
+    struct memviz_user_state_cell *state = &snapshot->dynamic_state[cell];
+    uint64 classified = state->resident_pages + state->cow_pages +
+                        state->lazy_pages + state->mmap_pages;
+    if(classified != state->total_pages)
+      panic("memviz user state");
+    snapshot->dynamic_resident_pages += state->resident_pages;
+    snapshot->dynamic_cow_pages += state->cow_pages;
+    snapshot->dynamic_lazy_pages += state->lazy_pages;
+    snapshot->dynamic_mmap_pages += state->mmap_pages;
+  }
+}
+
+/**
+ * fill_user_page_states 只读采集 dynamic_start 到 p->sz 的页级状态。
+ *
+ * @param p 当前进程；系统调用期间不会替换其页表或 VMA 数组。
+ * @param snapshot 已由 memviz_snapshot 清零并填写基本布局的快照。
+ *
+ * 本函数不调用 walkaddr()、cow_alloc() 或 mmap_fault()，因此不会分配物理页、
+ * 修改 PTE、复制 COW 页或读取 mmap 文件内容。
+ */
+static void
+fill_user_page_states(struct proc *p, struct memviz_snapshot *snapshot)
+{
+  initialize_dynamic_cells(snapshot);
+  if(snapshot->dynamic_page_count == 0)
+    return;
+  overlay_vma_ranges(p, snapshot);
+  scan_dynamic_leaves(p, snapshot, p->pagetable, 2, 0);
+  finish_dynamic_totals(snapshot);
+}
+
+/**
  * sys_memsnapshot 将当前进程可观察到的内存状态复制到用户空间。
  *
  * 系统调用参数 0 为 MEMVIZ_VIEW_*，参数 1 为用户态输出结构体地址。
@@ -165,6 +419,7 @@ sys_memsnapshot(void)
 
   struct proc *p = myproc();
   fill_user_top_snapshot(p, &memvizsys_snapshot);
+  fill_user_page_states(p, &memvizsys_snapshot);
   if(copyout(p->pagetable, address, (char *)&memvizsys_snapshot,
              sizeof(memvizsys_snapshot)) < 0){
     release(&memvizsys_lock);

--- a/tests/guest/memviztest.c
+++ b/tests/guest/memviztest.c
@@ -2,6 +2,7 @@
 #include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/riscv.h"
+#include "kernel/fcntl.h"
 #include "kernel/memviz.h"
 #include "user/user.h"
 
@@ -10,11 +11,7 @@ static struct memviz_snapshot after_alloc;
 static struct memviz_snapshot after_free;
 static char render_output[32768];
 
-/**
- * fail 输出失败原因并以非零状态终止测试。
- *
- * @param message 稳定的失败描述。
- */
+/** 输出失败原因并以非零状态终止测试。 */
 static void
 fail(char *message)
 {
@@ -23,7 +20,7 @@ fail(char *message)
 }
 
 /**
- * text_contains 判断完整输出中是否包含指定稳定片段。
+ * 判断完整输出中是否包含指定稳定片段。
  *
  * @param text 以 NUL 结尾的完整输出。
  * @param pattern 非空匹配片段。
@@ -43,15 +40,11 @@ text_contains(char *text, char *pattern)
 }
 
 /**
- * cell_page_count 返回按 memviz 等比例压缩规则落入指定 cell 的页数。
+ * 返回按 memviz 等比例压缩规则落入指定物理 cell 的页数。
  *
  * @param total_pages kalloc 管理的物理页总数。
- * @param cell 目标 cell 下标，范围为 [0, MEMVIZ_CELLS)。
+ * @param cell 目标 cell 下标。
  * @return 该 cell 覆盖的连续物理页数量。
- *
- * 使用两个向上取整边界直接计算区间长度，避免在 2 GiB 配置下让每个
- * cell 再遍历全部物理页。该公式与内核中的 floor(page*cells/total) 分桶
- * 完全等价，但复杂度从 O(total_pages*cells) 降为 O(cells)。
  */
 static uint64
 cell_page_count(uint64 total_pages, int cell)
@@ -64,8 +57,101 @@ cell_page_count(uint64 total_pages, int cell)
 }
 
 /**
- * test_user_snapshot 验证用户栈、顶端固定页和物理计数的基本不变量。
+ * 校验动态页状态单元、全局计数和逻辑页总数相互一致。
+ *
+ * @param snapshot 已由 MEMVIZ_VIEW_USER 取得的快照。
  */
+static void
+check_dynamic_state_totals(struct memviz_snapshot *snapshot)
+{
+  if(snapshot->dynamic_state_cell_count > MEMVIZ_USER_STATE_CELLS)
+    fail("dynamic state cell count");
+  if(snapshot->dynamic_page_count == 0 &&
+     snapshot->dynamic_state_cell_count != 0)
+    fail("empty dynamic state keeps cells");
+  if(snapshot->dynamic_page_count > 0 &&
+     snapshot->dynamic_state_cell_count == 0)
+    fail("dynamic state cells missing");
+
+  uint64 total = 0;
+  uint64 resident = 0;
+  uint64 cow = 0;
+  uint64 lazy = 0;
+  uint64 mmap_pages = 0;
+  for(int i = 0; i < (int)snapshot->dynamic_state_cell_count; i++){
+    struct memviz_user_state_cell *cell = &snapshot->dynamic_state[i];
+    uint64 classified = cell->resident_pages + cell->cow_pages +
+                        cell->lazy_pages + cell->mmap_pages;
+    if(classified != cell->total_pages)
+      fail("dynamic cell classification");
+    total += cell->total_pages;
+    resident += cell->resident_pages;
+    cow += cell->cow_pages;
+    lazy += cell->lazy_pages;
+    mmap_pages += cell->mmap_pages;
+  }
+
+  if(total != snapshot->dynamic_page_count)
+    fail("dynamic cell page total");
+  if(resident != snapshot->dynamic_resident_pages ||
+     cow != snapshot->dynamic_cow_pages ||
+     lazy != snapshot->dynamic_lazy_pages ||
+     mmap_pages != snapshot->dynamic_mmap_pages)
+    fail("dynamic global state totals");
+  if(resident + cow + lazy + mmap_pages != snapshot->dynamic_page_count)
+    fail("dynamic state partition");
+}
+
+/**
+ * 执行真实 memviz user 命令并捕获其 stdout。
+ *
+ * @param plain 非零时传入 --plain。
+ * @return 捕获字节数；执行失败时直接终止测试。
+ */
+static int
+capture_user_render(int plain)
+{
+  int fds[2];
+  if(pipe(fds) < 0)
+    fail("render pipe");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("render fork");
+  if(pid == 0){
+    close(fds[0]);
+    close(1);
+    if(dup(fds[1]) != 1)
+      exit(1);
+    close(fds[1]);
+
+    char *plain_argv[] = { "memviz", "user", "--plain", 0 };
+    char *color_argv[] = { "memviz", "user", 0 };
+    exec("memviz", plain ? plain_argv : color_argv);
+    exit(1);
+  }
+
+  close(fds[1]);
+  int total = 0;
+  while(total < (int)sizeof(render_output) - 1){
+    int count = read(fds[0], render_output + total,
+                     sizeof(render_output) - 1 - total);
+    if(count < 0)
+      fail("render read");
+    if(count == 0)
+      break;
+    total += count;
+  }
+  close(fds[0]);
+  render_output[total] = 0;
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("memviz user execution");
+  return total;
+}
+
+/** 验证用户栈、顶端固定页、动态状态和物理计数的基本不变量。 */
 static void
 test_user_snapshot(void)
 {
@@ -134,63 +220,18 @@ test_user_snapshot(void)
     fail("process size below dynamic start");
   if(before.process_size > before.user_limit)
     fail("process size above user limit");
-  if(before.process_size == before.dynamic_start){
-    uint64 dynamic_pages = 0;
-    if(dynamic_pages != 0)
-      fail("empty dynamic extent accounting");
-  }
+  check_dynamic_state_totals(&before);
   if(before.free_pages + before.used_pages != before.total_pages)
     fail("physical total in user view");
 
   printf("memviztest: user invariants OK\n");
 }
 
-/**
- * test_user_render 黑盒验证增强字符图确实显示固定页、物理页和比例断裂。
- *
- * 子进程通过 pipe 重定向 stdout 后 exec 真实 memviz 命令；父进程只断言稳定
- * 教学标签，不复制 renderer 的地址或布局计算。
- */
+/** 验证增强字符图、纯文本降级和三种 ANSI 点颜色。 */
 static void
 test_user_render(void)
 {
-  int fds[2];
-  if(pipe(fds) < 0)
-    fail("render pipe");
-
-  int pid = fork();
-  if(pid < 0)
-    fail("render fork");
-  if(pid == 0){
-    close(fds[0]);
-    close(1);
-    if(dup(fds[1]) != 1)
-      exit(1);
-    close(fds[1]);
-
-    char *argv[] = { "memviz", "user", "--plain", 0 };
-    exec("memviz", argv);
-    exit(1);
-  }
-
-  close(fds[1]);
-  int total = 0;
-  while(total < (int)sizeof(render_output) - 1){
-    int count = read(fds[0], render_output + total,
-                     sizeof(render_output) - 1 - total);
-    if(count < 0)
-      fail("render read");
-    if(count == 0)
-      break;
-    total += count;
-  }
-  close(fds[0]);
-  render_output[total] = 0;
-
-  int status = -1;
-  if(wait(&status) != pid || status != 0)
-    fail("memviz user execution");
-
+  capture_user_render(1);
   if(!text_contains(render_output, "MAXVA"))
     fail("render MAXVA missing");
   if(!text_contains(render_output, "TRAMPOLINE / supervisor-only RX"))
@@ -201,51 +242,126 @@ test_user_render(void)
     fail("render address gap break missing");
   if(!text_contains(render_output, "not drawn to scale"))
     fail("render scale warning missing");
+  if(!text_contains(render_output, "DYNAMIC EXTENT / page states"))
+    fail("render dynamic states missing");
+  if(!text_contains(render_output, "# resident") ||
+     !text_contains(render_output, "C COW") ||
+     !text_contains(render_output, "L lazy") ||
+     !text_contains(render_output, "M mmap"))
+    fail("plain dynamic legend missing");
   if(!text_contains(render_output, "TRAMPOLINE PAGE DETAIL"))
     fail("render trampoline detail missing");
   if(!text_contains(render_output, "TRAPFRAME PAGE MEMBER ORDER"))
     fail("render trapframe detail missing");
-  if(!text_contains(render_output, "PA page:"))
-    fail("render physical page range missing");
   if(!text_contains(render_output, "name=kernel_satp") ||
      !text_contains(render_output, "name=t6"))
     fail("render trapframe member boundaries missing");
+
+  capture_user_render(0);
+  if(!text_contains(render_output, "\033[33m.\033[0m"))
+    fail("COW yellow point missing");
+  if(!text_contains(render_output, "\033[34m.\033[0m"))
+    fail("lazy blue point missing");
+  if(!text_contains(render_output, "\033[38;5;208m.\033[0m"))
+    fail("mmap orange point missing");
 
   printf("memviztest: user renderer OK\n");
 }
 
 /**
- * test_dynamic_extent 验证 sbrk 后 p->sz 从 dynamic_start 向高地址增长。
+ * 验证 lazy 未触页、普通驻留、mmap 区域和 fork 后 COW 的分类优先级。
  */
 static void
-test_dynamic_extent(void)
+test_dynamic_page_states(void)
 {
   const int pages = 2;
   if(memsnapshot(MEMVIZ_VIEW_USER, &before) < 0)
-    fail("dynamic baseline snapshot");
+    fail("page-state baseline snapshot");
+  check_dynamic_state_totals(&before);
 
   char *base = sbrk(pages * PGSIZE);
   if(base == (char *)-1)
-    fail("dynamic sbrk allocate");
-  for(int i = 0; i < pages; i++)
-    base[i * PGSIZE] = (char)i;
-
+    fail("lazy sbrk allocate");
   if(memsnapshot(MEMVIZ_VIEW_USER, &after_alloc) < 0)
-    fail("dynamic allocated snapshot");
-  if(after_alloc.process_size <= after_alloc.dynamic_start)
-    fail("dynamic extent did not grow upward");
-  if((after_alloc.process_size - after_alloc.dynamic_start) / PGSIZE < pages)
-    fail("dynamic extent page count");
+    fail("lazy snapshot");
+  check_dynamic_state_totals(&after_alloc);
+  if(after_alloc.dynamic_page_count != before.dynamic_page_count + pages)
+    fail("lazy page count");
+  if(after_alloc.dynamic_lazy_pages != before.dynamic_lazy_pages + pages)
+    fail("untouched sbrk pages are not lazy");
+
+  base[0] = 7;
+  if(memsnapshot(MEMVIZ_VIEW_USER, &after_free) < 0)
+    fail("resident snapshot");
+  check_dynamic_state_totals(&after_free);
+  if(after_free.dynamic_resident_pages !=
+     after_alloc.dynamic_resident_pages + 1)
+    fail("touched lazy page not resident");
+  if(after_free.dynamic_lazy_pages + 1 != after_alloc.dynamic_lazy_pages)
+    fail("touched lazy count did not decrease");
 
   if(sbrk(-pages * PGSIZE) == (char *)-1)
-    fail("dynamic sbrk release");
+    fail("lazy sbrk release");
 
-  printf("memviztest: dynamic extent OK\n");
+  char *path = "memviz-state-file";
+  int fd = open(path, O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("mmap test open");
+  if(write(fd, "x", 1) != 1)
+    fail("mmap test write");
+
+  char *mapped = mmap(0, pages * PGSIZE, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE, fd, 0);
+  if(mapped == (char *)-1)
+    fail("mmap page-state map");
+  if(memsnapshot(MEMVIZ_VIEW_USER, &after_alloc) < 0)
+    fail("untouched mmap snapshot");
+  check_dynamic_state_totals(&after_alloc);
+  if(after_alloc.dynamic_mmap_pages != before.dynamic_mmap_pages + pages)
+    fail("untouched mmap pages not orange class");
+
+  mapped[0] ^= 1;
+  if(memsnapshot(MEMVIZ_VIEW_USER, &after_free) < 0)
+    fail("resident mmap snapshot");
+  check_dynamic_state_totals(&after_free);
+  if(after_free.dynamic_mmap_pages != before.dynamic_mmap_pages + pages)
+    fail("resident mmap page lost mmap class");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("page-state fork");
+  if(pid == 0){
+    if(memsnapshot(MEMVIZ_VIEW_USER, &before) < 0)
+      exit(1);
+    check_dynamic_state_totals(&before);
+    if(before.dynamic_cow_pages < 1)
+      exit(1);
+    if(before.dynamic_mmap_pages < 1)
+      exit(1);
+    exit(0);
+  }
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("child COW state");
+  if(memsnapshot(MEMVIZ_VIEW_USER, &after_free) < 0)
+    fail("parent COW snapshot");
+  check_dynamic_state_totals(&after_free);
+  if(after_free.dynamic_cow_pages < 1)
+    fail("parent mmap leaf not promoted to COW");
+  if(after_free.dynamic_mmap_pages < 1)
+    fail("untouched mmap page missing after fork");
+
+  if(munmap(mapped, pages * PGSIZE) < 0)
+    fail("mmap page-state unmap");
+  close(fd);
+  if(unlink(path) < 0)
+    fail("mmap test unlink");
+
+  printf("memviztest: dynamic page states OK\n");
 }
 
-/**
- * test_physical_snapshot 验证 cell、CPU freelist 与全局页数相互一致。
- */
+/** 验证 cell、CPU freelist 与全局页数相互一致。 */
 static void
 test_physical_snapshot(void)
 {
@@ -257,15 +373,6 @@ test_physical_snapshot(void)
   for(int i = 0; i < MEMVIZ_CELLS; i++){
     if(before.physical[i].free_pages > before.physical[i].total_pages)
       fail("cell free exceeds total");
-    char state;
-    if(before.physical[i].free_pages == 0)
-      state = '#';
-    else if(before.physical[i].free_pages == before.physical[i].total_pages)
-      state = '.';
-    else
-      state = ':';
-    if(state != '#' && state != '.' && state != ':')
-      fail("invalid cell state");
     cell_total += before.physical[i].total_pages;
     cell_free += before.physical[i].free_pages;
   }
@@ -293,9 +400,7 @@ test_physical_snapshot(void)
   printf("memviztest: physical invariants OK\n");
 }
 
-/**
- * test_allocate_and_release 验证触页会消耗物理页，缩容后页面会归还 kalloc。
- */
+/** 验证触页会消耗物理页，缩容后页面会归还 kalloc。 */
 static void
 test_allocate_and_release(void)
 {
@@ -324,9 +429,7 @@ test_allocate_and_release(void)
   printf("memviztest: allocate/release OK\n");
 }
 
-/**
- * test_kernel_snapshot 验证当前内核栈、MMIO 和用户别名窗口可观察。
- */
+/** 验证当前内核栈、MMIO 和用户别名窗口可观察。 */
 static void
 test_kernel_snapshot(void)
 {
@@ -350,9 +453,7 @@ test_kernel_snapshot(void)
   printf("memviztest: kernel invariants OK\n");
 }
 
-/**
- * test_pagetable_snapshot 验证页表观察条目能连接用户 VA、别名 VA、PA 和 kalloc 池。
- */
+/** 验证页表观察条目能连接用户 VA、别名 VA、PA 和 kalloc 池。 */
 static void
 test_pagetable_snapshot(void)
 {
@@ -458,18 +559,14 @@ test_pagetable_snapshot(void)
   printf("memviztest: pagetable invariants OK\n");
 }
 
-/**
- * run_named 运行一个具名检查，便于 CI 将失败定位到单一不变量组。
- *
- * @param name user、phys、alloc、kernel 或 pagetable。
- * @return 名称有效返回 0，否则返回 -1。
- */
+/** 运行一个具名检查，便于 CI 将失败定位到单一不变量组。 */
 static int
 run_named(char *name)
 {
   if(strcmp(name, "user") == 0){
     test_user_snapshot();
     test_user_render();
+    test_dynamic_page_states();
   } else if(strcmp(name, "phys") == 0)
     test_physical_snapshot();
   else if(strcmp(name, "alloc") == 0)
@@ -484,7 +581,7 @@ run_named(char *name)
 }
 
 /**
- * main 默认运行完整测试；传入一个名称时只运行对应检查。
+ * 默认运行完整测试；传入一个名称时只运行对应检查。
  *
  * @param argc 参数数量。
  * @param argv 可选具名检查。
@@ -496,7 +593,7 @@ main(int argc, char **argv)
   if(argc == 1){
     test_user_snapshot();
     test_user_render();
-    test_dynamic_extent();
+    test_dynamic_page_states();
     test_physical_snapshot();
     test_allocate_and_release();
     test_kernel_snapshot();

--- a/user/memviz.c
+++ b/user/memviz.c
@@ -8,11 +8,16 @@
 #define ANSI_RED "\033[31m"
 #define ANSI_GREEN "\033[32m"
 #define ANSI_YELLOW "\033[33m"
+#define ANSI_BLUE "\033[34m"
 #define ANSI_CYAN "\033[36m"
+#define ANSI_ORANGE "\033[38;5;208m"
 #define ANSI_RESET "\033[0m"
 
 #define USER_BAR_CELLS 32
 #define USER_GAP_BREAK_MIN_PAGES 16
+
+_Static_assert(USER_BAR_CELLS == MEMVIZ_USER_STATE_CELLS,
+               "user renderer width must match snapshot cells");
 
 // 使用静态缓冲，避免扩展后的快照占满固定一页用户栈。
 static struct memviz_snapshot user_snapshot;
@@ -26,9 +31,14 @@ static char *trapframe_slot_names[MEMVIZ_TRAPFRAME_SLOT_COUNT] = {
   "t3", "t4", "t5", "t6",
 };
 
-/**
- * usage 输出 memviz 支持的视图和纯文本选项。
- */
+enum dynamic_display_kind {
+  DYNAMIC_RESIDENT = 1,
+  DYNAMIC_LAZY = 2,
+  DYNAMIC_MMAP = 3,
+  DYNAMIC_COW = 4,
+};
+
+/** 输出 memviz 支持的视图和纯文本选项。 */
 static void
 usage(void)
 {
@@ -36,7 +46,7 @@ usage(void)
 }
 
 /**
- * string_length 返回以 NUL 结尾字符串的字节数。
+ * 返回以 NUL 结尾字符串的字节数。
  *
  * @param text 非空字符串。
  * @return 不包含结尾 NUL 的字节数。
@@ -51,7 +61,7 @@ string_length(char *text)
 }
 
 /**
- * print_glyph 输出一个可选 ANSI 颜色的单字节字符。
+ * 输出一个可选 ANSI 颜色的单字节字符。
  *
  * @param glyph 要输出的字符。
  * @param color ANSI 颜色前缀。
@@ -66,23 +76,14 @@ print_glyph(char glyph, char *color, int plain)
     printf("%s%c%s", color, glyph, ANSI_RESET);
 }
 
-/**
- * print_line 输出带真实地址的字符图边界线。
- *
- * @param address 边界虚拟地址。
- * @param mark 边界标签与横线。
- */
+/** 输出带真实地址的字符图边界线。 */
 static void
 print_line(uint64 address, char *mark)
 {
   printf("%p %s\n", address, mark);
 }
 
-/**
- * print_box_text 输出地址空间框内的一行文本并补齐右边界。
- *
- * @param text 最长 34 字节的静态标签。
- */
+/** 输出地址空间框内的一行文本并补齐右边界。 */
 static void
 print_box_text(char *text)
 {
@@ -94,7 +95,7 @@ print_box_text(char *text)
 }
 
 /**
- * scaled_cells 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
+ * 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
  *
  * @param used 已使用字节或页数。
  * @param total 总字节或总页数。
@@ -112,14 +113,7 @@ scaled_cells(uint64 used, uint64 total, int cells)
   return (int)result;
 }
 
-/**
- * print_box_bar 输出低偏移到高偏移方向的页内用量条。
- *
- * @param used_cells 已使用字符数。
- * @param used 已使用区域字符。
- * @param free 未使用区域字符。
- * @param plain 非零时禁用 ANSI 颜色。
- */
+/** 输出低偏移到高偏移方向的页内用量条。 */
 static void
 print_box_bar(int used_cells, char used, char free, int plain)
 {
@@ -133,12 +127,7 @@ print_box_bar(int used_cells, char used, char free, int plain)
   printf("] |\n");
 }
 
-/**
- * print_box_reverse_bar 输出高地址侧已使用的向下增长栈用量条。
- *
- * @param used_cells 已使用字符数。
- * @param plain 非零时禁用 ANSI 颜色。
- */
+/** 输出高地址侧已使用的向下增长栈用量条。 */
 static void
 print_box_reverse_bar(int used_cells, int plain)
 {
@@ -152,11 +141,7 @@ print_box_reverse_bar(int used_cells, int plain)
   printf("] |\n");
 }
 
-/**
- * print_pte_flags 输出教学相关的 RISC-V PTE 权限位。
- *
- * @param flags PTE 低十位 flags。
- */
+/** 输出教学相关的 RISC-V PTE 权限位。 */
 static void
 print_pte_flags(uint64 flags)
 {
@@ -169,26 +154,7 @@ print_pte_flags(uint64 flags)
          (flags & PTE_COW) ? 'C' : '-');
 }
 
-/**
- * dynamic_pages 计算动态起点到 p->sz 已覆盖的页数。
- *
- * @param state 当前内存快照。
- * @return 动态区域向上取整后的页数。
- */
-static uint64
-dynamic_pages(struct memviz_snapshot *state)
-{
-  if(state->process_size <= state->dynamic_start)
-    return 0;
-  return (state->process_size - state->dynamic_start + PGSIZE - 1) / PGSIZE;
-}
-
-/**
- * remaining_pages 计算 p->sz 到 USERMAX 之间仍未使用的整页数。
- *
- * @param state 当前内存快照。
- * @return 普通用户 VA 的剩余整页数。
- */
+/** 计算 p->sz 到 USERMAX 之间仍未使用的整页数。 */
 static uint64
 remaining_pages(struct memviz_snapshot *state)
 {
@@ -198,12 +164,9 @@ remaining_pages(struct memviz_snapshot *state)
 }
 
 /**
- * print_user_gap 用明显的断裂线表现 p->sz 到 USERMAX 的巨大地址跨度。
+ * 用明显的断裂线表现 p->sz 到 USERMAX 的巨大地址跨度。
  *
  * @param state 当前内存快照。
- *
- * 小于阈值时保留紧凑布局；超过阈值时增加纵向留白、断裂符号和
- * not-drawn-to-scale 提示，避免字符图暗示上下边界物理相邻。
  */
 static void
 print_user_gap(struct memviz_snapshot *state)
@@ -227,10 +190,77 @@ print_user_gap(struct memviz_snapshot *state)
 }
 
 /**
- * print_trampoline_details 展示 trampoline 页的 VA、PA、权限和代码顺序。
+ * 返回压缩单元应显示的主状态。
+ *
+ * @param cell 一个连续动态页范围的精确分类计数。
+ * @return DYNAMIC_* 显示类型。
+ *
+ * 单元只覆盖一页时结果即该页状态。压缩单元混合多种状态时选择页数最多者；
+ * 数量相同按 COW > mmap > lazy > resident 决定，使高语义状态不会在平局中消失。
+ */
+static int
+dynamic_cell_kind(struct memviz_user_state_cell *cell)
+{
+  int kind = DYNAMIC_RESIDENT;
+  uint best = cell->resident_pages;
+  if(cell->lazy_pages >= best){
+    kind = DYNAMIC_LAZY;
+    best = cell->lazy_pages;
+  }
+  if(cell->mmap_pages >= best){
+    kind = DYNAMIC_MMAP;
+    best = cell->mmap_pages;
+  }
+  if(cell->cow_pages >= best)
+    kind = DYNAMIC_COW;
+  return kind;
+}
+
+/**
+ * 输出动态逻辑范围的页状态条。
  *
  * @param state 当前内存快照。
+ * @param plain 非零时用 #/C/L/M 替代颜色。
  */
+static void
+print_dynamic_state_bar(struct memviz_snapshot *state, int plain)
+{
+  printf("           | [");
+  for(int index = 0; index < USER_BAR_CELLS; index++){
+    if(index >= (int)state->dynamic_state_cell_count){
+      printf(" ");
+      continue;
+    }
+
+    int kind = dynamic_cell_kind(&state->dynamic_state[index]);
+    if(kind == DYNAMIC_COW)
+      print_glyph(plain ? 'C' : '.', ANSI_YELLOW, plain);
+    else if(kind == DYNAMIC_LAZY)
+      print_glyph(plain ? 'L' : '.', ANSI_BLUE, plain);
+    else if(kind == DYNAMIC_MMAP)
+      print_glyph(plain ? 'M' : '.', ANSI_ORANGE, plain);
+    else
+      print_glyph('#', ANSI_RED, plain);
+  }
+  printf("] |\n");
+}
+
+/** 输出动态页状态图例；正常模式中的三类特殊状态都使用彩色点。 */
+static void
+print_dynamic_legend(int plain)
+{
+  printf("           | legend: ");
+  print_glyph('#', ANSI_RED, plain);
+  printf(" resident ");
+  print_glyph(plain ? 'C' : '.', ANSI_YELLOW, plain);
+  printf(" COW ");
+  print_glyph(plain ? 'L' : '.', ANSI_BLUE, plain);
+  printf(" lazy ");
+  print_glyph(plain ? 'M' : '.', ANSI_ORANGE, plain);
+  printf(" mmap\n");
+}
+
+/** 展示 trampoline 页的 VA、PA、权限和代码顺序。 */
 static void
 print_trampoline_details(struct memviz_snapshot *state)
 {
@@ -266,14 +296,7 @@ print_trampoline_details(struct memviz_snapshot *state)
          state->trampoline_pa + PGSIZE);
 }
 
-/**
- * print_trapframe_details 按真实 ABI 顺序展开 trapframe 页内全部成员。
- *
- * @param state 当前内存快照。
- *
- * 每个槽位同时展示页内 offset、对应 VA、对应 PA 和 memsnapshot 系统调用
- * 入口时保存的值；该值不是任意时刻的实时寄存器。
- */
+/** 按真实 ABI 顺序展开 trapframe 页内全部成员。 */
 static void
 print_trapframe_details(struct memviz_snapshot *state)
 {
@@ -311,9 +334,9 @@ print_trapframe_details(struct memviz_snapshot *state)
 }
 
 /**
- * print_user_view 输出包含顶端固定页、巨大 VA 空洞和低地址进程区域的完整视图。
+ * 输出包含固定页、动态页状态、巨大 VA 空洞和低地址进程区域的完整视图。
  *
- * @param plain 非零时禁用 ANSI 颜色。
+ * @param plain 非零时禁用 ANSI 颜色并使用 #/C/L/M 状态字符。
  * @return 采样成功返回 0，系统调用失败返回 -1。
  */
 static int
@@ -322,10 +345,6 @@ print_user_view(int plain)
   if(memsnapshot(MEMVIZ_VIEW_USER, &user_snapshot) < 0)
     return -1;
 
-  uint64 used_pages = dynamic_pages(&user_snapshot);
-  int dynamic_cells = scaled_cells(used_pages,
-                                   remaining_pages(&user_snapshot) + used_pages,
-                                   USER_BAR_CELLS);
   int trampoline_cells = scaled_cells(user_snapshot.trampoline_used,
                                       PGSIZE, USER_BAR_CELLS);
   int trapframe_cells = scaled_cells(user_snapshot.trapframe_used,
@@ -346,9 +365,17 @@ print_user_view(int plain)
 
   print_user_gap(&user_snapshot);
   print_line(user_snapshot.process_size, "+--------------- p->sz ----------------+");
-  print_box_text("DYNAMIC EXTENT");
-  print_box_bar(dynamic_cells, '#', '.', plain);
-  printf("           | pages=%d\n", (int)used_pages);
+  print_box_text("DYNAMIC EXTENT / page states");
+  print_dynamic_state_bar(&user_snapshot, plain);
+  printf("           | pages=%d resident=%d cow=%d\n",
+         (int)user_snapshot.dynamic_page_count,
+         (int)user_snapshot.dynamic_resident_pages,
+         (int)user_snapshot.dynamic_cow_pages);
+  printf("           | lazy=%d mmap=%d cells=%d\n",
+         (int)user_snapshot.dynamic_lazy_pages,
+         (int)user_snapshot.dynamic_mmap_pages,
+         (int)user_snapshot.dynamic_state_cell_count);
+  print_dynamic_legend(plain);
   print_line(user_snapshot.dynamic_start, "+----------- dynamic start ------------+");
 
   if(user_snapshot.user_stack_valid){
@@ -391,7 +418,12 @@ print_user_view(int plain)
          user_snapshot.user_limit - user_snapshot.process_size);
   printf("  stack: used=%d free=%d\n",
          (int)user_snapshot.stack_used, (int)user_snapshot.stack_free);
-  printf("  dynamic pages: %d\n", (int)used_pages);
+  printf("  dynamic: pages=%d resident=%d cow=%d lazy=%d mmap=%d\n",
+         (int)user_snapshot.dynamic_page_count,
+         (int)user_snapshot.dynamic_resident_pages,
+         (int)user_snapshot.dynamic_cow_pages,
+         (int)user_snapshot.dynamic_lazy_pages,
+         (int)user_snapshot.dynamic_mmap_pages);
   printf("  physical pages: free=%d used=%d total=%d\n",
          (int)user_snapshot.free_pages, (int)user_snapshot.used_pages,
          (int)user_snapshot.total_pages);
@@ -401,12 +433,7 @@ print_user_view(int plain)
   return 0;
 }
 
-/**
- * print_all_views 依次输出增强用户视图和其余已有视图。
- *
- * @param plain 非零时禁用 ANSI 颜色。
- * @return 全部视图成功返回 0；任一采样失败返回 -1。
- */
+/** 依次输出增强用户视图和其余已有视图。 */
 static int
 print_all_views(int plain)
 {
@@ -420,7 +447,7 @@ print_all_views(int plain)
 }
 
 /**
- * main 解析命令行并打印指定的当前进程内存视图。
+ * 解析命令行并打印指定的当前进程内存视图。
  *
  * @param argc 参数数量。
  * @param argv 参数数组；第一个位置参数必须是视图名。


### PR DESCRIPTION
将 main 的 #119 memviz lazy/COW/mmap 页状态可视化同步到 `concept/115-linux-directory-layout`。目录布局分支在 `tests/guest/memviztest.c` 上额外保留 `/usr/bin/memviz` 绝对路径执行语义。该 PR 仅用于更新功能分支基线，不合入 main。