### PR TITLE
test: 验证 TLB 地址空间切换与权限同步

### DIFF
--- a/tests/guest/vaaccesstest.c
+++ b/tests/guest/vaaccesstest.c
@@ -7,7 +7,17 @@
 #include "user/paths.h"
 #include "tests/guest/testlib.h"
 
+#define TLB_SWITCH_ROUNDS 64
+
 static char output[4096];
+
+/** 记录 COW 后 child 在同一 VA 上观察到的翻译与权限。 */
+struct tlb_switch_report {
+  uint64 va;
+  uint64 pa;
+  uint64 flags;
+  int query_ok;
+};
 
 /**
  * fail 输出稳定失败原因并以非零状态终止测试。
@@ -146,6 +156,113 @@ test_cow_access(void)
   printf("vaaccesstest: cow access OK\n");
 }
 
+/**
+ * test_tlb_switch_isolation 验证同一 VA 在父子地址空间之间反复切换时不会复用旧翻译。
+ *
+ * child 首次写入会触发 COW，使父子保留相同 VA 但映射到不同 PA，并同时改变写权限。
+ * 两个进程随后通过 pipe 交替阻塞和唤醒；在 CPUS=1 下，每轮都要求同一 hart 在两个
+ * 地址空间之间切换。断言只观察页表状态与读回值，不把运行时间解释为 TLB 事件。
+ */
+static void
+test_tlb_switch_isolation(void)
+{
+  int parent_to_child[2];
+  int child_to_parent[2];
+  int status = 0;
+  int ok = 1;
+  char token = 'x';
+  char *base = sbrk(PGSIZE);
+  struct tlb_switch_report report;
+  struct memviz_va_query parent_query;
+
+  if(base == (char *)-1)
+    fail("tlb page allocation failed");
+  volatile unsigned char *page = (volatile unsigned char *)base;
+  *page = 0x51;
+  memset(&report, 0, sizeof(report));
+  memset(&parent_query, 0, sizeof(parent_query));
+
+  if(pipe(parent_to_child) < 0 || pipe(child_to_parent) < 0)
+    fail("tlb pipe failed");
+
+  int pid = fork();
+  if(pid < 0)
+    fail("tlb fork failed");
+
+  if(pid == 0){
+    close(parent_to_child[1]);
+    close(child_to_parent[0]);
+
+    // 该 store 必须在 COW PTE 更新及 TLB 同步后重试成功。
+    *page = 0xa7;
+    struct memviz_va_query child_query;
+    if(vaquery((uint64)base, &child_query) < 0)
+      exit(1);
+
+    report.va = (uint64)base;
+    report.pa = child_query.pa;
+    report.flags = child_query.flags;
+    report.query_ok = child_query.present;
+    if(write(child_to_parent[1], &report, sizeof(report)) != sizeof(report))
+      exit(1);
+
+    for(int round = 0; round < TLB_SWITCH_ROUNDS; round++){
+      if(read(parent_to_child[0], &token, 1) != 1)
+        exit(1);
+      if(*page != 0xa7)
+        exit(1);
+      token = (char)(round & 0x7f);
+      if(write(child_to_parent[1], &token, 1) != 1)
+        exit(1);
+    }
+
+    close(parent_to_child[0]);
+    close(child_to_parent[1]);
+    exit(0);
+  }
+
+  close(parent_to_child[0]);
+  close(child_to_parent[1]);
+
+  if(read(child_to_parent[0], &report, sizeof(report)) != sizeof(report))
+    ok = 0;
+  if(ok && vaquery((uint64)base, &parent_query) < 0)
+    ok = 0;
+  if(ok && (!report.query_ok || !parent_query.present ||
+            report.va != (uint64)base || report.pa == parent_query.pa ||
+            (report.flags & PTE_W) == 0 || (report.flags & PTE_COW) != 0 ||
+            (parent_query.flags & PTE_W) != 0 ||
+            (parent_query.flags & PTE_COW) == 0))
+    ok = 0;
+
+  for(int round = 0; ok && round < TLB_SWITCH_ROUNDS; round++){
+    if(*page != 0x51){
+      ok = 0;
+      break;
+    }
+    token = (char)(round & 0x7f);
+    if(write(parent_to_child[1], &token, 1) != 1 ||
+       read(child_to_parent[0], &token, 1) != 1 ||
+       *page != 0x51)
+      ok = 0;
+  }
+
+  // 先关闭父端 pipe，让任何等待中的 child 能退出，再统一 wait 回收。
+  close(parent_to_child[1]);
+  close(child_to_parent[0]);
+  if(wait(&status) != pid || status != 0)
+    ok = 0;
+  if(*page != 0x51)
+    ok = 0;
+  if(sbrk(-PGSIZE) == (char *)-1)
+    ok = 0;
+
+  if(!ok)
+    fail("tlb context switch isolation");
+  printf("vaaccesstest: tlb switch isolation OK rounds=%d\n",
+         TLB_SWITCH_ROUNDS);
+}
+
 /** test_faults 验证非法访问只杀 worker，supervisor 和后续命令仍可继续。 */
 static void
 test_faults(void)
@@ -235,6 +352,7 @@ main(int argc, char **argv)
   test_mapped_access();
   test_lazy_access();
   test_cow_access();
+  test_tlb_switch_isolation();
   test_faults();
   test_parsing_and_expect();
   test_va_zero_follows_real_pagetable();


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #143
- 变更类型：测试
- 影响范围：Lab3 用户态 VA 回归、COW 后页表权限与地址空间切换观察
- 一句话摘要：在既有 `vaaccesstest` 中补充同一虚拟地址跨父子地址空间反复切换的确定性断言，不使用运行时间推断 TLB 事件。

## 实现了什么

- 复用现有 `sbrk`、`fork`、COW、`vaquery`、pipe 和 `xv6test`，没有引入新的内核接口或硬件计数器。
- child 首次写入共享页后，断言同一 VA 已映射到与 parent 不同的 PA，child PTE 恢复 `PTE_W` 并清除 `PTE_COW`，parent PTE 仍保持只读 COW。
- 父子进程通过两条 pipe 交替阻塞/唤醒 64 轮；每轮分别验证各自地址空间中的字节值不被另一地址空间的旧翻译污染。
- `CPUS=1` 时该握手强制同一 hart 反复切换两个页表根；默认多核回归继续检查跨进程隔离。该测试不声称观测到具体 TLB hit/miss、替换策略或命中率。

## 添加/修改了什么单元测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `lab3-vaaccess / test_tlb_switch_isolation` | 同一 VA 经 COW 后对应不同 PA，并在父子进程间交替运行 64 轮 | child `PTE_W=1/PTE_COW=0`、parent `PTE_W=0/PTE_COW=1`、父子 PA 不同，且每轮 parent 保持 `0x51`、child 保持 `0xa7` |

## 如何通过 CLI 回归观察此 PR 现象

### 前置条件

```bash
make clean
make
```

### 操作步骤

```bash
# 单核：确保同一 hart 反复切换父子地址空间。
make qemu CPUS=1
# 进入 xv6 后：
/usr/bin/xv6test --run lab3-vaaccess

# 多核自动化回归：
python3 tests/run.py --suite lab-vm --cpus 3
```

### 预期现象

```text
vaaccesstest: tlb switch isolation OK rounds=64
XV6TEST ok 1 - lab3-vaaccess
XV6TEST done status=0
```

失败判据：页表查询失败、父子 PA 未分离、COW 权限未按预期变化、任一轮读回值串扰、pipe/wait 失败，或最终 `XV6TEST done status` 非 0。

## 自动化测试结果

基于 head commit `ac8fbb88c1efd0f3ff154e5f22ddb8aa7a3a594d`：

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `make test-unit` / runner 语法检查 | 通过 | `xv6 CI` 的 `Unit-test regression grader` 成功 |
| `make clean && make -j2` | 通过 | `xv6 CI` 的 `Build xv6` 成功 |
| selected PR QEMU regression，`CPUS=3` | 通过 | `Run selected PR QEMU regression` 成功，包含 `lab-vm` |
| `make test-suite SUITE=lab-vm CPUS=1` | 通过 | `Run VM regression single-core` 成功 |
| Scheduler family PR/full usertests 与 reparent 单核回归 | 通过 | `regression` job 全部成功 |
| RR/FIFO/SJF/STCF/MLFQ/CFS 单核调度回归 | 通过 | 6 个 policy job 全部成功 |
| RR/MLFQ/CFS 三核 smoke | 通过 | 3 个 SMP smoke job 全部成功 |
| uthread debug workflow | 通过 | workflow run #145 success |

## Review 主线

1. `tests/guest/vaaccesstest.c::test_tlb_switch_isolation`
   - 先确认 COW 后同一 VA 的父子 PA/权限断言，以及 64 轮握手不会依赖计时。
2. `kernel/kalloc.c::cow_install_writable_page` 与 `cow_alloc`
   - 再核对 PTE 更新、process kernel alias 刷新和 `sfence_vma()` 的顺序。
3. `kernel/sched.c::scheduler`、`kernel/trampoline.S::{uservec,userret}`
   - 最后结合 `satp` 切换后的全量 `sfence.vma`，验证单核地址空间切换闭环。
