### PR TITLE
feat: 增强 kalloc 空闲页审计与可验证分配实验

### DIFF
--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -23,15 +23,30 @@ struct run {
 struct {
   struct spinlock lock;
   struct run *freelist;
+  uint64 free_count;
 } kmem[NCPU];
 
 #define NPHYPAGES ((PHYSTOP - KERNBASE) / PGSIZE)
+#define KALLOC_AUDIT_BYTES ((NPHYPAGES + 7) / 8)
 
 struct {
   struct spinlock lock;
   int count[NPHYPAGES];
 } pageref;
 
+// 审计位图只在 memviz 快照期间复用；每一位表示对应物理页是否已在任一
+// CPU freelist 中出现，用于在损坏链表上检测重复节点和环而不无限遍历。
+struct {
+  struct spinlock lock;
+  uchar seen[KALLOC_AUDIT_BYTES];
+} kalloc_audit;
+
+/**
+ * pa_index 将页对齐物理地址换算为 pageref 与审计位图的稳定下标。
+ *
+ * @param pa 位于 [KERNBASE, PHYSTOP) 的页对齐物理地址。
+ * @return 对应物理页下标；参数越界或未对齐时触发 panic。
+ */
 static int
 pa_index(uint64 pa)
 {
@@ -40,6 +55,12 @@ pa_index(uint64 pa)
   return (pa - KERNBASE) / PGSIZE;
 }
 
+/**
+ * page_refcount 读取一个已分配物理页的引用计数。
+ *
+ * @param pa 位于 pageref 管理范围内的页对齐物理地址。
+ * @return 当前引用数；读取期间由 pageref.lock 保护。
+ */
 static int
 page_refcount(uint64 pa)
 {
@@ -52,6 +73,37 @@ page_refcount(uint64 pa)
   return refs;
 }
 
+/**
+ * audit_mark_page 在本轮 allocator 快照中登记一个空闲页。
+ *
+ * @param pa 已完成范围和对齐校验的物理页地址。
+ * @return 首次出现返回 1；同一页已被其他链表节点登记时返回 0。
+ *
+ * 调用者必须持有 kalloc_audit.lock。重复节点既可能来自跨 CPU 重复挂链，
+ * 也可能来自单链表形成环；返回 0 后调用者应停止跟随该链，避免死循环。
+ */
+static int
+audit_mark_page(uint64 pa)
+{
+  int index = pa_index(pa);
+  int byte = index / 8;
+  uchar mask = (uchar)(1U << (index % 8));
+
+  if(kalloc_audit.seen[byte] & mask)
+    return 0;
+  kalloc_audit.seen[byte] |= mask;
+  return 1;
+}
+
+/**
+ * cow_install_writable_page 将当前 COW 叶子替换为可写映射并刷新内核别名。
+ *
+ * @param pagetable 待修改的用户页表。
+ * @param va 页对齐用户虚拟地址。
+ * @param pte 目标叶子 PTE。
+ * @param pa 新映射的页对齐物理地址。
+ * @param flags 新 PTE 权限位。
+ */
 static void
 cow_install_writable_page(pagetable_t pagetable, uint64 va,
                           pte_t *pte, uint64 pa, uint flags)
@@ -68,12 +120,17 @@ cow_install_writable_page(pagetable_t pagetable, uint64 va,
   sfence_vma();
 }
 
+/** 初始化每 CPU 空闲链表、页引用计数和只读审计工作区。 */
 void
 kinit()
 {
-  for(int i = 0; i < NCPU; i++)
+  for(int i = 0; i < NCPU; i++){
     initlock(&kmem[i].lock, "kmem");
+    kmem[i].freelist = 0;
+    kmem[i].free_count = 0;
+  }
   initlock(&pageref.lock, "pageref");
+  initlock(&kalloc_audit.lock, "kalloc_audit");
   freerange(end, (void*)PHYSTOP);
 }
 
@@ -84,9 +141,9 @@ kinit()
  * @param pa_end 可回收物理区间的一过终点，不会加入该地址所在页面。
  *
  * 启动阶段只有 hart 0 执行 kinit，因此可以在各持一次锁的临界区内批量
- * 初始化引用计数和链表。这里故意不复用 kfree()：正常 kfree() 会把整页
- * 写成毒化字节，用于发现释放后使用；若对 2 GiB 初始 RAM 的每一页都做
- * 4 KiB memset，会让每次 QEMU 启动无意义地写满全部物理内存。kalloc()
+ * 初始化引用计数、链表和独立计数器。这里故意不复用 kfree()：正常 kfree()
+ * 会把整页写成毒化字节，用于发现释放后使用；若对 2 GiB 初始 RAM 的每一页
+ * 都做 4 KiB memset，会让每次 QEMU 启动无意义地写满全部物理内存。kalloc()
  * 仍会在页面真正分配时写入调试字节，因此该优化不改变已分配页的初始化语义。
  */
 void
@@ -101,11 +158,21 @@ freerange(void *pa_start, void *pa_end)
     pageref.count[pa_index((uint64)p)] = 0;
     r->next = kmem[0].freelist;
     kmem[0].freelist = r;
+    kmem[0].free_count++;
   }
   release(&kmem[0].lock);
   release(&pageref.lock);
 }
 
+/**
+ * kfree 释放一个物理页引用，并在最后一个引用消失时归还当前 CPU freelist。
+ *
+ * @param pa 页对齐物理地址；必须来自 kalloc 管理范围且当前引用数为正。
+ *
+ * 重复释放由 pageref 的 `ref <= 0` 守卫触发 `panic("kfree ref")`，这是
+ * allocator 的负向 oracle。页面只有在引用数降到 0 后才会被毒化并重新挂链；
+ * freelist 指针和 free_count 始终在同一个 kmem 锁临界区内同步更新。
+ */
 void
 kfree(void *pa)
 {
@@ -135,10 +202,20 @@ kfree(void *pa)
   acquire(&kmem[id].lock);
   r->next = kmem[id].freelist;
   kmem[id].freelist = r;
+  kmem[id].free_count++;
   release(&kmem[id].lock);
   pop_off();
 }
 
+/**
+ * kalloc 从当前 CPU freelist 取一页；本地为空时依次从其他 CPU 偷取一页。
+ *
+ * @return 成功时返回一页物理内存，所有权引用计数设为 1；耗尽时返回 0。
+ *
+ * 该固定粒度分配器只执行链表头部移除，不实现可变大小分割、相邻合并或
+ * first/best/worst-fit。freelist 与 free_count 在同一锁内更新；若链表非空但
+ * 计数为 0，说明元数据已失配并立即 panic，而不是让计数静默下溢。
+ */
 void *
 kalloc(void)
 {
@@ -149,8 +226,12 @@ kalloc(void)
 
   acquire(&kmem[id].lock);
   r = kmem[id].freelist;
-  if(r)
+  if(r){
+    if(kmem[id].free_count == 0)
+      panic("kalloc count");
     kmem[id].freelist = r->next;
+    kmem[id].free_count--;
+  }
   release(&kmem[id].lock);
 
   if(!r){
@@ -159,8 +240,12 @@ kalloc(void)
         continue;
       acquire(&kmem[i].lock);
       r = kmem[i].freelist;
-      if(r)
+      if(r){
+        if(kmem[i].free_count == 0)
+          panic("kalloc count");
         kmem[i].freelist = r->next;
+        kmem[i].free_count--;
+      }
       release(&kmem[i].lock);
       if(r)
         break;
@@ -184,20 +269,20 @@ free_mem(void)
 
   for(int i = 0; i < NCPU; i++){
     acquire(&kmem[i].lock);
-    for(struct run *r = kmem[i].freelist; r; r = r->next)
-      pages++;
+    pages += kmem[i].free_count;
     release(&kmem[i].lock);
   }
   return pages * PGSIZE;
 }
 
 /**
- * kalloc_mem_snapshot 按物理地址采集 allocator 管理页的空闲分布。
+ * kalloc_mem_snapshot 按物理地址采集 allocator 管理页的空闲分布并审计元数据。
  *
  * @param snapshot 输出快照；调用者必须先清零，函数会填写 kalloc 相关字段。
  *
  * 所有 kmem 锁按 CPU 编号递增获取、递减释放。持锁期间只遍历 freelist 和
- * 写内核栈上的快照，不打印、不 copyout，也不申请新页。
+ * 写静态审计位图/内核快照，不打印、不 copyout，也不申请新页。独立 free_count
+ * 与实际链表遍历数必须相等；审计位图同时阻止重复节点或环导致无限遍历。
  */
 void
 kalloc_mem_snapshot(struct memviz_snapshot *snapshot)
@@ -215,29 +300,52 @@ kalloc_mem_snapshot(struct memviz_snapshot *snapshot)
     snapshot->physical[cell].total_pages++;
   }
 
+  acquire(&kalloc_audit.lock);
+  memset(kalloc_audit.seen, 0, sizeof(kalloc_audit.seen));
   for(int i = 0; i < NCPU; i++)
     acquire(&kmem[i].lock);
 
-  uint64 free = 0;
+  uint64 listed_free = 0;
+  uint64 counter_free = 0;
   for(int cpu = 0; cpu < NCPU; cpu++){
+    uint64 cpu_listed = 0;
+    counter_free += kmem[cpu].free_count;
+
     for(struct run *r = kmem[cpu].freelist; r; r = r->next){
       uint64 pa = (uint64)r;
-      if(pa < start || pa >= PHYSTOP || ((pa - start) % PGSIZE) != 0)
-        panic("kalloc snapshot");
+      if(pa < start || pa >= PHYSTOP || ((pa - start) % PGSIZE) != 0){
+        snapshot->allocator_invalid_nodes++;
+        break;
+      }
+      if(!audit_mark_page(pa)){
+        snapshot->allocator_duplicate_pages++;
+        break;
+      }
 
       uint64 page = (pa - start) / PGSIZE;
       int cell = (page * MEMVIZ_CELLS) / total;
       snapshot->physical[cell].free_pages++;
       snapshot->cpu_free_pages[cpu]++;
-      free++;
+      cpu_listed++;
+      listed_free++;
     }
+
+    if(cpu_listed != kmem[cpu].free_count)
+      snapshot->allocator_count_mismatches++;
   }
 
   for(int i = NCPU - 1; i >= 0; i--)
     release(&kmem[i].lock);
+  release(&kalloc_audit.lock);
 
-  snapshot->free_pages = free;
-  snapshot->used_pages = total - free;
+  snapshot->free_pages = listed_free;
+  snapshot->used_pages = listed_free <= total ? total - listed_free : 0;
+  snapshot->allocator_counter_free_pages = counter_free;
+  snapshot->allocator_invariant_ok =
+    listed_free <= total && listed_free == counter_free &&
+    snapshot->allocator_duplicate_pages == 0 &&
+    snapshot->allocator_invalid_nodes == 0 &&
+    snapshot->allocator_count_mismatches == 0;
 }
 
 void

--- a/kernel/memviz.h
+++ b/kernel/memviz.h
@@ -201,6 +201,14 @@ struct memviz_snapshot {
   uint64 cpu_free_pages[NCPU];
   struct memviz_cell physical[MEMVIZ_CELLS];
 
+  // kalloc 元数据审计结果。listed free pages 来自实际链表遍历，counter free
+  // pages 来自每 CPU 独立计数器；其余字段非零即为负向 oracle 命中。
+  uint64 allocator_counter_free_pages;
+  uint64 allocator_duplicate_pages;
+  uint64 allocator_invalid_nodes;
+  uint64 allocator_count_mismatches;
+  uint64 allocator_invariant_ok;
+
   uint64 kernel_pagetable;
   uint64 kernel_sp;
   uint64 kernel_stack_guard_start;

--- a/tests/guest/memviztest.c
+++ b/tests/guest/memviztest.c
@@ -6,6 +6,11 @@
 #include "kernel/memviz.h"
 #include "user/user.h"
 
+#define ALLOC_TRACE_PAGES 4
+#define ALLOC_STRESS_CHILDREN 4
+#define ALLOC_STRESS_ROUNDS 8
+#define ALLOC_STRESS_PAGES 2
+
 static struct memviz_snapshot before;
 static struct memviz_snapshot after_alloc;
 static struct memviz_snapshot after_free;
@@ -100,6 +105,84 @@ check_dynamic_state_totals(struct memviz_snapshot *snapshot)
     fail("dynamic global state totals");
   if(resident + cow + lazy + mmap_pages != snapshot->dynamic_page_count)
     fail("dynamic state partition");
+}
+
+/**
+ * 校验实际 freelist、独立计数器和损坏检测字段形成闭环。
+ *
+ * @param snapshot 任意 memsnapshot 视图返回的统一快照。
+ *
+ * duplicate、invalid 和 count mismatch 是 allocator 的非破坏性负向 oracle；
+ * 任一字段非零都说明空闲页元数据不再能被可信地遍历和计数。
+ */
+static void
+check_allocator_audit(struct memviz_snapshot *snapshot)
+{
+  if(!snapshot->allocator_invariant_ok)
+    fail("allocator audit failed");
+  if(snapshot->allocator_duplicate_pages != 0)
+    fail("allocator duplicate page");
+  if(snapshot->allocator_invalid_nodes != 0)
+    fail("allocator invalid node");
+  if(snapshot->allocator_count_mismatches != 0)
+    fail("allocator count mismatch");
+  if(snapshot->allocator_counter_free_pages != snapshot->free_pages)
+    fail("allocator counter/list mismatch");
+  if(snapshot->free_pages + snapshot->used_pages != snapshot->total_pages)
+    fail("allocator total mismatch");
+}
+
+/**
+ * 输出一条稳定的 allocator 阶段证据。
+ *
+ * @param stage baseline、allocated、returned、reallocated 或 final。
+ * @param snapshot 当前物理页池快照。
+ */
+static void
+print_allocator_stage(char *stage, struct memviz_snapshot *snapshot)
+{
+  printf("ALLOC TRACE stage=%s free=%d used=%d listed=%d counter=%d audit=%s\n",
+         stage, (int)snapshot->free_pages, (int)snapshot->used_pages,
+         (int)snapshot->free_pages,
+         (int)snapshot->allocator_counter_free_pages,
+         snapshot->allocator_invariant_ok ? "ok" : "fail");
+  printf("ALLOC TRACE oracle duplicate=%d invalid=%d count-mismatch=%d\n",
+         (int)snapshot->allocator_duplicate_pages,
+         (int)snapshot->allocator_invalid_nodes,
+         (int)snapshot->allocator_count_mismatches);
+}
+
+/**
+ * 查询一组已触页用户地址对应的真实物理页并输出 VA -> PA -> kalloc cell。
+ *
+ * @param phase owned 或 reallocated，用于区分两轮所有权。
+ * @param base 用户区间首地址，必须按页对齐。
+ * @param pages 连续页数，不能超过 ALLOC_TRACE_PAGES。
+ * @param physical 接收每页物理地址的数组。
+ */
+static void
+trace_allocated_pages(char *phase, char *base, int pages, uint64 *physical)
+{
+  if(pages <= 0 || pages > ALLOC_TRACE_PAGES)
+    fail("allocator trace page count");
+
+  for(int page = 0; page < pages; page++){
+    struct memviz_va_query query;
+    uint64 va = (uint64)base + (uint64)page * PGSIZE;
+    if(vaquery(va, &query) < 0 || !query.present)
+      fail("allocator trace VA missing");
+    if(query.pa < before.kalloc_start || query.pa >= before.kalloc_end)
+      fail("allocator trace PA outside kalloc");
+    if(query.kalloc_cell < 0 || query.kalloc_cell >= MEMVIZ_CELLS)
+      fail("allocator trace cell");
+
+    for(int previous = 0; previous < page; previous++)
+      if(physical[previous] == query.pa)
+        fail("allocator trace duplicate PA");
+    physical[page] = query.pa;
+    printf("ALLOC TRACE phase=%s page=%d va=%p pa=%p cell=%d\n",
+           phase, page, va, query.pa, query.kalloc_cell);
+  }
 }
 
 /**
@@ -221,8 +304,7 @@ test_user_snapshot(void)
   if(before.process_size > before.user_limit)
     fail("process size above user limit");
   check_dynamic_state_totals(&before);
-  if(before.free_pages + before.used_pages != before.total_pages)
-    fail("physical total in user view");
+  check_allocator_audit(&before);
 
   printf("memviztest: user invariants OK\n");
 }
@@ -361,12 +443,13 @@ test_dynamic_page_states(void)
   printf("memviztest: dynamic page states OK\n");
 }
 
-/** 验证 cell、CPU freelist 与全局页数相互一致。 */
+/** 验证 cell、CPU freelist、独立计数器与全局页数相互一致。 */
 static void
 test_physical_snapshot(void)
 {
   if(memsnapshot(MEMVIZ_VIEW_PHYS, &before) < 0)
     fail("physical snapshot syscall");
+  check_allocator_audit(&before);
 
   uint64 cell_total = 0;
   uint64 cell_free = 0;
@@ -400,13 +483,23 @@ test_physical_snapshot(void)
   printf("memviztest: physical invariants OK\n");
 }
 
-/** 验证触页会消耗物理页，缩容后页面会归还 kalloc。 */
+/**
+ * 验证分配、释放、非法重复缩容和再分配形成可观察的完整页生命周期。
+ *
+ * 该用例不假设再分配必然取得相同 PA：per-CPU LIFO 与进程迁移会影响重用页，
+ * 因此重用数量只作为证据输出；必须断言的是每轮页面可追踪且最终无泄漏。
+ */
 static void
 test_allocate_and_release(void)
 {
-  const int pages = 4;
+  const int pages = ALLOC_TRACE_PAGES;
+  uint64 first_physical[ALLOC_TRACE_PAGES] = {0};
+  uint64 second_physical[ALLOC_TRACE_PAGES] = {0};
+
   if(memsnapshot(MEMVIZ_VIEW_PHYS, &before) < 0)
     fail("baseline physical snapshot");
+  check_allocator_audit(&before);
+  print_allocator_stage("baseline", &before);
 
   char *base = sbrk(pages * PGSIZE);
   if(base == (char *)-1)
@@ -416,17 +509,132 @@ test_allocate_and_release(void)
 
   if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_alloc) < 0)
     fail("allocated physical snapshot");
+  check_allocator_audit(&after_alloc);
   if(after_alloc.free_pages + pages > before.free_pages)
     fail("touched pages did not reduce free memory");
+  trace_allocated_pages("owned", base, pages, first_physical);
+  print_allocator_stage("allocated", &after_alloc);
 
   if(sbrk(-pages * PGSIZE) == (char *)-1)
     fail("sbrk release");
   if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_free) < 0)
     fail("released physical snapshot");
+  check_allocator_audit(&after_free);
   if(after_free.free_pages != before.free_pages)
     fail("released pages did not return to kalloc");
+  print_allocator_stage("returned", &after_free);
 
-  printf("memviztest: allocate/release OK\n");
+  if(after_free.process_size > 0x7fffffff - PGSIZE)
+    fail("process too large for invalid shrink oracle");
+  int invalid_shrink = (int)after_free.process_size + PGSIZE;
+  if(sbrk(-invalid_shrink) != (char *)-1)
+    fail("invalid repeated release accepted");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_alloc) < 0)
+    fail("invalid release snapshot");
+  check_allocator_audit(&after_alloc);
+  if(after_alloc.process_size != after_free.process_size ||
+     after_alloc.free_pages != after_free.free_pages)
+    fail("invalid release changed allocator state");
+  printf("ALLOC TRACE negative=repeated-release guard=reject unchanged=yes\n");
+
+  char *second = sbrk(pages * PGSIZE);
+  if(second == (char *)-1)
+    fail("sbrk reallocate");
+  for(int i = 0; i < pages; i++)
+    second[i * PGSIZE] = (char)(i + 16);
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_alloc) < 0)
+    fail("reallocated physical snapshot");
+  check_allocator_audit(&after_alloc);
+  trace_allocated_pages("reallocated", second, pages, second_physical);
+
+  int reused = 0;
+  for(int current = 0; current < pages; current++)
+    for(int previous = 0; previous < pages; previous++)
+      if(second_physical[current] == first_physical[previous])
+        reused++;
+  print_allocator_stage("reallocated", &after_alloc);
+  printf("ALLOC TRACE reuse=%d/%d policy=per-cpu-lifo-local-first\n",
+         reused, pages);
+
+  if(sbrk(-pages * PGSIZE) == (char *)-1)
+    fail("sbrk final release");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_free) < 0)
+    fail("final physical snapshot");
+  check_allocator_audit(&after_free);
+  if(after_free.free_pages != before.free_pages)
+    fail("reallocated pages leaked");
+  print_allocator_stage("final", &after_free);
+  printf("ALLOC TRACE done status=0 split=none coalesce=none granularity=%d\n",
+         PGSIZE);
+
+  printf("memviztest: allocate/release/reallocate OK\n");
+}
+
+/**
+ * 在子进程中反复触发两页分配与归还，作为并发 allocator 压力源。
+ *
+ * @return 不返回；任一 sbrk 失败以非零状态退出。
+ */
+static void
+allocator_stress_worker(void)
+{
+  for(int round = 0; round < ALLOC_STRESS_ROUNDS; round++){
+    char *base = sbrk(ALLOC_STRESS_PAGES * PGSIZE);
+    if(base == (char *)-1)
+      exit(1);
+    for(int page = 0; page < ALLOC_STRESS_PAGES; page++)
+      base[page * PGSIZE] = (char)(round + page);
+    if(sbrk(-ALLOC_STRESS_PAGES * PGSIZE) == (char *)-1)
+      exit(1);
+  }
+  exit(0);
+}
+
+/**
+ * 在子进程分配/释放期间反复采样全部 per-CPU freelist，验证锁与计数闭环。
+ *
+ * 多核运行能覆盖真实并发临界区；CPUS=1 运行验证同一逻辑在调度交错下不依赖
+ * 并行时序。所有子进程回收后，空闲页总数必须恢复到基线。
+ */
+static void
+test_allocator_concurrency(void)
+{
+  int pids[ALLOC_STRESS_CHILDREN];
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &before) < 0)
+    fail("stress baseline snapshot");
+  check_allocator_audit(&before);
+
+  for(int child = 0; child < ALLOC_STRESS_CHILDREN; child++){
+    pids[child] = fork();
+    if(pids[child] < 0)
+      fail("stress fork");
+    if(pids[child] == 0)
+      allocator_stress_worker();
+  }
+
+  for(int sample = 0; sample < 24; sample++){
+    if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_alloc) < 0)
+      fail("stress snapshot");
+    check_allocator_audit(&after_alloc);
+  }
+
+  for(int child = 0; child < ALLOC_STRESS_CHILDREN; child++){
+    int status = -1;
+    int pid = wait(&status);
+    if(pid < 0 || status != 0)
+      fail("stress child status");
+  }
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &after_free) < 0)
+    fail("stress final snapshot");
+  check_allocator_audit(&after_free);
+  if(after_free.free_pages != before.free_pages)
+    fail("stress leaked physical pages");
+
+  printf("ALLOC TRACE stress children=%d rounds=%d pages=%d audit=ok restored=yes\n",
+         ALLOC_STRESS_CHILDREN, ALLOC_STRESS_ROUNDS, ALLOC_STRESS_PAGES);
+  printf("memviztest: allocator concurrency OK\n");
 }
 
 /** 验证当前内核栈、MMIO 和用户别名窗口可观察。 */
@@ -569,9 +777,10 @@ run_named(char *name)
     test_dynamic_page_states();
   } else if(strcmp(name, "phys") == 0)
     test_physical_snapshot();
-  else if(strcmp(name, "alloc") == 0)
+  else if(strcmp(name, "alloc") == 0){
     test_allocate_and_release();
-  else if(strcmp(name, "kernel") == 0)
+    test_allocator_concurrency();
+  } else if(strcmp(name, "kernel") == 0)
     test_kernel_snapshot();
   else if(strcmp(name, "pagetable") == 0)
     test_pagetable_snapshot();
@@ -596,6 +805,7 @@ main(int argc, char **argv)
     test_dynamic_page_states();
     test_physical_snapshot();
     test_allocate_and_release();
+    test_allocator_concurrency();
     test_kernel_snapshot();
     test_pagetable_snapshot();
   } else if(argc == 2){


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #141
- 约束来源：#134
- 变更类型：功能 / 测试
- 影响范围：`kernel/kalloc.c`、`kernel/memviz.h`、`tests/guest/memviztest.c`
- 一句话摘要：在既有 per-CPU 物理页分配器上增加独立计数与只读审计，并通过 `memviztest alloc` 建立分配、释放、再分配和并发采样闭环。
- 基线 Commit：`fa8c205c667fbdd0236df9af3168ed616c64a5db`

## 实现了什么

- 为每个 `kmem` freelist 增加与链表指针同锁更新的 `free_count`，`kalloc()`、`kfree()` 与启动期 `freerange()` 保持计数和挂链/摘链原子一致。
- `kalloc_mem_snapshot()` 使用静态位图审计所有 per-CPU freelist，识别重复页/环、非法节点和链表计数不一致；快照同时暴露实际遍历页数、独立计数器总数和审计结果。
- 保留现有固定 4096 字节页分配策略：当前 CPU 链表头优先，本地耗尽后依 CPU 顺序偷取；没有引入第二套 allocator，也没有伪造可变大小分割、合并或 fit 策略。
- `memviztest alloc` 自动执行基线采样、4 页触页、VA→PA→kalloc cell 查询、归还、非法重复缩容、再次分配和最终回收，并输出稳定 `ALLOC TRACE` 证据。
- 增加多子进程反复分配/释放期间的 freelist 快照压力，验证单核调度交错和多核临界区下审计不变量。

## 添加/修改了什么测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `test_physical_snapshot` | 物理页池静态快照 | freelist 遍历数、每 CPU 汇总、独立 `free_count`、cell 总数全部一致，所有负向 oracle 为 0 |
| `test_allocate_and_release` | 分配→使用→释放→非法重复缩容→再分配→最终释放 | 每个已触页 VA 存在有效 PA；释放后空闲页恢复；非法缩容不改变 `p->sz` 和页数；第二轮结束无泄漏 |
| `test_allocator_concurrency` | 4 个子进程反复分配/释放，父进程并发采样 | 每次快照审计通过，子进程正常退出，回收后空闲页恢复基线 |

## CLI 回归

```bash
make clean
make
make qemu
```

进入 xv6 shell：

```text
memviztest alloc
```

稳定验收信号：

```text
ALLOC TRACE stage=baseline ... audit=ok
ALLOC TRACE phase=owned page=0 va=... pa=... cell=...
ALLOC TRACE stage=returned ... audit=ok
ALLOC TRACE negative=repeated-release guard=reject unchanged=yes
ALLOC TRACE phase=reallocated page=0 va=... pa=... cell=...
ALLOC TRACE reuse=<0..4>/4 policy=per-cpu-lifo-local-first
ALLOC TRACE stage=final ... audit=ok
ALLOC TRACE stress children=4 rounds=8 pages=2 audit=ok restored=yes
memviztest: OK
```

PA 和重用数量受 per-CPU LIFO 与进程迁移影响，不作为稳定断言；阶段、计数闭环和审计状态是验收信号。

## 自动化测试结果

GitHub Actions：[`xv6 CI #376`](https://github.com/mental1104/xv6/actions/runs/30157476609)

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `make clean` + `make -j2` | 通过 | `Build xv6` 成功 |
| `python3 tests/run.py --suite lab-basic --suite lab-vm --suite lab7-thread --suite lab8-locks --suite lab9-symlink --suite lab10-mmap --suite usertests-core --cpus 3` | 通过 | `Run selected PR QEMU regression` 成功；`lab-vm` 通过 `xv6test --group lab3` 执行完整 `memviztest` |
| `make test-suite SUITE=lab-vm CPUS=1` | 通过 | `Run VM regression single-core` 成功 |
| Scheduler family CI | 通过 | `Scheduler family CI #174` 成功 |
| uthread debug | 通过 | `uthread debug #154` 成功 |

CI runner 只将 guest 业务输出保存在测试进程内部并以 `XV6TEST done status=0` 作为宿主机稳定协议；`ALLOC TRACE` 的逐行原始证据可通过上述 guest CLI 直接复现。

## Review 主线

1. `kernel/kalloc.c`
   - 先确认 freelist 指针和 `free_count` 的同锁更新、锁顺序及重复释放/计数失配 oracle。
2. `kernel/memviz.h`
   - 再确认新增字段只描述既有 allocator 状态，不携带渲染策略。
3. `tests/guest/memviztest.c`
   - 最后沿 `ALLOC TRACE` 检查单页 VA→PA 证据、资源回收、非法路径和并发审计闭环。

## 教学边界

- 当前 `kalloc` 只管理固定 4 KiB 物理页，因此不存在可变大小 allocator 的 split、coalesce、first-fit、best-fit 或 worst-fit。
- 物理页层不会出现“大小不同的空闲洞”这种外部碎片；上层按整页满足非整页需求时仍可能产生页内浪费。
- `free_count` 是 freelist 的派生计数，真实链表遍历和审计位图提供独立校验；它不是第二套 allocator。
