### PR TITLE
[Concept Lab] memviz 支持按 PID 观察与 memtarget 实验进程

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,11 +255,13 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_memviz\
+	$U/_memtarget\
 	$U/_schedviz\
 	$U/_varead\
 	$U/_vawrite\
 	$U/_vaprobe\
 	$U/_memviztest\
+	$U/_memtargettest\
 	$U/_pgtbltest\
 	$U/_vaaccesstest\
 	$U/_addresswindowtest\

--- a/kernel/memviz.c
+++ b/kernel/memviz.c
@@ -13,7 +13,7 @@ extern char end[];
 /**
  * 根据系统调用入口保存的 user SP 推导固定一页用户栈的边界。
  *
- * @param p 当前进程；调用期间其地址空间不会被其他进程替换。
+ * @param p 被观察进程；调用者负责保证其地址空间在采样期间保持稳定。
  * @param snapshot 待填写的快照，不接管其所有权。
  */
 static void
@@ -48,15 +48,15 @@ fill_user_layout(struct proc *p, struct memviz_snapshot *snapshot)
 }
 
 /**
- * 填写当前进程运行时使用的内核页表和固定映射边界。
+ * 填写被观察进程的内核页表和固定映射边界。
  *
- * @param p 当前进程；其 kstack 和 kpagetable 在进程回收前保持有效。
+ * @param p 被观察进程；外部目标必须处于非 RUNNING 状态并由 p->lock 稳定。
  * @param snapshot 待填写的快照，不接管其所有权。
  */
 static void
 fill_kernel_layout(struct proc *p, struct memviz_snapshot *snapshot)
 {
-  uint64 sp = r_sp();
+  uint64 sp = p == myproc() ? r_sp() : p->context.sp;
 
   snapshot->kernel_pagetable = (uint64)p->kpagetable;
   snapshot->kernel_sp = sp;
@@ -191,7 +191,7 @@ fill_pte_path(pagetable_t pagetable, uint64 va,
 /**
  * fill_pagetable_observations 采集从 VA 到 PA 的代表性映射闭环。
  *
- * @param p 当前进程；调用期间页表稳定，函数只读 walk() 查询结果。
+ * @param p 被观察进程；调用者保证页表稳定，函数只读 walk() 查询结果。
  * @param snapshot 待填写的快照；调用者已经清零并填好布局边界。
  *
  * 本视图不递归打印完整页表树，避免在普通 memviz 命令中输出成百上千行。
@@ -318,7 +318,7 @@ scan_pt_usage(struct memviz_snapshot *snapshot, int space, int level,
 /**
  * fill_pagetable_usage 采集用户页表和内核页表页的槽位余量。
  *
- * @param p 当前进程；函数只读 p->pagetable 和 p->kpagetable。
+ * @param p 被观察进程；函数只读 p->pagetable 和 p->kpagetable。
  * @param snapshot 待填写的快照。
  */
 static void
@@ -329,16 +329,18 @@ fill_pagetable_usage(struct proc *p, struct memviz_snapshot *snapshot)
 }
 
 /**
- * memviz_snapshot 采集指定视图所需的稳定内存快照。
+ * memviz_snapshot_proc 采集显式进程的稳定内存快照。
  *
+ * @param p 被观察进程；外部目标必须由调用者持有 p->lock 且不是 RUNNING。
  * @param view MEMVIZ_VIEW_* 之一。
  * @param snapshot 输出结构体，必须为可写的内核地址。
- * @return 成功返回 0；view 非法或参数为空时返回 -1。
+ * @return 成功返回 0；参数、进程资源或 view 非法时返回 -1。
  */
 int
-memviz_snapshot(int view, struct memviz_snapshot *snapshot)
+memviz_snapshot_proc(struct proc *p, int view, struct memviz_snapshot *snapshot)
 {
-  if(snapshot == 0)
+  if(p == 0 || snapshot == 0 || p->pagetable == 0 || p->kpagetable == 0 ||
+     p->trapframe == 0)
     return -1;
   if(view != MEMVIZ_VIEW_USER && view != MEMVIZ_VIEW_PHYS &&
      view != MEMVIZ_VIEW_KERNEL && view != MEMVIZ_VIEW_PAGETABLE)
@@ -346,8 +348,8 @@ memviz_snapshot(int view, struct memviz_snapshot *snapshot)
 
   memset(snapshot, 0, sizeof(*snapshot));
   snapshot->view = view;
+  snapshot->process_pid = p->pid;
 
-  struct proc *p = myproc();
   fill_user_layout(p, snapshot);
   fill_kernel_layout(p, snapshot);
   fill_pagetable_observations(p, snapshot);
@@ -356,6 +358,15 @@ memviz_snapshot(int view, struct memviz_snapshot *snapshot)
   // kalloc 负责在锁内完成 freelist 采样，返回前已经释放所有 allocator 锁。
   kalloc_mem_snapshot(snapshot);
   return 0;
+}
+
+/**
+ * memviz_snapshot 采集当前进程的内存快照，保持原系统调用兼容接口。
+ */
+int
+memviz_snapshot(int view, struct memviz_snapshot *snapshot)
+{
+  return memviz_snapshot_proc(myproc(), view, snapshot);
 }
 
 /**

--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -159,7 +159,7 @@ struct memviz_snapshot {
   int view;
   int user_stack_valid;
   int kernel_stack_valid;
-  int reserved;
+  int process_pid;
 
   uint64 process_size;
   uint64 user_limit;
@@ -241,9 +241,13 @@ struct memviz_snapshot {
   struct memviz_pt_usage_page pagetable_usage[MEMVIZ_PT_USAGE_PAGES];
 };
 
+struct proc;
+
 // 以下接口只由内核实现调用；用户态仅使用 memsnapshot() 系统调用。
 void kalloc_mem_snapshot(struct memviz_snapshot *snapshot);
 int memviz_snapshot(int view, struct memviz_snapshot *snapshot);
+int memviz_snapshot_proc(struct proc *p, int view,
+                         struct memviz_snapshot *snapshot);
 int memviz_query_user_va(uint64 va, struct memviz_va_query *query);
 
 #endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -131,6 +131,7 @@ extern uint64 sys_mmap(void);
 extern uint64 sys_munmap(void);
 extern uint64 sys_backtrace(void);
 extern uint64 sys_memsnapshot(void);
+extern uint64 sys_memsnapshot_pid(void);
 extern uint64 sys_vaquery(void);
 extern uint64 sys_waitpid(void);
 extern uint64 sys_consolemode(void);
@@ -179,6 +180,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_munmap]    sys_munmap,
 [SYS_backtrace] sys_backtrace,
 [SYS_memsnapshot] sys_memsnapshot,
+[SYS_memsnapshot_pid] sys_memsnapshot_pid,
 [SYS_vaquery] sys_vaquery,
 [SYS_waitpid] sys_waitpid,
 [SYS_consolemode] sys_consolemode,

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -48,3 +48,4 @@
 #define SYS_swapinfo         47
 #define SYS_concurrencylab   48
 #define SYS_fsinspect        49
+#define SYS_memsnapshot_pid  50

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -35,6 +35,7 @@ static const char *const syscall_names[] = {
 [SYS_munmap]    = "munmap",
 [SYS_backtrace] = "backtrace",
 [SYS_memsnapshot] = "memsnapshot",
+[SYS_memsnapshot_pid] = "memsnapshot_pid",
 [SYS_vaquery]    = "vaquery",
 [SYS_waitpid]    = "waitpid",
 [SYS_consolemode] = "consolemode",

--- a/kernel/sysmemviz.c
+++ b/kernel/sysmemviz.c
@@ -12,6 +12,7 @@ extern char trampoline[];
 extern char uservec[];
 extern char userret[];
 extern char trampoline_end[];
+extern struct proc proc[NPROC];
 
 _Static_assert(sizeof(struct trapframe) ==
                MEMVIZ_TRAPFRAME_SLOT_COUNT * sizeof(uint64),
@@ -84,7 +85,7 @@ ensure_memvizsys_lock(void)
 /**
  * fill_user_leaf_mapping 读取用户页表中一个固定页的叶子映射。
  *
- * @param pagetable 当前进程用户页表，只读访问。
+ * @param pagetable 被观察进程用户页表，只读访问。
  * @param va 要查询的页对齐虚拟地址。
  * @param pa 接收页对齐物理地址；未映射时写 0。
  * @param flags 接收 PTE 低十位 flags；未映射时写 0。
@@ -109,8 +110,8 @@ fill_user_leaf_mapping(pagetable_t pagetable, uint64 va,
 /**
  * fill_user_top_snapshot 补充用户页表顶端两个 supervisor-only 固定页。
  *
- * @param p 当前进程；调用期间页表、trapframe 与 trampoline 映射保持有效。
- * @param snapshot 已由 memviz_snapshot 填写的快照，函数在原地补充顶端布局。
+ * @param p 被观察进程；调用者保证页表、trapframe 与 trampoline 映射稳定。
+ * @param snapshot 已由 memviz_snapshot_proc 填写的快照，函数在原地补充顶端布局。
  *
  * TRAPFRAME 的 36 个连续 uint64 槽按真实 ABI 原样复制，使用户态 renderer
  * 能同时展示页内偏移、虚拟地址、物理地址和采样值。TRAMPOLINE 的代码范围
@@ -209,7 +210,7 @@ initialize_dynamic_cells(struct memviz_snapshot *snapshot)
 /**
  * overlay_vma_ranges 将活动 VMA 覆盖的逻辑页从 lazy 改记为 mmap。
  *
- * @param p 当前进程；函数只读 p->vma[] 和 VMA 边界。
+ * @param p 被观察进程；函数只读 p->vma[] 和 VMA 边界。
  * @param snapshot 已初始化动态压缩单元的快照。
  *
  * 这里只根据 VMA 元数据标记整段逻辑区域，不读取文件、不建立 PTE。后续扫描
@@ -264,7 +265,7 @@ overlay_vma_ranges(struct proc *p, struct memviz_snapshot *snapshot)
 /**
  * classify_dynamic_leaf 将一个有效 L0 用户叶子覆盖到对应动态压缩单元。
  *
- * @param p 当前进程，用于判断该 VA 是否仍属于活动 VMA。
+ * @param p 被观察进程，用于判断该 VA 是否仍属于活动 VMA。
  * @param snapshot 已完成默认 lazy 和 VMA 覆盖的快照。
  * @param va 页对齐用户虚拟地址。
  * @param pte 该地址的有效叶子 PTE。
@@ -310,7 +311,7 @@ classify_dynamic_leaf(struct proc *p, struct memviz_snapshot *snapshot,
 /**
  * scan_dynamic_leaves 只遍历与动态范围相交的有效页表子树。
  *
- * @param p 当前进程。
+ * @param p 被观察进程。
  * @param snapshot 动态页状态快照。
  * @param pagetable 当前页表页。
  * @param level 当前 Sv39 层级，根为 2、叶为 0。
@@ -374,8 +375,8 @@ finish_dynamic_totals(struct memviz_snapshot *snapshot)
 /**
  * fill_user_page_states 只读采集 dynamic_start 到 p->sz 的页级状态。
  *
- * @param p 当前进程；系统调用期间不会替换其页表或 VMA 数组。
- * @param snapshot 已由 memviz_snapshot 清零并填写基本布局的快照。
+ * @param p 被观察进程；调用者保证页表和 VMA 数组稳定。
+ * @param snapshot 已由 memviz_snapshot_proc 清零并填写基本布局的快照。
  *
  * 本函数不调用 walkaddr()、cow_alloc() 或 mmap_fault()，因此不会分配物理页、
  * 修改 PTE、复制 COW 页或读取 mmap 文件内容。
@@ -389,6 +390,25 @@ fill_user_page_states(struct proc *p, struct memviz_snapshot *snapshot)
   overlay_vma_ranges(p, snapshot);
   scan_dynamic_leaves(p, snapshot, p->pagetable, 2, 0);
   finish_dynamic_totals(snapshot);
+}
+
+/** 采集一个已稳定进程的完整 memviz 快照。 */
+static int
+fill_process_snapshot(struct proc *p, int view)
+{
+  if(memviz_snapshot_proc(p, view, &memvizsys_snapshot) < 0)
+    return -1;
+  fill_user_top_snapshot(p, &memvizsys_snapshot);
+  fill_user_page_states(p, &memvizsys_snapshot);
+  return 0;
+}
+
+/** 把静态快照复制到调用者地址空间；调用者必须持有 memvizsys_lock。 */
+static int
+copy_snapshot_to_caller(struct proc *caller, uint64 address)
+{
+  return copyout(caller->pagetable, address, (char *)&memvizsys_snapshot,
+                 sizeof(memvizsys_snapshot));
 }
 
 /**
@@ -412,16 +432,60 @@ sys_memsnapshot(void)
   ensure_memvizsys_lock();
   acquire(&memvizsys_lock);
 
-  if(memviz_snapshot(view, &memvizsys_snapshot) < 0){
+  struct proc *caller = myproc();
+  if(fill_process_snapshot(caller, view) < 0 ||
+     copy_snapshot_to_caller(caller, address) < 0){
     release(&memvizsys_lock);
     return -1;
   }
 
-  struct proc *p = myproc();
-  fill_user_top_snapshot(p, &memvizsys_snapshot);
-  fill_user_page_states(p, &memvizsys_snapshot);
-  if(copyout(p->pagetable, address, (char *)&memvizsys_snapshot,
-             sizeof(memvizsys_snapshot)) < 0){
+  release(&memvizsys_lock);
+  return 0;
+}
+
+/**
+ * sys_memsnapshot_pid 采集指定 PID 的稳定进程快照。
+ *
+ * 参数 0 为正 PID，参数 1 为 MEMVIZ_VIEW_*，参数 2 为调用者输出地址。当前
+ * 进程可直接采样；外部目标必须持有 p->lock 且处于非 RUNNING、非 UNUSED、
+ * 非 USED 状态。持锁期间 scheduler 无法选中 RUNNABLE 目标，wait() 也无法
+ * 回收 ZOMBIE 目标的页表和 trapframe。
+ *
+ * @return 成功返回 0；PID、状态、view、目标资源或 copyout 无效时返回 -1。
+ */
+uint64
+sys_memsnapshot_pid(void)
+{
+  int pid;
+  int view;
+  uint64 address;
+
+  if(argint(0, &pid) < 0 || argint(1, &view) < 0 ||
+     argaddr(2, &address) < 0 || pid <= 0)
+    return -1;
+
+  ensure_memvizsys_lock();
+  acquire(&memvizsys_lock);
+
+  struct proc *caller = myproc();
+  int result = -1;
+  if(pid == caller->pid){
+    result = fill_process_snapshot(caller, view);
+  } else {
+    for(struct proc *target = proc; target < &proc[NPROC]; target++){
+      acquire(&target->lock);
+      if(target->pid != pid || target->state == UNUSED){
+        release(&target->lock);
+        continue;
+      }
+      if(target->state != USED && target->state != RUNNING)
+        result = fill_process_snapshot(target, view);
+      release(&target->lock);
+      break;
+    }
+  }
+
+  if(result < 0 || copy_snapshot_to_caller(caller, address) < 0){
     release(&memvizsys_lock);
     return -1;
   }

--- a/tests/guest/memtargettest.c
+++ b/tests/guest/memtargettest.c
@@ -1,0 +1,266 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+#include "user/paths.h"
+
+static char output[32768];
+static struct memviz_snapshot baseline;
+static struct memviz_snapshot observed;
+
+/** 输出失败原因并以非零状态终止测试。 */
+static void
+fail(char *message)
+{
+  fprintf(2, "memtargettest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/** 判断完整输出中是否包含指定稳定片段。 */
+static int
+text_contains(char *text, char *pattern)
+{
+  for(int i = 0; text[i] != 0; i++){
+    int j = 0;
+    while(pattern[j] != 0 && text[i + j] == pattern[j])
+      j++;
+    if(pattern[j] == 0)
+      return 1;
+  }
+  return 0;
+}
+
+/** 将正整数 PID 写成十进制字符串。 */
+static void
+format_pid(int pid, char *buffer)
+{
+  char reversed[16];
+  int count = 0;
+
+  do {
+    reversed[count++] = '0' + pid % 10;
+    pid /= 10;
+  } while(pid > 0);
+  for(int i = 0; i < count; i++)
+    buffer[i] = reversed[count - 1 - i];
+  buffer[count] = 0;
+}
+
+/**
+ * 执行用户程序并捕获标准输出。
+ *
+ * @param path 镜像内绝对程序路径。
+ * @param argv 传给 exec() 的参数向量。
+ * @param quiet_stderr 非零时关闭子进程标准错误。
+ * @return 子进程退出状态。
+ */
+static int
+run_and_capture(char *path, char **argv, int quiet_stderr)
+{
+  int fds[2];
+  if(pipe(fds) < 0)
+    fail("capture pipe");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("capture fork");
+  if(pid == 0){
+    close(fds[0]);
+    close(1);
+    if(dup(fds[1]) != 1)
+      exit(1);
+    close(fds[1]);
+    if(quiet_stderr)
+      close(2);
+    exec(path, argv);
+    exit(1);
+  }
+
+  close(fds[1]);
+  int total = 0;
+  while(total < (int)sizeof(output) - 1){
+    int count = read(fds[0], output + total, sizeof(output) - 1 - total);
+    if(count < 0)
+      fail("capture read");
+    if(count == 0)
+      break;
+    total += count;
+  }
+  close(fds[0]);
+  output[total] = 0;
+
+  int status = -1;
+  if(wait(&status) != pid)
+    fail("capture wait");
+  return status;
+}
+
+/** 验证 memtarget 正常生命周期和参数错误都可靠传播退出状态。 */
+static void
+test_memtarget_cli(void)
+{
+  char *valid[] = {
+    XV6_USR_BIN_PATH("memtarget"), "2", "1", "--exit", 0
+  };
+  if(run_and_capture(valid[0], valid, 0) != 0)
+    fail("valid lifecycle exit status");
+  if(!text_contains(output, "memtarget: pid=") ||
+     !text_contains(output, "page=1/2 state=lazy") ||
+     !text_contains(output, "page=1/2 state=resident") ||
+     !text_contains(output, "page=2/2 state=lazy") ||
+     !text_contains(output, "page=2/2 state=resident") ||
+     !text_contains(output, "state=complete pages=2"))
+    fail("lifecycle output");
+
+  char *zero_pages[] = {
+    XV6_USR_BIN_PATH("memtarget"), "0", "1", "--exit", 0
+  };
+  if(run_and_capture(zero_pages[0], zero_pages, 1) == 0)
+    fail("zero pages accepted");
+
+  char *zero_interval[] = {
+    XV6_USR_BIN_PATH("memtarget"), "1", "0", "--exit", 0
+  };
+  if(run_and_capture(zero_interval[0], zero_interval, 1) == 0)
+    fail("zero interval accepted");
+
+  printf("memtargettest: helper lifecycle OK\n");
+}
+
+/**
+ * 创建一个扩展两页后阻塞在 pipe read 的稳定目标。
+ *
+ * @param ready 子进程写入一个字节表示地址空间已经准备完成。
+ * @param release_pipe 父进程写入一个字节后允许子进程退出。
+ * @return 父进程中返回目标 PID；子进程不返回。
+ */
+static int
+spawn_stable_target(int ready[2], int release_pipe[2])
+{
+  if(pipe(ready) < 0 || pipe(release_pipe) < 0)
+    fail("target pipes");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("target fork");
+  if(pid == 0){
+    close(ready[0]);
+    close(release_pipe[1]);
+
+    char *base = sbrk(2 * PGSIZE);
+    if(base == (char *)-1)
+      exit(1);
+    base[0] = 7;
+    if(write(ready[1], "R", 1) != 1)
+      exit(1);
+    close(ready[1]);
+
+    char token;
+    if(read(release_pipe[0], &token, 1) != 1)
+      exit(1);
+    close(release_pipe[0]);
+    exit(0);
+  }
+
+  close(ready[1]);
+  close(release_pipe[0]);
+  return pid;
+}
+
+/** 多核调度下短暂重试，直到目标进入允许稳定采样的非 RUNNING 状态。 */
+static int
+snapshot_pid_retry(int pid, int view, struct memviz_snapshot *snapshot)
+{
+  for(int attempt = 0; attempt < 100; attempt++){
+    if(memsnapshot_pid(pid, view, snapshot) == 0)
+      return 0;
+    sleep(1);
+  }
+  return -1;
+}
+
+/** 验证系统调用拒绝非法 PID，并保留显式观察当前进程的兼容路径。 */
+static void
+test_pid_arguments(void)
+{
+  if(memsnapshot_pid(0, MEMVIZ_VIEW_USER, &observed) != -1 ||
+     memsnapshot_pid(-1, MEMVIZ_VIEW_USER, &observed) != -1 ||
+     memsnapshot_pid(0x7fffffff, MEMVIZ_VIEW_USER, &observed) != -1)
+    fail("invalid target pid accepted");
+  if(memsnapshot_pid(getpid(), MEMVIZ_VIEW_USER, &observed) < 0 ||
+     observed.process_pid != getpid())
+    fail("explicit self snapshot");
+
+  printf("memtargettest: pid arguments OK\n");
+}
+
+/** 验证 sleeping 目标的 user/kernel/pagetable 快照、CLI 输出和回收边界。 */
+static void
+test_stable_target_observation(void)
+{
+  if(memsnapshot(MEMVIZ_VIEW_USER, &baseline) < 0)
+    fail("parent baseline");
+
+  int ready[2];
+  int release_pipe[2];
+  int pid = spawn_stable_target(ready, release_pipe);
+
+  char token;
+  if(read(ready[0], &token, 1) != 1)
+    fail("target ready");
+  close(ready[0]);
+
+  if(snapshot_pid_retry(pid, MEMVIZ_VIEW_USER, &observed) < 0)
+    fail("target user snapshot");
+  if(observed.process_pid != pid)
+    fail("target pid identity");
+  if(observed.process_size != baseline.process_size + 2 * PGSIZE)
+    fail("target process size");
+  if(observed.dynamic_page_count != baseline.dynamic_page_count + 2)
+    fail("target dynamic page count");
+  if(observed.dynamic_resident_pages < baseline.dynamic_resident_pages + 1)
+    fail("target resident page missing");
+  if(observed.dynamic_lazy_pages < baseline.dynamic_lazy_pages + 1)
+    fail("target lazy page missing");
+
+  if(snapshot_pid_retry(pid, MEMVIZ_VIEW_KERNEL, &observed) < 0 ||
+     observed.process_pid != pid || !observed.kernel_stack_valid)
+    fail("target kernel snapshot");
+  if(snapshot_pid_retry(pid, MEMVIZ_VIEW_PAGETABLE, &observed) < 0 ||
+     observed.process_pid != pid || observed.user_pagetable == 0)
+    fail("target pagetable snapshot");
+
+  char pid_text[16];
+  format_pid(pid, pid_text);
+  char *memviz_argv[] = {
+    XV6_USR_BIN_PATH("memviz"), "user", "--pid", pid_text, "--plain", 0
+  };
+  if(run_and_capture(memviz_argv[0], memviz_argv, 0) != 0)
+    fail("memviz pid execution");
+  if(!text_contains(output, "observed process pid=") ||
+     !text_contains(output, pid_text) ||
+     !text_contains(output, "DYNAMIC EXTENT / page states"))
+    fail("memviz pid output");
+
+  if(write(release_pipe[1], "X", 1) != 1)
+    fail("target release");
+  close(release_pipe[1]);
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("target exit");
+  if(memsnapshot_pid(pid, MEMVIZ_VIEW_USER, &observed) != -1)
+    fail("reaped target remains observable");
+
+  printf("memtargettest: stable target observation OK\n");
+}
+
+int
+main(void)
+{
+  test_memtarget_cli();
+  test_pid_arguments();
+  test_stable_target_observation();
+  printf("memtargettest: OK\n");
+  exit(0);
+}

--- a/tests/guest/memtargettest.c
+++ b/tests/guest/memtargettest.c
@@ -1,6 +1,7 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
 #include "kernel/riscv.h"
+#include "kernel/param.h"
 #include "kernel/memviz.h"
 #include "user/user.h"
 #include "user/paths.h"

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -30,6 +30,7 @@ static char *lab3_copyout_argv[] = {XV6_TEST_PATH("usertests"), "copyout", 0};
 static char *lab3_copyinstr_argv[] = {XV6_TEST_PATH("usertests"), "copyinstr1", 0};
 static char *lab3_sbrkmuch_argv[] = {XV6_TEST_PATH("usertests"), "sbrkmuch", 0};
 static char *lab3_memviz_argv[] = {XV6_TEST_PATH("memviztest"), 0};
+static char *lab3_memtarget_argv[] = {XV6_TEST_PATH("memtargettest"), 0};
 static char *lab3_pgtbl_argv[] = {XV6_TEST_PATH("pgtbltest"), 0};
 static char *lab3_vaaccess_argv[] = {XV6_TEST_PATH("vaaccesstest"), 0};
 static char *lab3_address_window_argv[] = {XV6_TEST_PATH("addresswindowtest"), 0};
@@ -89,6 +90,7 @@ static struct xv6_test_case tests[] = {
   {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv},
   {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv},
   {"lab3", "lab3-memviz", lab3_memviz_argv},
+  {"lab3", "lab3-memtarget", lab3_memtarget_argv},
   {"lab3", "lab3-pgtbl", lab3_pgtbl_argv},
   {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
   {"lab3", "lab3-address-window", lab3_address_window_argv},

--- a/user/init.c
+++ b/user/init.c
@@ -65,6 +65,7 @@ static struct image_file image_files[] = {
   {"/whereis", XV6_BIN_PATH("whereis")},
 
   {"/memviz", XV6_USR_BIN_PATH("memviz")},
+  {"/memtarget", XV6_USR_BIN_PATH("memtarget")},
   {"/schedviz", XV6_USR_BIN_PATH("schedviz")},
   {"/varead", XV6_USR_BIN_PATH("varead")},
   {"/vawrite", XV6_USR_BIN_PATH("vawrite")},
@@ -78,6 +79,7 @@ static struct image_file image_files[] = {
   {"/xv6test", XV6_USR_BIN_PATH("xv6test")},
 
   {"/memviztest", XV6_TEST_PATH("memviztest")},
+  {"/memtargettest", XV6_TEST_PATH("memtargettest")},
   {"/pgtbltest", XV6_TEST_PATH("pgtbltest")},
   {"/vaaccesstest", XV6_TEST_PATH("vaaccesstest")},
   {"/addresswindowtest", XV6_TEST_PATH("addresswindowtest")},

--- a/user/memtarget.c
+++ b/user/memtarget.c
@@ -1,0 +1,119 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "user/user.h"
+
+#define MEMTARGET_DEFAULT_PAGES 8
+#define MEMTARGET_DEFAULT_INTERVAL 10
+#define MEMTARGET_MAX_PAGES 64
+#define MEMTARGET_MAX_INTERVAL 100000
+
+/** 输出 memtarget 支持的页数、间隔和自动退出参数。 */
+static void
+usage(void)
+{
+  fprintf(2,
+          "usage: memtarget [pages [interval_ticks]] [--exit]\n");
+}
+
+/**
+ * 解析有上界的正十进制整数。
+ *
+ * @param text 待解析的 NUL 结尾字符串。
+ * @param maximum 允许的最大值。
+ * @param value 接收解析结果。
+ * @return 成功返回 0；空串、非数字、零、溢出或超过上界时返回 -1。
+ */
+static int
+parse_positive(char *text, int maximum, int *value)
+{
+  int parsed = 0;
+
+  if(text[0] == 0)
+    return -1;
+  for(char *cursor = text; *cursor != 0; cursor++){
+    if(*cursor < '0' || *cursor > '9')
+      return -1;
+    int digit = *cursor - '0';
+    if(parsed > (maximum - digit) / 10)
+      return -1;
+    parsed = parsed * 10 + digit;
+  }
+  if(parsed <= 0 || parsed > maximum)
+    return -1;
+
+  *value = parsed;
+  return 0;
+}
+
+/**
+ * 逐页扩展地址空间，并把每页从 lazy 状态转换为 resident 状态。
+ *
+ * 默认完成后持续 sleep，便于另一进程通过 `memviz --pid` 采样稳定目标；
+ * `--exit` 供自动化回归验证有限生命周期和资源回收。
+ */
+int
+main(int argc, char **argv)
+{
+  int pages = MEMTARGET_DEFAULT_PAGES;
+  int interval = MEMTARGET_DEFAULT_INTERVAL;
+  int exit_after_complete = 0;
+  int positional = 0;
+
+  for(int i = 1; i < argc; i++){
+    if(strcmp(argv[i], "--exit") == 0){
+      if(exit_after_complete){
+        usage();
+        exit(1);
+      }
+      exit_after_complete = 1;
+      continue;
+    }
+
+    if(positional == 0){
+      if(parse_positive(argv[i], MEMTARGET_MAX_PAGES, &pages) < 0){
+        usage();
+        exit(1);
+      }
+    } else if(positional == 1){
+      if(parse_positive(argv[i], MEMTARGET_MAX_INTERVAL, &interval) < 0){
+        usage();
+        exit(1);
+      }
+    } else {
+      usage();
+      exit(1);
+    }
+    positional++;
+  }
+
+  int pid = getpid();
+  printf("memtarget: pid=%d pages=%d interval_ticks=%d\n",
+         pid, pages, interval);
+
+  for(int index = 0; index < pages; index++){
+    char *page = sbrk(PGSIZE);
+    if(page == (char *)-1){
+      fprintf(2, "memtarget: sbrk failed at page %d\n", index + 1);
+      exit(1);
+    }
+
+    printf("memtarget: pid=%d page=%d/%d state=lazy va=%p\n",
+           pid, index + 1, pages, (uint64)page);
+    sleep(interval);
+
+    page[0] = (char)(index + 1);
+    printf("memtarget: pid=%d page=%d/%d state=resident va=%p value=%d\n",
+           pid, index + 1, pages, (uint64)page, page[0]);
+    sleep(interval);
+  }
+
+  printf("memtarget: pid=%d state=complete pages=%d\n", pid, pages);
+  if(exit_after_complete)
+    exit(0);
+
+  printf("memtarget: pid=%d state=holding; terminate with kill %d\n",
+         pid, pid);
+  for(;;)
+    sleep(1000);
+}

--- a/user/memviz.c
+++ b/user/memviz.c
@@ -38,19 +38,14 @@ enum dynamic_display_kind {
   DYNAMIC_COW = 4,
 };
 
-/** 输出 memviz 支持的视图和纯文本选项。 */
+/** 输出 memviz 支持的视图、PID 注入和纯文本选项。 */
 static void
 usage(void)
 {
-  fprintf(2, "usage: memviz <user|phys|kernel|pagetable|all> [filter] [--plain]\n");
+  fprintf(2,
+          "usage: memviz <user|phys|kernel|pagetable|all> [filter] [--pid pid] [--plain]\n");
 }
 
-/**
- * 返回以 NUL 结尾字符串的字节数。
- *
- * @param text 非空字符串。
- * @return 不包含结尾 NUL 的字节数。
- */
 static int
 string_length(char *text)
 {
@@ -60,13 +55,6 @@ string_length(char *text)
   return length;
 }
 
-/**
- * 输出一个可选 ANSI 颜色的单字节字符。
- *
- * @param glyph 要输出的字符。
- * @param color ANSI 颜色前缀。
- * @param plain 非零时禁止输出 ANSI 转义序列。
- */
 static void
 print_glyph(char glyph, char *color, int plain)
 {
@@ -76,14 +64,12 @@ print_glyph(char glyph, char *color, int plain)
     printf("%s%c%s", color, glyph, ANSI_RESET);
 }
 
-/** 输出带真实地址的字符图边界线。 */
 static void
 print_line(uint64 address, char *mark)
 {
   printf("%p %s\n", address, mark);
 }
 
-/** 输出地址空间框内的一行文本并补齐右边界。 */
 static void
 print_box_text(char *text)
 {
@@ -94,14 +80,6 @@ print_box_text(char *text)
   printf(" |\n");
 }
 
-/**
- * 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
- *
- * @param used 已使用字节或页数。
- * @param total 总字节或总页数。
- * @param cells 条形图字符宽度。
- * @return 范围为 [0, cells] 的已使用字符数。
- */
 static int
 scaled_cells(uint64 used, uint64 total, int cells)
 {
@@ -113,7 +91,6 @@ scaled_cells(uint64 used, uint64 total, int cells)
   return (int)result;
 }
 
-/** 输出低偏移到高偏移方向的页内用量条。 */
 static void
 print_box_bar(int used_cells, char used, char free, int plain)
 {
@@ -127,7 +104,6 @@ print_box_bar(int used_cells, char used, char free, int plain)
   printf("] |\n");
 }
 
-/** 输出高地址侧已使用的向下增长栈用量条。 */
 static void
 print_box_reverse_bar(int used_cells, int plain)
 {
@@ -141,7 +117,6 @@ print_box_reverse_bar(int used_cells, int plain)
   printf("] |\n");
 }
 
-/** 输出教学相关的 RISC-V PTE 权限位。 */
 static void
 print_pte_flags(uint64 flags)
 {
@@ -154,7 +129,6 @@ print_pte_flags(uint64 flags)
          (flags & PTE_COW) ? 'C' : '-');
 }
 
-/** 计算 p->sz 到 USERMAX 之间仍未使用的整页数。 */
 static uint64
 remaining_pages(struct memviz_snapshot *state)
 {
@@ -163,11 +137,6 @@ remaining_pages(struct memviz_snapshot *state)
   return (state->user_limit - state->process_size) / PGSIZE;
 }
 
-/**
- * 用明显的断裂线表现 p->sz 到 USERMAX 的巨大地址跨度。
- *
- * @param state 当前内存快照。
- */
 static void
 print_user_gap(struct memviz_snapshot *state)
 {
@@ -189,15 +158,6 @@ print_user_gap(struct memviz_snapshot *state)
   }
 }
 
-/**
- * 返回压缩单元应显示的主状态。
- *
- * @param cell 一个连续动态页范围的精确分类计数。
- * @return DYNAMIC_* 显示类型。
- *
- * 单元只覆盖一页时结果即该页状态。压缩单元混合多种状态时选择页数最多者；
- * 数量相同按 COW > mmap > lazy > resident 决定，使高语义状态不会在平局中消失。
- */
 static int
 dynamic_cell_kind(struct memviz_user_state_cell *cell)
 {
@@ -216,12 +176,6 @@ dynamic_cell_kind(struct memviz_user_state_cell *cell)
   return kind;
 }
 
-/**
- * 输出动态逻辑范围的页状态条。
- *
- * @param state 当前内存快照。
- * @param plain 非零时用 #/C/L/M 替代颜色。
- */
 static void
 print_dynamic_state_bar(struct memviz_snapshot *state, int plain)
 {
@@ -245,7 +199,6 @@ print_dynamic_state_bar(struct memviz_snapshot *state, int plain)
   printf("] |\n");
 }
 
-/** 输出动态页状态图例；正常模式中的三类特殊状态都使用彩色点。 */
 static void
 print_dynamic_legend(int plain)
 {
@@ -260,7 +213,6 @@ print_dynamic_legend(int plain)
   printf(" mmap\n");
 }
 
-/** 展示 trampoline 页的 VA、PA、权限和代码顺序。 */
 static void
 print_trampoline_details(struct memviz_snapshot *state)
 {
@@ -296,7 +248,6 @@ print_trampoline_details(struct memviz_snapshot *state)
          state->trampoline_pa + PGSIZE);
 }
 
-/** 按真实 ABI 顺序展开 trapframe 页内全部成员。 */
 static void
 print_trapframe_details(struct memviz_snapshot *state)
 {
@@ -333,25 +284,29 @@ print_trapframe_details(struct memviz_snapshot *state)
          (int)(PGSIZE - state->trapframe_used));
 }
 
-/**
- * 输出包含固定页、动态页状态、巨大 VA 空洞和低地址进程区域的完整视图。
- *
- * @param plain 非零时禁用 ANSI 颜色并使用 #/C/L/M 状态字符。
- * @return 采样成功返回 0，系统调用失败返回 -1。
- */
+/** 采集当前进程或显式 PID，并输出完整用户地址空间视图。 */
 static int
-print_user_view(int plain)
+print_user_view(int target_pid, int plain)
 {
-  if(memsnapshot(MEMVIZ_VIEW_USER, &user_snapshot) < 0)
+  int result;
+  if(target_pid > 0)
+    result = memsnapshot_pid(target_pid, MEMVIZ_VIEW_USER, &user_snapshot);
+  else
+    result = memsnapshot(MEMVIZ_VIEW_USER, &user_snapshot);
+  if(result < 0){
+    if(target_pid > 0)
+      fprintf(2, "memviz: cannot snapshot pid %d\n", target_pid);
     return -1;
+  }
 
   int trampoline_cells = scaled_cells(user_snapshot.trampoline_used,
                                       PGSIZE, USER_BAR_CELLS);
   int trapframe_cells = scaled_cells(user_snapshot.trapframe_used,
                                      PGSIZE, USER_BAR_CELLS);
 
-  printf("\n%s=== CURRENT PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
+  printf("\n%s=== PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
          plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  printf("observed process pid=%d\n", user_snapshot.process_pid);
   printf("\n       HIGH ADDRESS\n");
   print_line(user_snapshot.maxva, "+--------------- MAXVA ---------------+");
   print_box_text("TRAMPOLINE / supervisor-only RX");
@@ -433,12 +388,18 @@ print_user_view(int plain)
   return 0;
 }
 
-/** 依次输出增强用户视图和其余已有视图。 */
 static int
-print_all_views(int plain)
+print_all_views(int target_pid, int plain)
 {
-  if(print_user_view(plain) < 0)
+  if(print_user_view(target_pid, plain) < 0)
     return -1;
+  if(target_pid > 0){
+    if(memviz_print_pid(target_pid, MEMVIZ_VIEW_PHYS, plain) < 0)
+      return -1;
+    if(memviz_print_pid(target_pid, MEMVIZ_VIEW_KERNEL, plain) < 0)
+      return -1;
+    return memviz_print_pid(target_pid, MEMVIZ_VIEW_PAGETABLE, plain);
+  }
   if(memviz_print(MEMVIZ_VIEW_PHYS, plain) < 0)
     return -1;
   if(memviz_print(MEMVIZ_VIEW_KERNEL, plain) < 0)
@@ -446,26 +407,34 @@ print_all_views(int plain)
   return memviz_print(MEMVIZ_VIEW_PAGETABLE, plain);
 }
 
-/**
- * 解析命令行并打印指定的当前进程内存视图。
- *
- * @param argc 参数数量。
- * @param argv 参数数组；第一个位置参数必须是视图名。
- * @return 成功返回 0；参数或采样失败返回 1。
- */
 int
 main(int argc, char **argv)
 {
-  if(argc < 2 || argc > 4){
+  if(argc < 2 || argc > 6){
     usage();
     exit(1);
   }
 
   int plain = 0;
+  int target_pid = 0;
   char *filter = 0;
   for(int i = 2; i < argc; i++){
     if(strcmp(argv[i], "--plain") == 0){
+      if(plain){
+        usage();
+        exit(1);
+      }
       plain = 1;
+    } else if(strcmp(argv[i], "--pid") == 0){
+      if(target_pid != 0 || i + 1 >= argc){
+        usage();
+        exit(1);
+      }
+      target_pid = atoi(argv[++i]);
+      if(target_pid <= 0){
+        usage();
+        exit(1);
+      }
     } else if(filter == 0){
       filter = argv[i];
     } else {
@@ -474,22 +443,28 @@ main(int argc, char **argv)
     }
   }
 
-  int result;
   if(strcmp(argv[1], "pagetable") != 0 && filter != 0){
     usage();
     exit(1);
   }
 
+  int result;
   if(strcmp(argv[1], "user") == 0)
-    result = print_user_view(plain);
+    result = print_user_view(target_pid, plain);
   else if(strcmp(argv[1], "phys") == 0)
-    result = memviz_print(MEMVIZ_VIEW_PHYS, plain);
+    result = target_pid > 0 ?
+      memviz_print_pid(target_pid, MEMVIZ_VIEW_PHYS, plain) :
+      memviz_print(MEMVIZ_VIEW_PHYS, plain);
   else if(strcmp(argv[1], "kernel") == 0)
-    result = memviz_print(MEMVIZ_VIEW_KERNEL, plain);
+    result = target_pid > 0 ?
+      memviz_print_pid(target_pid, MEMVIZ_VIEW_KERNEL, plain) :
+      memviz_print(MEMVIZ_VIEW_KERNEL, plain);
   else if(strcmp(argv[1], "pagetable") == 0)
-    result = memviz_print_filtered(MEMVIZ_VIEW_PAGETABLE, plain, filter);
+    result = target_pid > 0 ?
+      memviz_print_pid_filtered(target_pid, MEMVIZ_VIEW_PAGETABLE, plain, filter) :
+      memviz_print_filtered(MEMVIZ_VIEW_PAGETABLE, plain, filter);
   else if(strcmp(argv[1], "all") == 0)
-    result = print_all_views(plain);
+    result = print_all_views(target_pid, plain);
   else {
     usage();
     exit(1);

--- a/user/memvizlib.c
+++ b/user/memvizlib.c
@@ -18,9 +18,6 @@
 // 使用静态缓冲避免在固定一页的用户栈上放置较大的快照结构体。
 static struct memviz_snapshot snapshot;
 
-/**
- * 输出一个可选 ANSI 颜色的单字节字符。
- */
 static void
 print_glyph(char glyph, char *color, int plain)
 {
@@ -30,9 +27,6 @@ print_glyph(char glyph, char *color, int plain)
     printf("%s%c%s", color, glyph, ANSI_RESET);
 }
 
-/**
- * 返回以 NUL 结尾字符串的字节数。
- */
 static int
 string_length(char *text)
 {
@@ -42,15 +36,11 @@ string_length(char *text)
   return length;
 }
 
-/**
- * 判断静态文本中是否包含过滤子串；空过滤条件匹配全部。
- */
 static int
 string_contains(char *text, char *pattern)
 {
   if(pattern == 0 || pattern[0] == 0)
     return 1;
-
   for(int i = 0; text[i] != 0; i++){
     int j = 0;
     while(pattern[j] != 0 && text[i + j] == pattern[j])
@@ -61,9 +51,6 @@ string_contains(char *text, char *pattern)
   return 0;
 }
 
-/**
- * 输出左侧补零的非负十进制整数。
- */
 static void
 print_decimal_padded(int value, int width)
 {
@@ -77,10 +64,6 @@ print_decimal_padded(int value, int width)
   printf("%d", value);
 }
 
-/**
- * 返回页表采样角色的用户可见名称。内部 ABI 仍沿用 USER_MIRROR 枚举，
- * 但实现语义已经是高地址 alias window，因此界面统一使用 alias。
- */
 static char *
 pte_role_name(int role)
 {
@@ -120,9 +103,6 @@ pte_role_name(int role)
   }
 }
 
-/**
- * 返回页表所属地址空间的固定显示名。
- */
 static char *
 pte_space_name(int space)
 {
@@ -133,9 +113,6 @@ pte_space_name(int space)
   return "UNKNOWN";
 }
 
-/**
- * 将十进制或 0x 前缀的完整字符串解析为地址。
- */
 static int
 parse_filter_address(char *filter, uint64 *value)
 {
@@ -171,9 +148,6 @@ parse_filter_address(char *filter, uint64 *value)
   return 1;
 }
 
-/**
- * 判断页表采样条目是否满足角色、空间、MMIO 或地址过滤条件。
- */
 static int
 pte_entry_matches(struct memviz_pte_entry *entry, char *filter)
 {
@@ -198,9 +172,6 @@ pte_entry_matches(struct memviz_pte_entry *entry, char *filter)
   return 0;
 }
 
-/**
- * 输出 RISC-V PTE 的教学相关权限位。
- */
 static void
 print_pte_flags(uint64 flags)
 {
@@ -213,9 +184,6 @@ print_pte_flags(uint64 flags)
          (flags & PTE_COW) ? 'C' : '-');
 }
 
-/**
- * 把物理地址换算为 kalloc 压缩视图的 cell 下标。
- */
 static int
 kalloc_cell_index(struct memviz_snapshot *state, uint64 pa)
 {
@@ -228,9 +196,6 @@ kalloc_cell_index(struct memviz_snapshot *state, uint64 pa)
   return (int)cell;
 }
 
-/**
- * 返回物理页池压缩 cell 的字符状态。
- */
 static char
 kalloc_cell_state(struct memviz_snapshot *state, int cell)
 {
@@ -244,9 +209,6 @@ kalloc_cell_state(struct memviz_snapshot *state, int cell)
   return ':';
 }
 
-/**
- * 输出 leaf PA 在物理页池中的压缩位置。
- */
 static void
 print_kalloc_cell(struct memviz_snapshot *state, uint64 pa, int plain)
 {
@@ -268,9 +230,6 @@ print_kalloc_cell(struct memviz_snapshot *state, uint64 pa, int plain)
     print_glyph(glyph, ANSI_YELLOW, plain);
 }
 
-/**
- * 将用量压缩为固定宽度字符数，非零用量至少占一个字符。
- */
 static int
 scaled_cells(uint64 used, uint64 total, int cells)
 {
@@ -282,9 +241,6 @@ scaled_cells(uint64 used, uint64 total, int cells)
   return (int)result;
 }
 
-/**
- * 输出低地址到高地址方向的固定宽度条形图。
- */
 static void
 print_bar(int used_cells, char used, char free, char *used_color,
           char *free_color, int plain)
@@ -297,9 +253,6 @@ print_bar(int used_cells, char used, char free, char *used_color,
   printf("]");
 }
 
-/**
- * 输出高地址侧为已使用区域的反向条形图，用于向下增长的栈。
- */
 static void
 print_reverse_bar(int used_cells, char used, char free, char *used_color,
                   char *free_color, int plain)
@@ -312,18 +265,12 @@ print_reverse_bar(int used_cells, char used, char free, char *used_color,
   printf("]");
 }
 
-/**
- * 输出带真实地址的布局边界线。
- */
 static void
 print_line(uint64 address, char *mark)
 {
   printf("%p %s\n", address, mark);
 }
 
-/**
- * 输出竖向地址空间图中的一行文本，并补齐右边界。
- */
 static void
 print_box_text(char *text)
 {
@@ -334,9 +281,6 @@ print_box_text(char *text)
   printf(" |\n");
 }
 
-/**
- * 输出竖向地址空间图中的正向用量条。
- */
 static void
 print_box_bar(int used_cells, char used, char free, char *used_color,
               char *free_color, int plain)
@@ -346,9 +290,6 @@ print_box_bar(int used_cells, char used, char free, char *used_color,
   printf(" |\n");
 }
 
-/**
- * 输出竖向地址空间图中的反向用量条。
- */
 static void
 print_box_reverse_bar(int used_cells, char used, char free, char *used_color,
                       char *free_color, int plain)
@@ -358,9 +299,6 @@ print_box_reverse_bar(int used_cells, char used, char free, char *used_color,
   printf(" |\n");
 }
 
-/**
- * 计算动态区域已覆盖的页数。
- */
 static uint64
 dynamic_pages(struct memviz_snapshot *state)
 {
@@ -369,9 +307,6 @@ dynamic_pages(struct memviz_snapshot *state)
   return (state->process_size - state->dynamic_start + PGSIZE - 1) / PGSIZE;
 }
 
-/**
- * 计算动态起点到 USERMAX 的理论页容量。
- */
 static uint64
 dynamic_capacity_pages(struct memviz_snapshot *state)
 {
@@ -380,9 +315,6 @@ dynamic_capacity_pages(struct memviz_snapshot *state)
   return (state->user_limit - state->dynamic_start) / PGSIZE;
 }
 
-/**
- * 计算当前 break 到 USERMAX 之间仍可增长的整页数。
- */
 static uint64
 remaining_pages(struct memviz_snapshot *state)
 {
@@ -391,9 +323,6 @@ remaining_pages(struct memviz_snapshot *state)
   return (state->user_limit - state->process_size) / PGSIZE;
 }
 
-/**
- * 根据用户栈余量生成教学风险信号。
- */
 static char *
 stack_signal(struct memviz_snapshot *state)
 {
@@ -406,9 +335,6 @@ stack_signal(struct memviz_snapshot *state)
   return "normal";
 }
 
-/**
- * 根据可立即分配物理页比例生成教学 OOM 信号。
- */
 static char *
 physical_signal(struct memviz_snapshot *state)
 {
@@ -422,10 +348,12 @@ physical_signal(struct memviz_snapshot *state)
   return "normal";
 }
 
-/**
- * 输出当前进程的低地址用户布局。PLIC、CLINT 和 UART 仅是物理 MMIO
- * 数值，不再作为用户虚拟地址上限；真正边界由快照中的 USERMAX 给出。
- */
+static void
+print_process_pid(struct memviz_snapshot *state)
+{
+  printf("observed process pid=%d\n", state->process_pid);
+}
+
 static void
 print_user_view(struct memviz_snapshot *state, int plain)
 {
@@ -433,8 +361,9 @@ print_user_view(struct memviz_snapshot *state, int plain)
   uint64 capacity_pages = dynamic_capacity_pages(state);
   int used_cells = scaled_cells(used_pages, capacity_pages, BAR_CELLS);
 
-  printf("\n%s=== CURRENT PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
+  printf("\n%s=== PROCESS USER VIRTUAL ADDRESS SPACE ===%s\n",
          plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  print_process_pid(state);
   printf("\n       HIGH ADDRESS\n");
   print_line(state->user_limit, "+------------- USERMAX --------------+");
   print_box_text("AVAILABLE USER VA RANGE");
@@ -486,9 +415,6 @@ print_user_view(struct memviz_snapshot *state, int plain)
          (int)state->total_pages, physical_signal(state));
 }
 
-/**
- * 输出 kalloc 管理范围和每 CPU freelist 汇总。
- */
 static void
 print_phys_view(struct memviz_snapshot *state, int plain)
 {
@@ -530,18 +456,15 @@ print_phys_view(struct memviz_snapshot *state, int plain)
   printf("\nOOM signal: %s\n", physical_signal(state));
 }
 
-/**
- * 输出当前进程内核页表的主要映射，按 Sv39 高规范半区、非规范空洞和低规范
- * 半区的真实顺序展示用户 alias、trampoline、内核 direct map 与 MMIO。
- */
 static void
 print_kernel_view(struct memviz_snapshot *state, int plain)
 {
   uint64 alias_limit = state->user_mirror_start + state->user_limit;
   uint64 lower_canonical_limit = state->trampoline + PGSIZE;
 
-  printf("\n%s=== CURRENT PROCESS KERNEL ADDRESS SPACE ===%s\n",
+  printf("\n%s=== PROCESS KERNEL ADDRESS SPACE ===%s\n",
          plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  print_process_pid(state);
   printf("\n       HIGH ADDRESS\n");
   print_line(alias_limit, "+------------ KUSEREND --------------+");
   print_box_text("unused alias capacity");
@@ -590,9 +513,6 @@ print_kernel_view(struct memviz_snapshot *state, int plain)
          state->clint_start, state->plic_start);
 }
 
-/**
- * 输出一层页表 PTE；缺失项终止当前链路。
- */
 static void
 print_pagetable_level(struct memviz_pte_level *level, int last)
 {
@@ -607,9 +527,6 @@ print_pagetable_level(struct memviz_pte_level *level, int last)
   printf(" -> %p\n", level->pa);
 }
 
-/**
- * 输出一条从 VA 经 Sv39 三级页表到 PA 的链路。
- */
 static void
 print_pagetable_tree(struct memviz_snapshot *state,
                      struct memviz_pte_entry *entry, int plain)
@@ -635,9 +552,6 @@ print_pagetable_tree(struct memviz_snapshot *state,
     printf("          note: same PA as user page, supervisor-only alias\n");
 }
 
-/**
- * 输出指定地址空间中满足过滤条件的页表链路集合。
- */
 static int
 print_pagetable_forest(struct memviz_snapshot *state, int space, char *title,
                        uint64 root, int plain, char *filter)
@@ -656,9 +570,6 @@ print_pagetable_forest(struct memviz_snapshot *state, int space, char *title,
   return printed;
 }
 
-/**
- * 输出一个页表页的 512 个 PTE 槽压缩矩阵。
- */
 static void
 print_pt_usage_page(struct memviz_pt_usage_page *page, int plain)
 {
@@ -693,14 +604,12 @@ print_pt_usage_page(struct memviz_pt_usage_page *page, int plain)
   }
 }
 
-/**
- * 输出已分配页表页的 PTE 槽位余量。
- */
 static void
 print_pagetable_usage_view(struct memviz_snapshot *state, int plain)
 {
   printf("\n%s=== PAGE TABLE SLOT USAGE ===%s\n",
          plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  print_process_pid(state);
   printf("\nEach matrix compresses 512 PTE slots into 64 cells.\n");
   for(int index = 0; index < (int)state->pagetable_usage_count; index++)
     print_pt_usage_page(&state->pagetable_usage[index], plain);
@@ -709,9 +618,6 @@ print_pagetable_usage_view(struct memviz_snapshot *state, int plain)
          (int)state->pagetable_usage_count, MEMVIZ_PT_USAGE_PAGES);
 }
 
-/**
- * 输出当前进程用户页表和进程内核页表的代表性映射链路。
- */
 static void
 print_pagetable_view(struct memviz_snapshot *state, int plain, char *filter)
 {
@@ -720,8 +626,9 @@ print_pagetable_view(struct memviz_snapshot *state, int plain, char *filter)
     return;
   }
 
-  printf("\n%s=== CURRENT PROCESS PAGE TABLE TREE ===%s\n",
+  printf("\n%s=== PROCESS PAGE TABLE TREE ===%s\n",
          plain ? "" : ANSI_CYAN, plain ? "" : ANSI_RESET);
+  print_process_pid(state);
   printf("\nflow: root -> L2 -> L1 -> L0 leaf -> PA -> kalloc cell\n");
   if(filter != 0)
     printf("filter: %s\n", filter);
@@ -738,10 +645,46 @@ print_pagetable_view(struct memviz_snapshot *state, int plain, char *filter)
   printf("printed paths: %d\n", total);
 }
 
+/** 采集当前进程或指定 PID 的快照到静态用户态缓冲。 */
+static int
+load_snapshot(int pid, int view)
+{
+  if(pid > 0)
+    return memsnapshot_pid(pid, view, &snapshot);
+  return memsnapshot(view, &snapshot);
+}
+
+int
+memviz_print_pid_filtered(int pid, int view, int plain, char *filter)
+{
+  if(pid <= 0 || load_snapshot(pid, view) < 0){
+    fprintf(2, "memviz: cannot snapshot pid %d for view %d\n", pid, view);
+    return -1;
+  }
+
+  switch(view){
+  case MEMVIZ_VIEW_USER:
+    print_user_view(&snapshot, plain);
+    break;
+  case MEMVIZ_VIEW_PHYS:
+    print_phys_view(&snapshot, plain);
+    break;
+  case MEMVIZ_VIEW_KERNEL:
+    print_kernel_view(&snapshot, plain);
+    break;
+  case MEMVIZ_VIEW_PAGETABLE:
+    print_pagetable_view(&snapshot, plain, filter);
+    break;
+  default:
+    return -1;
+  }
+  return 0;
+}
+
 int
 memviz_print_filtered(int view, int plain, char *filter)
 {
-  if(memsnapshot(view, &snapshot) < 0){
+  if(load_snapshot(0, view) < 0){
     fprintf(2, "memviz: memsnapshot failed for view %d\n", view);
     return -1;
   }
@@ -772,6 +715,12 @@ memviz_print(int view, int plain)
 }
 
 int
+memviz_print_pid(int pid, int view, int plain)
+{
+  return memviz_print_pid_filtered(pid, view, plain, 0);
+}
+
+int
 memviz_print_all(int plain)
 {
   if(memviz_print(MEMVIZ_VIEW_USER, plain) < 0)
@@ -781,6 +730,20 @@ memviz_print_all(int plain)
   if(memviz_print(MEMVIZ_VIEW_PHYS, plain) < 0)
     return -1;
   if(memviz_print(MEMVIZ_VIEW_KERNEL, plain) < 0)
+    return -1;
+  return 0;
+}
+
+int
+memviz_print_all_pid(int pid, int plain)
+{
+  if(memviz_print_pid(pid, MEMVIZ_VIEW_USER, plain) < 0)
+    return -1;
+  if(memviz_print_pid(pid, MEMVIZ_VIEW_PAGETABLE, plain) < 0)
+    return -1;
+  if(memviz_print_pid(pid, MEMVIZ_VIEW_PHYS, plain) < 0)
+    return -1;
+  if(memviz_print_pid(pid, MEMVIZ_VIEW_KERNEL, plain) < 0)
     return -1;
   return 0;
 }

--- a/user/memvizlib.h
+++ b/user/memvizlib.h
@@ -28,4 +28,17 @@ int memviz_print_filtered(int view, int plain, char *filter);
  */
 int memviz_print_all(int plain);
 
+/**
+ * memviz_print_pid_filtered 采集并打印指定 PID 的稳定内存视图。
+ *
+ * @param pid 目标 PID，必须为正数。
+ * @param view MEMVIZ_VIEW_* 之一；当前只有 pagetable 使用 filter。
+ * @param plain 非零时禁用 ANSI 颜色。
+ * @param filter 页表过滤字符串；为空指针时打印默认完整视图。
+ * @return 成功返回 0；目标不可观察、系统调用或 view 无效时返回 -1。
+ */
+int memviz_print_pid_filtered(int pid, int view, int plain, char *filter);
+int memviz_print_pid(int pid, int view, int plain);
+int memviz_print_all_pid(int pid, int plain);
+
 #endif

--- a/user/user.h
+++ b/user/user.h
@@ -67,6 +67,17 @@ char *mmap(void *addr, int length, int prot, int flags, int fd, int offset);
 int munmap(void *addr, int length);
 int backtrace(void);
 int memsnapshot(int view, struct memviz_snapshot *snapshot);
+
+/**
+ * 只读采集指定进程的稳定内存快照。
+ *
+ * @param pid 目标进程 PID，必须为正数。
+ * @param view MEMVIZ_VIEW_* 之一。
+ * @param snapshot 接收快照的用户缓冲区。
+ * @return 当前进程或稳定的非 RUNNING 目标成功返回 0；否则返回 -1。
+ */
+int memsnapshot_pid(int pid, int view, struct memviz_snapshot *snapshot);
+
 int vaquery(uint64 va, struct memviz_va_query *query);
 int consolemode(int fd, int mode);
 int sched_set_hint(int ticks);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -47,6 +47,7 @@ entry("mmap");
 entry("munmap");
 entry("backtrace");
 entry("memsnapshot");
+entry("memsnapshot_pid");
 entry("vaquery");
 entry("consolemode");
 entry("sched_set_hint");


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #130
- 历史实现基线：`fa8c205c667fbdd0236df9af3168ed616c64a5db`
- 本轮重放基线：`main@0db7c4aaf95f4c7616cac7c022f599e345195034`
- 最终 Head：`e6647841f548d33b5dc1c9579ca4a8a61e5c198e`
- 分支：`concept/130-memviz-pid-observation`
- 状态：当前 Head 全部必需 CI 已通过，可合并

## 中心认知

把“观察另一个进程的地址空间”实体化为单终端可复现闭环：后台目标进程逐页经历 `lazy → resident`，前台观察进程按 PID 在稳定状态下读取其只读快照。

```text
memtarget 后台运行
→ sbrk 扩展一页，暂不触碰：lazy
→ sleep 让目标进入稳定可采样状态
→ 写入首字节：resident
→ 再次 sleep
→ memviz --pid 在前台观察目标
```

## 用户接口

```text
memviz user --pid <pid> [--plain]
memviz kernel --pid <pid> [--plain]
memviz pagetable [filter] --pid <pid> [--plain]
memviz all --pid <pid> [--plain]

memtarget [pages [interval_ticks]] [--exit]
```

- 无 `--pid` 时继续观察当前 `memviz` 进程。
- `memtarget` 默认创建 8 页，每个阶段间隔 10 ticks；每页先打印 `lazy`，触碰页首后打印 `resident`。
- 默认完成后持续 sleep，保留稳定 PID；`--exit` 用于有限运行和自动化测试。
- 页数范围 1～64；间隔范围 1～100000 ticks；空串、非数字、零和溢出均被拒绝。

单终端手工验收：

```text
memtarget 8 10 &
# Shell 输出 [jid] <pid>
memviz user --pid <pid> --plain
memviz pagetable --pid <pid> --plain
ps
kill <pid>
```

## 内核调用链与并发边界

```text
memviz --pid
→ memsnapshot_pid(pid, view, snapshot)
→ sys_memsnapshot_pid
→ 按 PID 扫描 proc[]
→ 持有目标 p->lock 并验证状态
→ memviz_snapshot_proc(target, ...)
→ 释放目标锁
→ copyout 到观察者
```

- 当前进程可在自身系统调用上下文直接采样。
- 外部目标仅在持有 `p->lock` 且状态不是 `RUNNING`、`USED`、`UNUSED` 时采样。
- `RUNNABLE` 目标持锁期间不会被 scheduler 选中；`ZOMBIE` 目标持锁期间不会被 `wait()` 回收。
- 当前进程内核栈指针来自实时 `r_sp()`；外部非运行目标来自调度切换保存的 `context.sp`。
- 不暂停正在其他 CPU 执行的目标；目标处于 `RUNNING` 时返回失败，调用者可稍后重试。
- 系统调用编号基于当前主线注册为 `SYS_memsnapshot_pid = 50`。

## 自动化测试

新增 `tests/guest/memtargettest.c` 并注册为 `lab3-memtarget`：

- 真实执行 `memtarget 2 1 --exit`，验证两页依次出现 `lazy → resident` 并正常退出；
- 拒绝零页数、零间隔等非法参数；
- 拒绝零、负数和不存在 PID；
- 显式观察当前进程；
- 子进程扩展两页，触碰一页后阻塞在 pipe read，父进程验证目标的 user/kernel/pagetable 快照；
- 真实执行 `memviz user --pid <pid> --plain` 并验证目标 PID 与动态区域输出；
- 子进程退出并由父进程回收后，旧 PID 不再可观察；
- 多核调度导致目标短暂 `RUNNING` 时使用有界重试。

## 当前 Head 验证结果

GitHub Actions，Head `e6647841f548d33b5dc1c9579ca4a8a61e5c198e`：

- `xv6 CI #519`：通过
  - regression runner 单元测试：通过
  - `Build xv6`：通过
  - PR 选择性 QEMU 回归（默认 `CPUS=3`）：通过
  - VM 单核回归（`CPUS=1`）：通过
  - 生命周期敏感完整 `usertests`：通过
- `Scheduler family CI #311`：通过
  - RR/FIFO/SJF/STCF/MLFQ/CFS 单核行为与多核 smoke：通过
- `uthread debug #296`：通过

修复记录：

- Head `9acf763f...` 首轮构建已通过，但 `memtargettest` 暴露 `user/memviz.c` 未带回 `--pid` 解析；最终 Head 恢复 CLI 路径后，`lab3-memtarget` 和整套回归通过。
- 本轮没有独立本地工作树，因此没有把 `make clean`、`make` 或 QEMU 命令伪报为本地已执行；合并依据上述当前 Head 的真实 GitHub Actions 结果。

## Review 主线

1. `user/memtarget.c`：lazy/resident 生命周期、参数边界和默认保持行为。
2. `tests/guest/memtargettest.c`：真实 CLI、稳定目标快照和回收边界。
3. `kernel/sysmemviz.c`：PID 定位、目标状态限制、`p->lock` 生命周期边界。
4. `kernel/memviz.c`：显式进程快照，以及当前/外部进程内核 SP 的不同来源。
5. `user/memviz.c` / `user/memvizlib.c`：`--pid` 与 user/kernel/pagetable/all 渲染路径。

## 教学边界

- 不是 `/proc`、ptrace 或权限完备的生产级进程检查接口。
- `memtarget` 是教学实验程序，不模拟真实业务负载。
- 每次命令只生成一份快照，不提供 `--watch`。
- 不提供正在其他 CPU 执行的外部进程的原子实时快照。
- `phys` 仍表示全局 kalloc 页池，不是指定 PID 的私有物理内存占用统计。
- 采样只读，不主动触发 lazy allocation、COW、mmap fault 或文件读入。