### PR TITLE
test: 建立分段概念到 Sv39 分页的验证闭环

### DIFF
--- a/tests/guest/memviztest_exec.h
+++ b/tests/guest/memviztest_exec.h
@@ -4,6 +4,7 @@
 #include "kernel/types.h"
 #include "user/user.h"
 #include "user/paths.h"
+#include "tests/guest/memviztest_region_mapping.h"
 
 /**
  * memviztest_exec_absolute 将 memviztest 的唯一外部程序调用固定到 `/usr/bin`。
@@ -22,6 +23,29 @@ memviztest_exec_absolute(char *path, char **argv)
   return exec(XV6_USR_BIN_PATH("memviz"), argv);
 }
 
+int memviztest_original_main(int argc, char **argv);
+
+/**
+ * 在 memviztest 原入口外增加聚焦的逻辑区域映射实验。
+ *
+ * @param argc 参数数量。
+ * @param argv 参数数组；`regions` 只运行概念映射实验，无参数时在完整回归前运行。
+ * @return 原入口的返回值；所有正常路径最终均由测试代码调用 exit()。
+ */
+int
+main(int argc, char **argv)
+{
+  if(argc == 1)
+    memviztest_region_mapping();
+  else if(argc == 2 && strcmp(argv[1], "regions") == 0){
+    memviztest_region_mapping();
+    exit(0);
+  }
+
+  return memviztest_original_main(argc, argv);
+}
+
 #define exec memviztest_exec_absolute
+#define main memviztest_original_main
 
 #endif

--- a/tests/guest/memviztest_region_mapping.h
+++ b/tests/guest/memviztest_region_mapping.h
@@ -86,6 +86,7 @@ memviztest_region_mapping(void)
   struct memviz_va_query guard;
   struct memviz_va_query stack;
   struct memviz_va_query dynamic;
+  uint64 touched_pa;
 
   if(memsnapshot(MEMVIZ_VIEW_USER, &region_before) < 0)
     region_mapping_fail("baseline snapshot");
@@ -149,6 +150,7 @@ memviztest_region_mapping(void)
   if(!dynamic.present ||
      (dynamic.flags & (PTE_U | PTE_W)) != (PTE_U | PTE_W))
     region_mapping_fail("touched dynamic page permissions");
+  touched_pa = dynamic.pa;
   if(memsnapshot(MEMVIZ_VIEW_USER, &region_resident) < 0)
     region_mapping_fail("resident growth snapshot");
   if(region_resident.dynamic_resident_pages !=
@@ -181,7 +183,7 @@ memviztest_region_mapping(void)
          region_before.stack_bottom, region_before.stack_top,
          region_before.user_sp, region_deep_stack.user_sp);
   printf("regionmapping: dynamic old-end=%p lazy-end=%p touched-pa=%p direction=up\n",
-         region_before.process_size, region_lazy.process_size, dynamic.pa);
+         region_before.process_size, region_lazy.process_size, touched_pa);
   printf("regionmapping: external fragmentation is not reproduced by page-granular allocation\n");
   printf("regionmapping: OK\n");
 }

--- a/tests/guest/memviztest_region_mapping.h
+++ b/tests/guest/memviztest_region_mapping.h
@@ -2,9 +2,17 @@
 #define XV6_MEMVIZTEST_REGION_MAPPING_H
 
 #include "kernel/types.h"
-#include "kernel/riscv.h"
+#include "kernel/param.h"
 #include "kernel/memviz.h"
 #include "user/user.h"
+
+#define REGION_PGSIZE 4096L
+#define REGION_PTE_V (1L << 0)
+#define REGION_PTE_R (1L << 1)
+#define REGION_PTE_W (1L << 2)
+#define REGION_PTE_X (1L << 3)
+#define REGION_PTE_U (1L << 4)
+#define REGION_PTE_COW (1L << 8)
 
 static struct memviz_snapshot region_before;
 static struct memviz_snapshot region_deep_stack;
@@ -39,12 +47,12 @@ static void
 region_mapping_print_flags(uint64 flags)
 {
   printf("%c%c%c%c%c%c",
-         (flags & PTE_V) ? 'V' : '-',
-         (flags & PTE_R) ? 'R' : '-',
-         (flags & PTE_W) ? 'W' : '-',
-         (flags & PTE_X) ? 'X' : '-',
-         (flags & PTE_U) ? 'U' : '-',
-         (flags & PTE_COW) ? 'C' : '-');
+         (flags & REGION_PTE_V) ? 'V' : '-',
+         (flags & REGION_PTE_R) ? 'R' : '-',
+         (flags & REGION_PTE_W) ? 'W' : '-',
+         (flags & REGION_PTE_X) ? 'X' : '-',
+         (flags & REGION_PTE_U) ? 'U' : '-',
+         (flags & REGION_PTE_COW) ? 'C' : '-');
 }
 
 static void region_mapping_capture_deep_stack(int depth) __attribute__((noinline));
@@ -97,9 +105,9 @@ memviztest_region_mapping(void)
     region_mapping_fail("ELF image range");
   if(region_before.image_end != region_before.stack_guard_start)
     region_mapping_fail("ELF and guard boundary");
-  if(region_before.stack_guard_start + PGSIZE != region_before.stack_bottom)
+  if(region_before.stack_guard_start + REGION_PGSIZE != region_before.stack_bottom)
     region_mapping_fail("guard and stack boundary");
-  if(region_before.stack_bottom + PGSIZE != region_before.stack_top)
+  if(region_before.stack_bottom + REGION_PGSIZE != region_before.stack_top)
     region_mapping_fail("fixed one-page stack");
   if(region_before.stack_top != region_before.dynamic_start)
     region_mapping_fail("stack and dynamic boundary");
@@ -109,11 +117,15 @@ memviztest_region_mapping(void)
   region_mapping_query(region_before.image_start, &image);
   region_mapping_query(region_before.stack_guard_start, &guard);
   region_mapping_query(region_before.stack_bottom, &stack);
-  if(!image.present || (image.flags & (PTE_U | PTE_X)) != (PTE_U | PTE_X))
+  if(!image.present ||
+     (image.flags & (REGION_PTE_U | REGION_PTE_X)) !=
+     (REGION_PTE_U | REGION_PTE_X))
     region_mapping_fail("ELF representative leaf permissions");
-  if(!guard.present || (guard.flags & PTE_U) != 0)
+  if(!guard.present || (guard.flags & REGION_PTE_U) != 0)
     region_mapping_fail("guard remains user accessible");
-  if(!stack.present || (stack.flags & (PTE_U | PTE_W)) != (PTE_U | PTE_W))
+  if(!stack.present ||
+     (stack.flags & (REGION_PTE_U | REGION_PTE_W)) !=
+     (REGION_PTE_U | REGION_PTE_W))
     region_mapping_fail("stack representative leaf permissions");
 
   region_mapping_capture_deep_stack(4);
@@ -127,14 +139,14 @@ memviztest_region_mapping(void)
   if(region_deep_stack.stack_used <= region_before.stack_used)
     region_mapping_fail("deeper stack did not consume more bytes");
 
-  char *dynamic_base = sbrk(PGSIZE);
+  char *dynamic_base = sbrk(REGION_PGSIZE);
   if(dynamic_base == (char *)-1)
     region_mapping_fail("sbrk grow");
   if((uint64)dynamic_base != region_before.process_size)
     region_mapping_fail("sbrk old break");
   if(memsnapshot(MEMVIZ_VIEW_USER, &region_lazy) < 0)
     region_mapping_fail("lazy growth snapshot");
-  if(region_lazy.process_size != region_before.process_size + PGSIZE)
+  if(region_lazy.process_size != region_before.process_size + REGION_PGSIZE)
     region_mapping_fail("p->sz did not grow upward by one page");
   if(region_lazy.dynamic_page_count != region_before.dynamic_page_count + 1)
     region_mapping_fail("dynamic page count after sbrk");
@@ -148,7 +160,8 @@ memviztest_region_mapping(void)
   dynamic_base[0] = 0x5a;
   region_mapping_query((uint64)dynamic_base, &dynamic);
   if(!dynamic.present ||
-     (dynamic.flags & (PTE_U | PTE_W)) != (PTE_U | PTE_W))
+     (dynamic.flags & (REGION_PTE_U | REGION_PTE_W)) !=
+     (REGION_PTE_U | REGION_PTE_W))
     region_mapping_fail("touched dynamic page permissions");
   touched_pa = dynamic.pa;
   if(memsnapshot(MEMVIZ_VIEW_USER, &region_resident) < 0)
@@ -159,7 +172,7 @@ memviztest_region_mapping(void)
   if(region_resident.dynamic_lazy_pages + 1 != region_lazy.dynamic_lazy_pages)
     region_mapping_fail("lazy count did not decrease after touch");
 
-  if(sbrk(-PGSIZE) == (char *)-1)
+  if(sbrk(-REGION_PGSIZE) == (char *)-1)
     region_mapping_fail("sbrk shrink");
   if(memsnapshot(MEMVIZ_VIEW_USER, &region_restored) < 0)
     region_mapping_fail("restored snapshot");
@@ -187,5 +200,13 @@ memviztest_region_mapping(void)
   printf("regionmapping: external fragmentation is not reproduced by page-granular allocation\n");
   printf("regionmapping: OK\n");
 }
+
+#undef REGION_PGSIZE
+#undef REGION_PTE_V
+#undef REGION_PTE_R
+#undef REGION_PTE_W
+#undef REGION_PTE_X
+#undef REGION_PTE_U
+#undef REGION_PTE_COW
 
 #endif

--- a/tests/guest/memviztest_region_mapping.h
+++ b/tests/guest/memviztest_region_mapping.h
@@ -1,0 +1,189 @@
+#ifndef XV6_MEMVIZTEST_REGION_MAPPING_H
+#define XV6_MEMVIZTEST_REGION_MAPPING_H
+
+#include "kernel/types.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+
+static struct memviz_snapshot region_before;
+static struct memviz_snapshot region_deep_stack;
+static struct memviz_snapshot region_lazy;
+static struct memviz_snapshot region_resident;
+static struct memviz_snapshot region_restored;
+static volatile int region_stack_sink;
+
+/** 输出分段概念映射实验的失败原因并以非零状态终止。 */
+static void
+region_mapping_fail(char *message)
+{
+  printf("regionmapping: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 查询当前进程一个用户虚拟地址的 Sv39 叶子映射。
+ *
+ * @param va 待观察的用户虚拟地址，允许当前尚未建立叶子 PTE。
+ * @param query 接收三级页表路径和最终叶子状态。
+ */
+static void
+region_mapping_query(uint64 va, struct memviz_va_query *query)
+{
+  if(vaquery(va, query) < 0)
+    region_mapping_fail("vaquery rejected ordinary user address");
+}
+
+/** 输出一个代表页的教学相关 PTE 权限位。 */
+static void
+region_mapping_print_flags(uint64 flags)
+{
+  printf("%c%c%c%c%c%c",
+         (flags & PTE_V) ? 'V' : '-',
+         (flags & PTE_R) ? 'R' : '-',
+         (flags & PTE_W) ? 'W' : '-',
+         (flags & PTE_X) ? 'X' : '-',
+         (flags & PTE_U) ? 'U' : '-',
+         (flags & PTE_COW) ? 'C' : '-');
+}
+
+static void region_mapping_capture_deep_stack(int depth) __attribute__((noinline));
+
+/**
+ * 在更深的真实用户调用栈中采集快照，用 SP 下降证明栈按低地址方向使用。
+ *
+ * @param depth 还需建立的递归栈帧数量；每层保留一块 volatile 数据防止尾调用消除。
+ */
+static void
+region_mapping_capture_deep_stack(int depth)
+{
+  volatile char frame[96];
+  frame[0] = (char)depth;
+  frame[sizeof(frame) - 1] = (char)(depth + 1);
+
+  if(depth == 0){
+    if(memsnapshot(MEMVIZ_VIEW_USER, &region_deep_stack) < 0)
+      region_mapping_fail("deep stack snapshot");
+  } else {
+    region_mapping_capture_deep_stack(depth - 1);
+  }
+
+  // 递归返回后仍读取当前帧，防止编译器把递归改写成尾调用。
+  region_stack_sink += frame[0] + frame[sizeof(frame) - 1];
+}
+
+/**
+ * 验证教材分段概念在当前 xv6 中只能映射为逻辑区域和分页证据。
+ *
+ * 实验不创建段描述符，也不声称 RISC-V Sv39 实现了 base/bounds 分段。它检查 ELF、
+ * guard、栈和动态区域的真实边界与 PTE，并通过递归和 sbrk 分别观察向下使用的栈与
+ * 向高地址增长的动态范围。
+ */
+static void
+memviztest_region_mapping(void)
+{
+  struct memviz_va_query image;
+  struct memviz_va_query guard;
+  struct memviz_va_query stack;
+  struct memviz_va_query dynamic;
+
+  if(memsnapshot(MEMVIZ_VIEW_USER, &region_before) < 0)
+    region_mapping_fail("baseline snapshot");
+  if(!region_before.user_stack_valid)
+    region_mapping_fail("baseline user stack");
+
+  if(region_before.image_start >= region_before.image_end)
+    region_mapping_fail("ELF image range");
+  if(region_before.image_end != region_before.stack_guard_start)
+    region_mapping_fail("ELF and guard boundary");
+  if(region_before.stack_guard_start + PGSIZE != region_before.stack_bottom)
+    region_mapping_fail("guard and stack boundary");
+  if(region_before.stack_bottom + PGSIZE != region_before.stack_top)
+    region_mapping_fail("fixed one-page stack");
+  if(region_before.stack_top != region_before.dynamic_start)
+    region_mapping_fail("stack and dynamic boundary");
+  if(region_before.process_size < region_before.dynamic_start)
+    region_mapping_fail("dynamic extent below start");
+
+  region_mapping_query(region_before.image_start, &image);
+  region_mapping_query(region_before.stack_guard_start, &guard);
+  region_mapping_query(region_before.stack_bottom, &stack);
+  if(!image.present || (image.flags & (PTE_U | PTE_X)) != (PTE_U | PTE_X))
+    region_mapping_fail("ELF representative leaf permissions");
+  if(!guard.present || (guard.flags & PTE_U) != 0)
+    region_mapping_fail("guard remains user accessible");
+  if(!stack.present || (stack.flags & (PTE_U | PTE_W)) != (PTE_U | PTE_W))
+    region_mapping_fail("stack representative leaf permissions");
+
+  region_mapping_capture_deep_stack(4);
+  if(!region_deep_stack.user_stack_valid)
+    region_mapping_fail("deep stack invalid");
+  if(region_deep_stack.stack_bottom != region_before.stack_bottom ||
+     region_deep_stack.stack_top != region_before.stack_top)
+    region_mapping_fail("stack bounds changed during recursion");
+  if(region_deep_stack.user_sp >= region_before.user_sp)
+    region_mapping_fail("deeper stack did not move toward lower VA");
+  if(region_deep_stack.stack_used <= region_before.stack_used)
+    region_mapping_fail("deeper stack did not consume more bytes");
+
+  char *dynamic_base = sbrk(PGSIZE);
+  if(dynamic_base == (char *)-1)
+    region_mapping_fail("sbrk grow");
+  if((uint64)dynamic_base != region_before.process_size)
+    region_mapping_fail("sbrk old break");
+  if(memsnapshot(MEMVIZ_VIEW_USER, &region_lazy) < 0)
+    region_mapping_fail("lazy growth snapshot");
+  if(region_lazy.process_size != region_before.process_size + PGSIZE)
+    region_mapping_fail("p->sz did not grow upward by one page");
+  if(region_lazy.dynamic_page_count != region_before.dynamic_page_count + 1)
+    region_mapping_fail("dynamic page count after sbrk");
+  if(region_lazy.dynamic_lazy_pages != region_before.dynamic_lazy_pages + 1)
+    region_mapping_fail("untouched growth is not lazy");
+
+  region_mapping_query((uint64)dynamic_base, &dynamic);
+  if(dynamic.present)
+    region_mapping_fail("untouched lazy page already has a leaf");
+
+  dynamic_base[0] = 0x5a;
+  region_mapping_query((uint64)dynamic_base, &dynamic);
+  if(!dynamic.present ||
+     (dynamic.flags & (PTE_U | PTE_W)) != (PTE_U | PTE_W))
+    region_mapping_fail("touched dynamic page permissions");
+  if(memsnapshot(MEMVIZ_VIEW_USER, &region_resident) < 0)
+    region_mapping_fail("resident growth snapshot");
+  if(region_resident.dynamic_resident_pages !=
+     region_lazy.dynamic_resident_pages + 1)
+    region_mapping_fail("touched page did not become resident");
+  if(region_resident.dynamic_lazy_pages + 1 != region_lazy.dynamic_lazy_pages)
+    region_mapping_fail("lazy count did not decrease after touch");
+
+  if(sbrk(-PGSIZE) == (char *)-1)
+    region_mapping_fail("sbrk shrink");
+  if(memsnapshot(MEMVIZ_VIEW_USER, &region_restored) < 0)
+    region_mapping_fail("restored snapshot");
+  if(region_restored.process_size != region_before.process_size ||
+     region_restored.dynamic_page_count != region_before.dynamic_page_count)
+    region_mapping_fail("dynamic range not restored");
+  region_mapping_query((uint64)dynamic_base, &dynamic);
+  if(dynamic.present)
+    region_mapping_fail("shrunk dynamic leaf remains mapped");
+
+  printf("regionmapping: translation=Sv39 paging; textbook base/bounds segments=absent\n");
+  printf("regionmapping: ELF [%p, %p) flags=", region_before.image_start,
+         region_before.image_end);
+  region_mapping_print_flags(image.flags);
+  printf("\n");
+  printf("regionmapping: guard [%p, %p) flags=", region_before.stack_guard_start,
+         region_before.stack_bottom);
+  region_mapping_print_flags(guard.flags);
+  printf("\n");
+  printf("regionmapping: stack [%p, %p) shallow-sp=%p deep-sp=%p direction=down\n",
+         region_before.stack_bottom, region_before.stack_top,
+         region_before.user_sp, region_deep_stack.user_sp);
+  printf("regionmapping: dynamic old-end=%p lazy-end=%p touched-pa=%p direction=up\n",
+         region_before.process_size, region_lazy.process_size, dynamic.pa);
+  printf("regionmapping: external fragmentation is not reproduced by page-granular allocation\n");
+  printf("regionmapping: OK\n");
+}
+
+#endif

--- a/tests/segmentation_experiment.py
+++ b/tests/segmentation_experiment.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""采集“教材分段概念 → xv6 逻辑区域与 Sv39 分页”的可归档证据。"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import run as runner
+
+
+SUITE_NAME = "segmentation-mapping"
+TEST_NAME = "segmentation-mapping"
+
+# 业务断言由 guest 内的 memviztest 持有；host 仅编排 QEMU、保留原始输出并检查
+# XV6TEST 的稳定结束协议，避免把内存模型语义重新搬到 Python。
+EXPERIMENT = runner.TestCase(
+    name=TEST_NAME,
+    commands=(
+        "/usr/bin/memviz user --plain",
+        "/usr/bin/memviz pagetable user --plain",
+        "/usr/bin/memviz pagetable guard --plain",
+        "/usr/bin/memviz pagetable stack --plain",
+        "/usr/bin/memviztest regions",
+        "/usr/bin/xv6test --run lab3-memviz",
+    ),
+    expected=runner.GUEST_SUCCESS,
+    timeout=700,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """解析 QEMU CPU 数量。"""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cpus", type=int, default=3, help="QEMU CPU count")
+    return parser.parse_args()
+
+
+def evidence_log_path() -> Path:
+    """返回本实验使用的稳定原始日志路径。"""
+
+    return runner.RESULT_ROOT / SUITE_NAME / f"{TEST_NAME}.log"
+
+
+def main() -> int:
+    """运行单个 QEMU snapshot，并报告可直接归档的原始日志。"""
+
+    args = parse_args()
+    if args.cpus < 1:
+        raise SystemExit("--cpus must be at least 1")
+
+    runner._run_qemu_tests(SUITE_NAME, (EXPERIMENT,), args.cpus)
+    log_path = evidence_log_path().relative_to(runner.REPO_ROOT)
+    print(f"Segmentation mapping evidence: {log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #140
- 约束来源：#134
- 基线 Commit：`fa8c205c667fbdd0236df9af3168ed616c64a5db`
- 最终 Head：`29f3a96b2f590e3b89680357b2d2f5b3f6681e8b`
- 分支：`concept/140-segmentation-mapping`

## 实现了什么

本 PR **没有在 xv6 中伪造教材式 base/bounds 分段机制**。当前 RISC-V/xv6 使用 Sv39 分页，因此实现聚焦于把教材中的“代码、guard、栈、动态区域、权限和增长方向”映射为真实页表与运行时证据：

1. 为 `memviztest` 增加 `regions` 聚焦实验：
   - 校验 ELF、guard、固定一页用户栈与动态范围的连续边界；
   - 通过 `vaquery()` 观察代表页的三级页表叶子与权限；
   - 通过递归前后 SP 对比证明用户栈向低地址使用；
   - 通过 `sbrk()`、lazy fault、触页和缩容证明动态范围向高地址增长，并验证资源回收；
   - 明确输出“Sv39 paging；textbook base/bounds segments absent”。
2. 默认 `memviztest` 回归会先运行该实验；也可以单独运行 `memviztest regions`。
3. 新增 `tests/segmentation_experiment.py`，在单个 QEMU snapshot 中自动采集：
   - 用户地址空间字符图；
   - 用户、guard、stack 页表链路；
   - 聚焦实验输出；
   - `lab3-memviz` guest 回归结果。

## 测试责任边界

- 逻辑区域、权限、增长方向、lazy/resident 与缩容断言全部由 xv6 guest 中的 `memviztest` 持有。
- Python 仅负责 QEMU 生命周期、命令编排、原始日志和 `XV6TEST done status=0` 协议，不重复解释内存模型。

## CLI 观察

```bash
make clean
make -j2
python3 tests/run.py --list
python3 tests/segmentation_experiment.py --cpus 3
python3 tests/segmentation_experiment.py --cpus 1
```

原始证据保存在：

```text
test-results/segmentation-mapping/segmentation-mapping.log
```

关键稳定输出：

```text
regionmapping: translation=Sv39 paging; textbook base/bounds segments=absent
regionmapping: ... direction=down
regionmapping: ... direction=up
regionmapping: external fragmentation is not reproduced by page-granular allocation
regionmapping: OK
XV6TEST done status=0
```

失败判据：任一 guest 断言失败、QEMU panic/kerneltrap、命令超时、缺少 `XV6TEST done status=0` 或进程返回非零。

## 自动化结果

最终 Head `29f3a96b2f590e3b89680357b2d2f5b3f6681e8b`：

- `xv6 CI` #379：通过
  - regression grader：通过
  - `make clean` + `make -j2`：通过
  - 选定 PR QEMU 回归（CPUS=3）：通过
  - VM 回归（CPUS=1）：通过
- `Scheduler family CI` #177：通过
  - 默认 RR 构建、PR 回归、完整 usertests、单核清理及各调度策略检查：通过
- `uthread debug` #157：通过

迭代中曾发现强制包含测试头导致 `NCPU` 缺失和 `riscv.h` 重复定义；已通过显式依赖与局部观测常量修复，最终全部工作流为绿色。

## Review 主线

1. 确认没有新增段寄存器、段描述符或 base/bounds 翻译路径。
2. 检查 `memviztest_region_mapping.h` 的边界、PTE、SP 与 `sbrk` 断言是否只描述当前实现。
3. 检查 `memviztest_exec.h` 的入口包装是否保持原有具名测试和 exec 绝对路径适配。
4. 检查 Python 是否只负责编排和证据留存。

## 教学边界

- 当前页表映射由 Sv39 PTE 完成，不存在教材中的段表和段寄存器。
- xv6 用户栈固定为一页，本实验只验证栈指针在该页内向低地址使用，不声称支持自动栈扩展。
- 普通 `uvmalloc()` 页在当前教学实现中使用统一 RWXU 权限；这不是生产系统常见的 W^X 策略。
- 分页不复现可变长连续段分配导致的外部碎片；仍可能存在页内碎片、页表开销与虚拟地址空洞。