### PR TITLE
[Concept Lab] 实体化：多级反馈队列可验证闭环

### DIFF
--- a/tests/guest/schedtest.c
+++ b/tests/guest/schedtest.c
@@ -1,11 +1,12 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
 #include "kernel/schedstat.h"
+#include "kernel/schedtrace_abi.h"
 #include "user/user.h"
 
 #define WORKERS 3
 #define MLFQ_CPU_TICKS 8
-#define MLFQ_COMPETITION_CPU_TICKS 24
+#define MLFQ_COMPETITION_CPU_TICKS 80
 #define MLFQ_INTERACTIVE_ROUNDS 4
 #define MLFQ_INTERACTIVE_SLEEP_TICKS 2
 #define MLFQ_BOOST_RUNTIME_LIMIT 96
@@ -17,6 +18,8 @@ struct worker_result {
   unsigned long initial_mlfq_epoch;
   struct sched_stats stats;
 };
+
+static struct schedtrace_snapshot mlfq_snapshot;
 
 static void
 burn(void)
@@ -410,9 +413,78 @@ mlfq_interactive_worker(int readyfd, int startfd, int resultfd)
 }
 
 /**
- * run_mlfq_competition 验证睡眠型任务在 CPU 密集任务结束前完成且始终停留在 Q0。
+ * verify_mlfq_trace 从混合负载快照中校验降级、睡眠唤醒、boost 和单核抢占。
  *
- * @return 响应顺序和层级均符合预期返回 0，否则返回 -1。
+ * @param cpu_pid CPU 密集 worker PID。
+ * @param interactive_pid 周期睡眠 worker PID。
+ * @return 所有事件契约满足返回 0，否则输出缺失项并返回 -1。
+ */
+static int
+verify_mlfq_trace(int cpu_pid, int interactive_pid)
+{
+  int saw_level1 = 0;
+  int saw_level2 = 0;
+  int saw_interactive_sleep = 0;
+  int saw_interactive_resume = 0;
+  int saw_boost = 0;
+  int saw_higher_queue = 0;
+
+  if(schedtrace(SCHEDTRACE_OP_READ, &mlfq_snapshot,
+                SCHEDTRACE_MAX_EVENTS) < 0)
+    return -1;
+  if(mlfq_snapshot.policy != SCHED_POLICY_MLFQ ||
+     mlfq_snapshot.events <= 0 || mlfq_snapshot.dropped != 0){
+    printf("schedtest: mlfq trace policy=%d events=%d dropped=%d\n",
+           mlfq_snapshot.policy, mlfq_snapshot.events, mlfq_snapshot.dropped);
+    return -1;
+  }
+
+  for(int i = 0; i < mlfq_snapshot.events; i++){
+    struct schedtrace_event *event = &mlfq_snapshot.events_buffer[i];
+    if(event->event_type == SCHEDTRACE_EVENT_MLFQ_BOOST)
+      saw_boost = 1;
+    if(event->pid == cpu_pid &&
+       event->event_type == SCHEDTRACE_EVENT_RUN_STOP){
+      if(event->stop_reason == SCHEDTRACE_REASON_MLFQ_QUANTUM &&
+         event->mlfq_level == 1)
+        saw_level1 = 1;
+      if(event->stop_reason == SCHEDTRACE_REASON_MLFQ_QUANTUM &&
+         event->mlfq_level == 2)
+        saw_level2 = 1;
+      if(event->stop_reason == SCHEDTRACE_REASON_MLFQ_HIGHER_QUEUE)
+        saw_higher_queue = 1;
+    }
+    if(event->pid == interactive_pid &&
+       event->event_type == SCHEDTRACE_EVENT_RUN_STOP &&
+       event->stop_reason == SCHEDTRACE_REASON_SLEEP &&
+       event->mlfq_level == 0)
+      saw_interactive_sleep = 1;
+    if(saw_interactive_sleep && event->pid == interactive_pid &&
+       event->event_type == SCHEDTRACE_EVENT_RUN_START &&
+       event->mlfq_level == 0)
+      saw_interactive_resume = 1;
+  }
+
+  if(!saw_level1 || !saw_level2 || !saw_interactive_sleep ||
+     !saw_interactive_resume || !saw_boost){
+    printf("schedtest: mlfq trace q1=%d q2=%d sleep=%d resume=%d boost=%d\n",
+           saw_level1, saw_level2, saw_interactive_sleep,
+           saw_interactive_resume, saw_boost);
+    return -1;
+  }
+#if defined(XV6_CPUS) && XV6_CPUS == 1
+  if(!saw_higher_queue){
+    printf("schedtest: mlfq trace missing higher-queue preemption\n");
+    return -1;
+  }
+#endif
+  return 0;
+}
+
+/**
+ * run_mlfq_competition 验证睡眠型任务优先完成，并保留可由 schedviz dump 读取的快照。
+ *
+ * @return 响应顺序、层级和 trace 契约均符合预期返回 0，否则返回 -1。
  */
 static int
 run_mlfq_competition(void)
@@ -453,6 +525,12 @@ run_mlfq_competition(void)
   if(read_exact(ready[0], &token, 1) < 0 ||
      read_exact(ready[0], &token, 1) < 0)
     return -1;
+
+  if(schedtrace(SCHEDTRACE_OP_RESET, 0, 0) < 0 ||
+     schedtrace(SCHEDTRACE_OP_WATCH_PID, 0, cpu_pid) < 0 ||
+     schedtrace(SCHEDTRACE_OP_WATCH_PID, 0, interactive_pid) < 0 ||
+     schedtrace(SCHEDTRACE_OP_START, 0, 0) < 0)
+    return -1;
   if(write_exact(start[1], "s", 1) < 0 ||
      write_exact(start[1], "s", 1) < 0)
     return -1;
@@ -465,6 +543,8 @@ run_mlfq_competition(void)
   close(result[0]);
   wait(0);
   wait(0);
+  if(schedtrace(SCHEDTRACE_OP_STOP, 0, 0) < 0)
+    return -1;
 
   if(first.id != 1 || second.id != 0){
     printf("schedtest: mlfq response first=%d second=%d\n", first.id, second.id);
@@ -475,7 +555,7 @@ run_mlfq_competition(void)
            first.max_mlfq_level, first.stats.mlfq_level);
     return -1;
   }
-  return 0;
+  return verify_mlfq_trace(cpu_pid, interactive_pid);
 }
 
 /**

--- a/tests/guest/schedtest.c
+++ b/tests/guest/schedtest.c
@@ -472,6 +472,7 @@ verify_mlfq_trace(int cpu_pid, int interactive_pid)
            saw_interactive_resume, saw_boost);
     return -1;
   }
+  (void)saw_higher_queue;
 #if defined(XV6_CPUS) && XV6_CPUS == 1
   if(!saw_higher_queue){
     printf("schedtest: mlfq trace missing higher-queue preemption\n");

--- a/tests/guest/schedtest.c
+++ b/tests/guest/schedtest.c
@@ -4,10 +4,17 @@
 #include "user/user.h"
 
 #define WORKERS 3
+#define MLFQ_CPU_TICKS 8
+#define MLFQ_COMPETITION_CPU_TICKS 24
+#define MLFQ_INTERACTIVE_ROUNDS 4
+#define MLFQ_INTERACTIVE_SLEEP_TICKS 2
+#define MLFQ_BOOST_RUNTIME_LIMIT 96
 
 struct worker_result {
   int id;
   int completed_tick;
+  int max_mlfq_level;
+  unsigned long initial_mlfq_epoch;
   struct sched_stats stats;
 };
 
@@ -63,16 +70,35 @@ consume_runtime_ticks(int ticks)
   return 0;
 }
 
+/**
+ * write_result_details 写回 worker 的完成顺序、MLFQ 历史峰值和最终状态。
+ *
+ * @param fd 父进程读取结果的管道写端。
+ * @param id 场景内稳定 worker 编号。
+ * @param initial_epoch worker 开始时看到的 boost 代际；无关场景传 0。
+ * @param max_level worker 运行期间观察到的最高 MLFQ 层级。
+ */
 static void
-write_result(int fd, int id)
+write_result_details(int fd, int id, unsigned long initial_epoch, int max_level)
 {
   struct worker_result result;
   result.id = id;
   result.completed_tick = uptime();
+  result.max_mlfq_level = max_level;
+  result.initial_mlfq_epoch = initial_epoch;
   if(sched_get_stats(&result.stats) < 0)
     exit(1);
   if(write_exact(fd, &result, sizeof(result)) < 0)
     exit(1);
+}
+
+static void
+write_result(int fd, int id)
+{
+  struct sched_stats stats;
+  if(sched_get_stats(&stats) < 0)
+    exit(1);
+  write_result_details(fd, id, 0, stats.mlfq_level);
 }
 
 static void
@@ -254,11 +280,13 @@ verify_stcf(void)
   return 0;
 }
 
+/** CPU 密集 worker 连续消耗时间片，并记录实际到达过的最低优先级。 */
 static void
 mlfq_cpu_worker(int resultfd)
 {
   struct sched_stats initial;
   struct sched_stats current;
+  int max_level = 0;
 
   if(sched_get_stats(&initial) < 0)
     exit(1);
@@ -266,16 +294,22 @@ mlfq_cpu_worker(int resultfd)
     burn();
     if(sched_get_stats(&current) < 0)
       exit(1);
-  } while(current.runtime_ticks - initial.runtime_ticks < 8);
-  write_result(resultfd, 0);
+    if(current.mlfq_level > max_level)
+      max_level = current.mlfq_level;
+  } while(current.runtime_ticks - initial.runtime_ticks < MLFQ_CPU_TICKS);
+  write_result_details(resultfd, 0, initial.mlfq_epoch, max_level);
   exit(0);
 }
 
+/**
+ * mlfq_gaming_worker 在每个短 CPU 片段后主动睡眠，验证队列预算不会随 dispatch 清零。
+ */
 static void
 mlfq_gaming_worker(int resultfd)
 {
   struct sched_stats before;
   struct sched_stats after;
+  int max_level = 0;
 
   if(sched_get_stats(&before) < 0)
     exit(1);
@@ -284,18 +318,22 @@ mlfq_gaming_worker(int resultfd)
       burn();
       if(sched_get_stats(&after) < 0)
         exit(1);
+      if(after.mlfq_level > max_level)
+        max_level = after.mlfq_level;
     } while(after.runtime_ticks - before.runtime_ticks < (uint64)(i + 1));
     sleep(1);
   }
-  write_result(resultfd, 1);
+  write_result_details(resultfd, 1, before.mlfq_epoch, max_level);
   exit(0);
 }
 
+/** 长时 CPU worker 等待全局 priority boost，并回报 boost 前后的代际。 */
 static void
 mlfq_boost_worker(int resultfd)
 {
   struct sched_stats initial;
   struct sched_stats current;
+  int max_level = 0;
 
   if(sched_get_stats(&initial) < 0)
     exit(1);
@@ -303,10 +341,12 @@ mlfq_boost_worker(int resultfd)
     burn();
     if(sched_get_stats(&current) < 0)
       exit(1);
-    if(current.runtime_ticks - initial.runtime_ticks > 96)
+    if(current.mlfq_level > max_level)
+      max_level = current.mlfq_level;
+    if(current.runtime_ticks - initial.runtime_ticks > MLFQ_BOOST_RUNTIME_LIMIT)
       exit(1);
   } while(current.mlfq_epoch == initial.mlfq_epoch);
-  write_result(resultfd, 2);
+  write_result_details(resultfd, 2, initial.mlfq_epoch, max_level);
   exit(0);
 }
 
@@ -331,6 +371,116 @@ run_one_result_worker(void (*worker)(int), struct worker_result *result)
   return 0;
 }
 
+/** 同步启动 CPU 密集任务，直到收到 start token 后持续占用 CPU。 */
+static void
+mlfq_competition_cpu_worker(int readyfd, int startfd, int resultfd)
+{
+  char token = 'r';
+  if(write_exact(readyfd, &token, 1) < 0 ||
+     read_exact(startfd, &token, 1) < 0)
+    exit(1);
+  if(consume_runtime_ticks(MLFQ_COMPETITION_CPU_TICKS) < 0)
+    exit(1);
+  write_result(resultfd, 0);
+  exit(0);
+}
+
+/**
+ * mlfq_interactive_worker 周期性睡眠后只执行极短控制路径，模拟交互任务的唤醒。
+ */
+static void
+mlfq_interactive_worker(int readyfd, int startfd, int resultfd)
+{
+  struct sched_stats current;
+  char token = 'r';
+  int max_level = 0;
+
+  if(write_exact(readyfd, &token, 1) < 0 ||
+     read_exact(startfd, &token, 1) < 0)
+    exit(1);
+  for(int i = 0; i < MLFQ_INTERACTIVE_ROUNDS; i++){
+    sleep(MLFQ_INTERACTIVE_SLEEP_TICKS);
+    if(sched_get_stats(&current) < 0)
+      exit(1);
+    if(current.mlfq_level > max_level)
+      max_level = current.mlfq_level;
+  }
+  write_result_details(resultfd, 1, 0, max_level);
+  exit(0);
+}
+
+/**
+ * run_mlfq_competition 验证睡眠型任务在 CPU 密集任务结束前完成且始终停留在 Q0。
+ *
+ * @return 响应顺序和层级均符合预期返回 0，否则返回 -1。
+ */
+static int
+run_mlfq_competition(void)
+{
+  int ready[2];
+  int start[2];
+  int result[2];
+  struct worker_result first;
+  struct worker_result second;
+  char token;
+
+  if(pipe(ready) < 0 || pipe(start) < 0 || pipe(result) < 0)
+    return -1;
+
+  int cpu_pid = fork();
+  if(cpu_pid < 0)
+    return -1;
+  if(cpu_pid == 0){
+    close(ready[0]);
+    close(start[1]);
+    close(result[0]);
+    mlfq_competition_cpu_worker(ready[1], start[0], result[1]);
+  }
+
+  int interactive_pid = fork();
+  if(interactive_pid < 0)
+    return -1;
+  if(interactive_pid == 0){
+    close(ready[0]);
+    close(start[1]);
+    close(result[0]);
+    mlfq_interactive_worker(ready[1], start[0], result[1]);
+  }
+
+  close(ready[1]);
+  close(start[0]);
+  close(result[1]);
+  if(read_exact(ready[0], &token, 1) < 0 ||
+     read_exact(ready[0], &token, 1) < 0)
+    return -1;
+  if(write_exact(start[1], "s", 1) < 0 ||
+     write_exact(start[1], "s", 1) < 0)
+    return -1;
+  close(start[1]);
+  close(ready[0]);
+
+  if(read_exact(result[0], &first, sizeof(first)) < 0 ||
+     read_exact(result[0], &second, sizeof(second)) < 0)
+    return -1;
+  close(result[0]);
+  wait(0);
+  wait(0);
+
+  if(first.id != 1 || second.id != 0){
+    printf("schedtest: mlfq response first=%d second=%d\n", first.id, second.id);
+    return -1;
+  }
+  if(first.max_mlfq_level != 0 || first.stats.mlfq_level != 0){
+    printf("schedtest: mlfq interactive max=%d final=%d\n",
+           first.max_mlfq_level, first.stats.mlfq_level);
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * verify_mlfq 组合验证降级、反 gaming、交互响应和周期 boost 四个行为契约。
+ */
 static int
 verify_mlfq(void)
 {
@@ -340,20 +490,22 @@ verify_mlfq(void)
 
   if(run_one_result_worker(mlfq_cpu_worker, &cpu) < 0 ||
      run_one_result_worker(mlfq_gaming_worker, &gamer) < 0 ||
+     run_mlfq_competition() < 0 ||
      run_one_result_worker(mlfq_boost_worker, &boost) < 0)
     return -1;
 
-  if(cpu.stats.mlfq_level != 2 || cpu.stats.dispatches < 3){
-    printf("schedtest: mlfq cpu level=%d dispatch=%d\n",
-           cpu.stats.mlfq_level, (int)cpu.stats.dispatches);
+  if(cpu.max_mlfq_level != 2 || cpu.stats.dispatches < 3){
+    printf("schedtest: mlfq cpu max_level=%d dispatch=%d\n",
+           cpu.max_mlfq_level, (int)cpu.stats.dispatches);
     return -1;
   }
-  if(gamer.stats.mlfq_level == 0){
+  if(gamer.max_mlfq_level == 0){
     printf("schedtest: mlfq gaming reset budget\n");
     return -1;
   }
-  if(boost.stats.mlfq_epoch == 1){
-    printf("schedtest: mlfq boost not observed\n");
+  if(boost.stats.mlfq_epoch <= boost.initial_mlfq_epoch){
+    printf("schedtest: mlfq boost initial=%d final=%d\n",
+           (int)boost.initial_mlfq_epoch, (int)boost.stats.mlfq_epoch);
     return -1;
   }
   return 0;
@@ -429,12 +581,16 @@ verify_cfs(void)
   return 0;
 }
 
+/** 多核 smoke 对 MLFQ 仍执行完整行为验证，其他策略保留轻量活性检查。 */
 static int
-run_smoke(void)
+run_smoke(int policy)
 {
   const int hints[WORKERS] = {4, 3, 2};
   const int weights[WORKERS] = {1024, 2048, 512};
   struct worker_result results[WORKERS];
+
+  if(policy == SCHED_POLICY_MLFQ)
+    return verify_mlfq();
   return run_barrier_workers(hints, weights, results);
 }
 
@@ -459,7 +615,7 @@ main(int argc, char **argv)
   }
 
   if(argc > 1 && strcmp(argv[1], "smoke") == 0){
-    ok = run_smoke();
+    ok = run_smoke(stats.policy);
   } else {
     switch(stats.policy){
     case SCHED_POLICY_FIFO:


### PR DESCRIPTION
## PR 信息

- 关联 Issue：#136
- 约束来源：#134
- Obsidian 跟进：mental1104/Obsidian#206
- 基线 Commit：`fa8c205c667fbdd0236df9af3168ed616c64a5db`
- 分支：`concept/136-mlfq-closed-loop`
- 最终测试提交：`b8c5641ec6c2bc33d6efdf977bbc44fe537818ab`

## 中心认知与范围

本轮只处理 MLFQ 的一个中心问题：**队列层级、累计时间配额、睡眠唤醒与周期 boost 如何共同形成“响应性 + 防饿死”的闭环。**

不新增另一套调度器，不仿制 Linux 生产调度器；复用当前 `kernel/sched.c`、`sched_get_stats`、`schedtrace`、`schedviz dump` 和既有 `schedtest`。

## 实现

- CPU 密集任务不再只检查最终层级，而是记录运行期间到达过的最低优先级，避免 boost 在结尾把结果重置为 Q0 后产生假阴性。
- 反 gaming 用例在多个短 CPU 片段之间主动睡眠；累计队列预算仍必须触发降级。
- 新增 CPU 密集任务与周期睡眠任务的同步竞争场景：
  - 交互任务必须先于长 CPU 任务完成；
  - 交互任务整个生命周期保持在 Q0；
  - CPU 任务必须出现 Q0→Q1→Q2 的量子耗尽事件；
  - trace 必须出现 `SLEEP`、Q0 恢复运行和 `MLFQ_BOOST`；
  - `CPUS=1` 额外要求出现 `MLFQ_HIGHER_QUEUE` 抢占。
- 混合负载结束后保留 trace 快照，可继续执行 `schedviz dump`。
- 多核 `smoke` 对 MLFQ 复用完整行为断言；其他策略维持原有轻量活性检查。

## 失败判定

以下任一情况均非零退出：未到达 Q2、睡眠清空累计预算、交互任务被降级或晚于 CPU 长任务完成、缺少降级/睡眠/恢复/boost 事件、单核缺少高队列抢占、boost epoch 未推进、trace 丢事件。

## CLI

```bash
make clean
make SCHED_POLICY=mlfq CPUS=3
make qemu SCHED_POLICY=mlfq CPUS=3
# guest
/usr/lib/xv6/tests/schedtest verify
schedviz dump
```

```bash
make clean
make SCHED_POLICY=mlfq CPUS=1
make qemu SCHED_POLICY=mlfq CPUS=1
# guest
/usr/lib/xv6/tests/schedtest verify
schedviz dump
```

稳定结束标记：

```text
schedtest: OK policy=mlfq
SCHEDTRACE done status=0
```

## 自动化验证

Scheduler family CI run `30157768002` 全部通过：

- MLFQ 单核行为测试：通过；
- MLFQ 三核完整行为 smoke：通过；
- RR/FIFO/SJF/STCF/CFS 单核矩阵：通过；
- RR/MLFQ/CFS 三核 smoke：通过；
- runner unit tests、默认 RR 构建、Shell 交互回归、PR regression suites、完整 `usertests`、单核 reparent cleanup：通过。

首轮 run `30157468215` 暴露 `CPUS=3` 下 `saw_higher_queue` 仅赋值未读取的 `-Werror` 编译失败；提交 `b8c5641` 显式消费该诊断状态后，完整矩阵通过。该失败没有被隐藏或标记为通过。

## Review 路径

1. `tests/guest/schedtest.c::verify_mlfq`
2. `tests/guest/schedtest.c::run_mlfq_competition`
3. `tests/guest/schedtest.c::verify_mlfq_trace`
4. `tests/guest/schedtest.c::run_smoke`

## 教学边界

- boost 周期基于全局 scheduler clock；多核下它聚合各 CPU timer tick，不等同墙上时间。
- 周期 `sleep()` 只模拟阻塞 I/O 的调度行为，不建模真实设备延迟。
- 本 PR 不修改 MLFQ 策略实现；它把现有规则提升为可重复、可失败、可导出的行为闭环。

## 文档联动

代码合并后由 mental1104/Obsidian#206 更新：

`Atlas/100-Computer Science/130-Operating System/虚拟化/调度：多级反馈队列.md`

文档将使用本 PR 合并 Commit 的固定链接补齐 `## XV6`、Golden Trace、Source-State-Test Closure、命令、真实测试结果和教学边界。