### PR TITLE
实体化分页地址转换与空间开销实验

### DIFF
--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -121,12 +121,14 @@ struct memviz_pte_entry {
 
 // 对单个用户虚拟地址执行只读页表查询的结果。
 struct memviz_va_query {
+  // va 和 pa 都是页对齐基址；调用者保留原始 VA 才能恢复页内偏移。
   uint64 va;
   int present;
   int kalloc_cell;
   int reserved;
   uint64 pte;
   uint64 flags;
+  // 映射存在时，字节物理地址等于 pa + (original_va & (PGSIZE - 1))。
   uint64 pa;
   struct memviz_pte_level levels[3];
 };

--- a/tests/guest/addresswindowtest.c
+++ b/tests/guest/addresswindowtest.c
@@ -9,6 +9,20 @@
 
 static struct memviz_snapshot snapshot;
 static struct memviz_va_query query;
+static struct memviz_va_query paging_lazy_query;
+static struct memviz_va_query paging_inside_query;
+static struct memviz_va_query paging_left_query;
+static struct memviz_va_query paging_right_query;
+static struct memviz_va_query paging_unmapped_query;
+static struct memviz_va_query paging_cleanup_query;
+
+/** 一个地址空间快照中用户页表页的精确槽位统计。 */
+struct paging_table_stats {
+  uint64 pages;
+  uint64 bytes;
+  uint64 used_entries;
+  uint64 total_entries;
+};
 
 /**
  * fail 输出稳定失败原因并终止当前测试进程。
@@ -45,6 +59,220 @@ require_present(uint64 va)
 {
   if(vaquery(va, &query) < 0 || !query.present)
     fail("expected user mapping missing");
+}
+
+/**
+ * collect_user_pagetable_stats 汇总快照中实际分配的用户页表页。
+ *
+ * @param state 由 MEMVIZ_VIEW_PAGETABLE 取得的只读快照。
+ * @param stats 接收页表页数、字节数和有效槽位数。
+ *
+ * memviz 先递归扫描用户页表，再扫描进程内核页表。这里仅累计 USER 空间，
+ * 因而页表空间开销来自真实页表页和真实 PTE 槽位，而不是按理论层数估算。
+ */
+static void
+collect_user_pagetable_stats(struct memviz_snapshot *state,
+                             struct paging_table_stats *stats)
+{
+  memset(stats, 0, sizeof(*stats));
+  for(int i = 0; i < (int)state->pagetable_usage_count; i++){
+    struct memviz_pt_usage_page *page = &state->pagetable_usage[i];
+    if(page->space != MEMVIZ_PTE_SPACE_USER)
+      continue;
+    stats->pages++;
+    stats->used_entries += page->used_entries;
+    stats->total_entries += page->total_entries;
+  }
+  stats->bytes = stats->pages * PGSIZE;
+}
+
+/**
+ * print_paging_flags 输出地址转换实验关注的叶子 PTE 权限位。
+ *
+ * @param flags PTE_FLAGS() 返回的低十位标志。
+ */
+static void
+print_paging_flags(uint64 flags)
+{
+  printf("%c%c%c%c%c%c",
+         (flags & PTE_V) ? 'V' : '-',
+         (flags & PTE_R) ? 'R' : '-',
+         (flags & PTE_W) ? 'W' : '-',
+         (flags & PTE_X) ? 'X' : '-',
+         (flags & PTE_U) ? 'U' : '-',
+         (flags & PTE_COW) ? 'C' : '-');
+}
+
+/**
+ * print_paging_translation 展示一个具体 VA 的 VPN、页内偏移、PTE、PFN 与字节 PA。
+ *
+ * @param label 稳定的样本名称。
+ * @param va 用户实际访问的字节虚拟地址。
+ * @param result vaquery() 返回的页表链路；PA 是页对齐的物理页基址。
+ */
+static void
+print_paging_translation(char *label, uint64 va,
+                          struct memviz_va_query *result)
+{
+  uint64 offset = va & (PGSIZE - 1);
+  printf("PAGING address label=%s va=%p vpn=%p offset=%d mapped=%d",
+         label, va, va >> PGSHIFT, (int)offset, result->present);
+  if(result->present){
+    printf(" pte=%p flags=", result->pte);
+    print_paging_flags(result->flags);
+    printf(" page_pa=%p pfn=%p byte_pa=%p",
+           result->pa, result->pa >> PGSHIFT, result->pa + offset);
+  }
+  printf("\n");
+}
+
+/**
+ * test_paging_model 将分页基础概念实体化为一次可重复的真实地址转换实验。
+ *
+ * 实验先把 break 对齐到页边界，再申请 PGSIZE+1 字节。该范围必然跨越两页，
+ * 因而能够同时观察页边界、两个独立 PFN 和 PGSIZE-1 字节内部碎片。sbrk 只
+ * 扩大逻辑范围，首次写入才触发 lazy allocation；未触页样本与范围外样本分别
+ * 证明“无叶子 PTE”既可能表示合法 lazy VA，也可能表示真正未映射 VA。
+ *
+ * 结束前恢复原 break 并验证两张叶子映射已移除。空的中间页表页允许保留到
+ * 进程退出，这是当前 xv6 freewalk 生命周期的教学边界。
+ */
+static void
+test_paging_model(void)
+{
+  struct paging_table_stats before_stats;
+  struct paging_table_stats after_stats;
+  uint64 oldbrk = (uint64)sbrk(0);
+  uint64 base = PGROUNDUP(oldbrk);
+  uint64 padding = base - oldbrk;
+  uint64 requested_bytes = PGSIZE + 1;
+  uint64 rounded_bytes = PGROUNDUP(requested_bytes);
+  uint64 reserve_bytes64 = padding + requested_bytes;
+  uint64 free_before;
+
+  if(PGSIZE != 4096 || PGSHIFT != 12 || sizeof(pte_t) != sizeof(uint64))
+    fail("unexpected paging geometry");
+  if(reserve_bytes64 > 0x7fffffffULL)
+    fail("paging reserve exceeds sbrk ABI");
+
+  if(memsnapshot(MEMVIZ_VIEW_PAGETABLE, &snapshot) < 0)
+    fail("paging baseline snapshot");
+  collect_user_pagetable_stats(&snapshot, &before_stats);
+  free_before = snapshot.free_pages;
+
+  int reserve_bytes = (int)reserve_bytes64;
+  if((uint64)sbrk(reserve_bytes) != oldbrk)
+    fail("paging sbrk reserve");
+
+  if(vaquery(base, &paging_lazy_query) < 0 || paging_lazy_query.present)
+    fail("untouched lazy page already mapped");
+
+  uint64 inside_va = base + 0xabc;
+  uint64 left_va = base + PGSIZE - 1;
+  uint64 right_va = base + PGSIZE;
+  uint64 unmapped_va = base + rounded_bytes;
+  volatile char *inside = (volatile char *)inside_va;
+  volatile char *left = (volatile char *)left_va;
+  volatile char *right = (volatile char *)right_va;
+
+  *inside = 0x5a;
+  *left = 0x6b;
+  *right = 0x7c;
+
+  if(*inside != 0x5a || *left != 0x6b || *right != 0x7c)
+    fail("cross-page readback");
+  if(vaquery(inside_va, &paging_inside_query) < 0 ||
+     vaquery(left_va, &paging_left_query) < 0 ||
+     vaquery(right_va, &paging_right_query) < 0 ||
+     vaquery(unmapped_va, &paging_unmapped_query) < 0)
+    fail("paging vaquery syscall");
+
+  if(!paging_inside_query.present || !paging_left_query.present ||
+     !paging_right_query.present)
+    fail("touched paging sample missing");
+  if(paging_unmapped_query.present)
+    fail("outside paging sample mapped");
+  if(paging_inside_query.va != PGROUNDDOWN(inside_va) ||
+     paging_left_query.va != PGROUNDDOWN(left_va) ||
+     paging_right_query.va != PGROUNDDOWN(right_va))
+    fail("vaquery page alignment");
+  if((paging_inside_query.pa % PGSIZE) != 0 ||
+     (paging_left_query.pa % PGSIZE) != 0 ||
+     (paging_right_query.pa % PGSIZE) != 0)
+    fail("physical frame alignment");
+  if(paging_inside_query.pa != paging_left_query.pa)
+    fail("same virtual page changed PFN");
+  if(paging_left_query.pa == paging_right_query.pa)
+    fail("adjacent virtual pages share frame");
+  if((left_va >> PGSHIFT) + 1 != (right_va >> PGSHIFT) ||
+     (left_va & (PGSIZE - 1)) != PGSIZE - 1 ||
+     (right_va & (PGSIZE - 1)) != 0)
+    fail("page boundary decomposition");
+  if(((paging_inside_query.pa + (inside_va & (PGSIZE - 1))) &
+      (PGSIZE - 1)) != (inside_va & (PGSIZE - 1)) ||
+     ((paging_left_query.pa + (left_va & (PGSIZE - 1))) &
+      (PGSIZE - 1)) != (left_va & (PGSIZE - 1)) ||
+     ((paging_right_query.pa + (right_va & (PGSIZE - 1))) &
+      (PGSIZE - 1)) != (right_va & (PGSIZE - 1)))
+    fail("page offset not preserved");
+  if((paging_inside_query.flags & (PTE_V | PTE_R | PTE_W | PTE_U)) !=
+     (PTE_V | PTE_R | PTE_W | PTE_U) ||
+     (paging_right_query.flags & (PTE_V | PTE_R | PTE_W | PTE_U)) !=
+     (PTE_V | PTE_R | PTE_W | PTE_U))
+    fail("paging leaf permissions");
+
+  if(memsnapshot(MEMVIZ_VIEW_PAGETABLE, &snapshot) < 0)
+    fail("paging materialized snapshot");
+  collect_user_pagetable_stats(&snapshot, &after_stats);
+  if(after_stats.pages == 0 || after_stats.pages < before_stats.pages)
+    fail("user pagetable page accounting");
+  if(after_stats.total_entries != after_stats.pages * (PGSIZE / sizeof(pte_t)))
+    fail("user pagetable slot capacity");
+  if(after_stats.used_entries < before_stats.used_entries + 2)
+    fail("two leaf PTEs not reflected in usage");
+  if(rounded_bytes != 2 * PGSIZE ||
+     rounded_bytes - requested_bytes != PGSIZE - 1)
+    fail("internal fragmentation arithmetic");
+
+  printf("PAGING geometry page_size=%d offset_bits=%d pte_bytes=%d pte_slots=%d\n",
+         PGSIZE, PGSHIFT, (int)sizeof(pte_t),
+         (int)(PGSIZE / sizeof(pte_t)));
+  printf("PAGING request old_break=%p base=%p padding=%d requested=%d rounded=%d frames=2 internal_fragment=%d\n",
+         oldbrk, base, (int)padding, (int)requested_bytes,
+         (int)rounded_bytes, (int)(rounded_bytes - requested_bytes));
+  print_paging_translation("lazy-before-touch", base, &paging_lazy_query);
+  print_paging_translation("inside", inside_va, &paging_inside_query);
+  print_paging_translation("boundary-left", left_va, &paging_left_query);
+  print_paging_translation("boundary-right", right_va, &paging_right_query);
+  print_paging_translation("outside-extent", unmapped_va,
+                           &paging_unmapped_query);
+  printf("PAGING cross left_value=%d right_value=%d vpn_step=1 distinct_frames=1\n",
+         (int)*left, (int)*right);
+  printf("PAGING pagetable before_pages=%d before_bytes=%d before_used=%d before_slots=%d after_pages=%d after_bytes=%d after_used=%d after_slots=%d delta_pages=%d delta_used=%d\n",
+         (int)before_stats.pages, (int)before_stats.bytes,
+         (int)before_stats.used_entries, (int)before_stats.total_entries,
+         (int)after_stats.pages, (int)after_stats.bytes,
+         (int)after_stats.used_entries, (int)after_stats.total_entries,
+         (int)(after_stats.pages - before_stats.pages),
+         (int)(after_stats.used_entries - before_stats.used_entries));
+  int allocator_pages_delta = free_before >= snapshot.free_pages ?
+                              (int)(free_before - snapshot.free_pages) : 0;
+  printf("PAGING frames data_frames=2 data_bytes=%d first_pfn=%p second_pfn=%p allocator_pages_delta=%d\n",
+         2 * PGSIZE, paging_left_query.pa >> PGSHIFT,
+         paging_right_query.pa >> PGSHIFT, allocator_pages_delta);
+
+  uint64 expected_current_break = base + requested_bytes;
+  if((uint64)sbrk(-reserve_bytes) != expected_current_break)
+    fail("paging sbrk release");
+  if((uint64)sbrk(0) != oldbrk)
+    fail("paging break not restored");
+  if(vaquery(base, &paging_cleanup_query) < 0 || paging_cleanup_query.present)
+    fail("first paging mapping survived cleanup");
+  if(vaquery(right_va, &paging_cleanup_query) < 0 || paging_cleanup_query.present)
+    fail("second paging mapping survived cleanup");
+
+  printf("PAGING cleanup restored_break=1 mappings_removed=1\n");
+  printf("PAGING RESULT PASS\n");
 }
 
 /**
@@ -219,11 +447,13 @@ test_direct_map_crossing(void)
 }
 
 /**
- * run_worker 在一个短生命周期进程中完成地址窗口功能验证。
+ * run_worker 在一个短生命周期进程中完成分页与地址窗口功能验证。
  */
 static void
 run_worker(void)
 {
+  test_paging_model();
+
   uint64 oldbrk = (uint64)sbrk(0);
   uint64 target = VIRTIO0 + 3 * PGSIZE;
   if(oldbrk >= target)
@@ -261,14 +491,24 @@ run_worker(void)
 }
 
 /**
- * main 验证功能路径，并在 worker 回收后检查页面和页表资源是否归还。
+ * main 运行分页实验或完整地址窗口回归。
+ *
+ * @param argc 不带参数时运行完整回归；传入 paging 时只运行分页闭环。
+ * @param argv 命令行参数数组。
+ * @return 成功路径通过 exit(0) 结束；断言失败由 fail 以非零状态终止。
  */
 int
 main(int argc, char **argv)
 {
-  (void)argv;
-  if(argc != 1)
+  if(argc == 2 && strcmp(argv[1], "paging") == 0){
+    test_paging_model();
+    printf("addresswindowtest: paging OK\n");
+    exit(0);
+  }
+  if(argc != 1){
+    fprintf(2, "usage: addresswindowtest [paging]\n");
     exit(2);
+  }
 
   uint64 before = free_pages();
   int pid = fork();


### PR DESCRIPTION
## PR 信息

- 关联 Issue：Closes #142
- 约束来源：#134
- 基线 Commit：`fa8c205c667fbdd0236df9af3168ed616c64a5db`
- 范围：只扩展现有 `tests/guest/addresswindowtest.c`，并补充 `memviz_va_query` 的页基址语义注释；不新增内核机制、不修改工作流。

## 实现内容

在既有 `memsnapshot()`、`vaquery()`、lazy allocation 与 Lab3 guest 回归入口上增加分页入门闭环：

- 自动把 break 对齐到 4 KiB 页边界，并申请 `PGSIZE + 1` 字节；
- 分别构造页内地址、页末地址、下一页页首、合法但尚未触页的 lazy VA、范围外未映射 VA；
- 输出并断言 `VA -> VPN + offset -> PTE -> PFN -> byte PA`；
- 以两个真实且不同的物理页框计算数据页占用与 `4095 B` 内部碎片；
- 从 memviz 实际扫描到的用户页表页/PTE 槽位统计页表字节开销；
- 恢复原 break，并验证两张叶子映射已移除；
- 保留现有地址窗口完整回归，并提供独立命令 `addresswindowtest paging`。

## 断言测试

分页实验独立覆盖：

1. **正常页内转换**：VPN、offset、leaf PTE、PFN、byte PA 完整闭环；
2. **页边界**：左样本 offset=`4095`，右样本 offset=`0`，VPN 递增且 PFN 不同；
3. **未映射语义**：区分合法 lazy VA 与真正范围外 VA；
4. **空间开销**：页表页数、页表字节数、有效槽位增量均来自 memviz 快照；
5. **内部碎片**：`4097 B` 请求真实落到两个数据页，碎片为 `8192-4097=4095 B`；
6. **资源释放与重复执行**：恢复 break，叶子 PTE 消失；完整 Lab3 入口仍由短生命周期 worker 回收所有页。

## CLI 复现

```bash
make clean
make
make qemu
```

进入 xv6 shell 后：

```text
addresswindowtest paging
```

预期稳定结束标志：

```text
PAGING cleanup restored_break=1 mappings_removed=1
PAGING RESULT PASS
addresswindowtest: paging OK
```

完整既有回归：

```text
xv6test --run lab3-address-window
```

## 自动化结果

GitHub Actions `xv6 CI` run `30157489449`：**success**。

- Unit-test regression grader：通过；
- `make clean && make -j2`：通过；
- selected PR QEMU regression，`CPUS=3`：通过；
- `make test-suite SUITE=lab-vm CPUS=1`：通过；
- `addresswindowtest paging` 的断言逻辑由 `lab-vm -> lab3-address-window` 在三核与单核回归中覆盖；未把独立交互命令伪报为单独执行。

## Review 顺序

1. `test_paging_model()` 的场景构造与 cleanup；
2. `print_paging_translation()` 的 VA/VPN/PFN 表达；
3. `collect_user_pagetable_stats()` 的证据边界；
4. `main()` 的独立 `paging` 入口与原回归兼容性。