### PR TITLE
fix: 优化命令不存在提示

### DIFF
--- a/tests/test_shell_diagnostics.py
+++ b/tests/test_shell_diagnostics.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证 Shell 命令不存在诊断的源码契约。"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHELL_SOURCE_PATH = REPO_ROOT / "user" / "sh.c"
+
+
+class ShellDiagnosticTests(unittest.TestCase):
+    """验证 PATH 搜索失败后的用户可见诊断及控制流顺序。"""
+
+    def test_missing_command_uses_quoted_command_not_found_message(self) -> None:
+        """命令不存在时必须用双引号包裹原始命令名。"""
+
+        source = SHELL_SOURCE_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            'fprintf(2, "\\\"%s\\\" command not found\\n", program);',
+            source,
+        )
+
+    def test_failure_exits_before_legacy_shell_core_diagnostic(self) -> None:
+        """PATH 候选耗尽后应在进入 shcore.inc 的旧失败输出前结束子进程。"""
+
+        source = SHELL_SOURCE_PATH.read_text(encoding="utf-8")
+        exec_position = source.index("execvpe(program, argv, shell_environment);")
+        message_position = source.index(
+            'fprintf(2, "\\\"%s\\\" command not found\\n", program);',
+            exec_position,
+        )
+        exit_position = source.index("exit(0);", message_position)
+        include_position = source.index('#include "user/shcore.inc"', exit_position)
+
+        self.assertLess(exec_position, message_position)
+        self.assertLess(message_position, exit_position)
+        self.assertLess(exit_position, include_position)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user/sh.c
+++ b/user/sh.c
@@ -32,14 +32,13 @@ shell_print_environment(void)
 }
 
 /**
- * 代替原 Shell 对 exec() 的直接调用，并保留失败返回语义。
+ * 在命令子进程中执行内置 env 或通过 PATH 搜索外部程序。
  *
  * @param program 用户输入的命令名或显式路径。
- * @param argv 解析后的参数数组。
- * @return PATH 中全部候选执行失败时返回 -1；成功后不返回。
+ * @param argv 解析后的空指针结尾参数数组。
  *
- * `env` 是当前教学 Shell 的只读内置工具，运行在命令子进程中。其他命令统一通过
- * execvpe() 搜索，内核 execve() 本身从不解释 PATH。
+ * 成功执行外部程序后当前进程镜像被替换；内置命令或全部候选执行失败时直接退出，
+ * 因此本函数不会返回调用方。内核 execve() 本身从不解释 PATH。
  */
 static int
 shell_exec(char *program, char **argv)
@@ -52,7 +51,12 @@ shell_exec(char *program, char **argv)
     shell_print_environment();
     exit(0);
   }
-  return execvpe(program, argv, shell_environment);
+
+  execvpe(program, argv, shell_environment);
+  // execvpe() 只会在显式路径或 PATH 中全部候选均执行失败后返回。这里直接终止命令
+  // 子进程，避免 shcore.inc 再输出旧的 `exec ... failed` 诊断。
+  fprintf(2, "\"%s\" command not found\n", program);
+  exit(0);
 }
 
 // 保持原 Shell 实现及其静态状态位于同一个翻译单元，使启动层可以在进入主循环前


### PR DESCRIPTION
## 改动

- 当 Shell 的显式路径或 `PATH` 候选全部执行失败时，输出：

  ```text
  "<command>" command not found
  ```

- 在 `user/sh.c` 的统一 `execvpe()` 包装层处理失败，避免继续落入 `shcore.inc` 的旧 `exec <command> failed` 诊断。
- 新增 host 单元测试，固定双引号格式及失败路径必须在旧诊断前结束命令子进程。

## 原因

当前 Shell 已通过 `execvpe()` 负责 `PATH` 搜索，但搜索失败后仍由原始 Shell 核心输出偏底层的 `exec %s failed`。本次只收敛用户可见提示，不修改内核 `execve()` 或 PATH 搜索策略。

## 基线

- `main@dc0631fabe0484705c46e399fdf64102e45166dd`
- 无关联 Issue：按小需求直接提交 PR。

## 验证

已实际运行新增测试：

```text
python3 -m unittest discover -s tests -p 'test_*.py' -v

Ran 2 tests in 0.000s
OK
```

上述命令在只包含本次相关文件的最小目录中执行。当前执行环境没有 `gh`、RISC-V 工具链，且无法联网 clone 完整仓库，因此未将 `make clean && make` 标记为本地通过；完整构建与仓库级回归以 GitHub Actions 结果为准。

## 用户影响

输入不存在的命令，例如：

```text
missing-command
```

预期诊断变为：

```text
"missing-command" command not found
```
