### PR TITLE
test: 建立 CPU、内存与 I/O 虚拟化可验证闭环

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ UPROGS=\
 	$U/_memtargettest\
 	$U/_pgtbltest\
 	$U/_semaphoretest\
+	$U/_ostepintrotest\
 	$U/_vaaccesstest\
 	$U/_addresswindowtest\
 	$U/_wc\

--- a/tests/ci_plan.py
+++ b/tests/ci_plan.py
@@ -76,6 +76,7 @@ VM_PATHS = {
     "tests/guest/cowtest.c",
     "tests/guest/lazytests.c",
     "tests/guest/memviztest.c",
+    "tests/guest/ostepintrotest.c",
     "tests/guest/vaaccesstest.c",
 }
 CONCURRENCY_PATHS = {

--- a/tests/guest/ostepintrotest.c
+++ b/tests/guest/ostepintrotest.c
@@ -1,0 +1,394 @@
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/riscv.h"
+#include "kernel/fcntl.h"
+#include "kernel/schedstat.h"
+#include "kernel/schedtrace_abi.h"
+#include "user/user.h"
+
+// 调度轨迹快照较大，放在 BSS 中避免占用 xv6 单页用户栈。
+static struct schedtrace_snapshot trace_snapshot;
+
+struct memory_observation {
+  uint64 address;
+  int before;
+  int after;
+};
+
+/**
+ * 输出稳定失败原因并以非零状态终止当前测试进程。
+ *
+ * @param message 描述未满足的不变量或失败步骤。
+ */
+static void
+fail(char *message)
+{
+  printf("ostepintrotest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 断言一个测试条件；条件不成立时立即终止测试。
+ *
+ * @param condition 非零表示断言成立。
+ * @param message 断言失败时输出的诊断文本。
+ */
+static void
+check(int condition, char *message)
+{
+  if(!condition)
+    fail(message);
+}
+
+/** 执行一段不可被编译器消除的 CPU 工作，等待 timer tick 推进。 */
+static void
+burn(void)
+{
+  volatile unsigned long value = 1;
+  for(int i = 0; i < 100000; i++)
+    value = value * 1664525 + 1013904223;
+}
+
+/**
+ * 让当前进程实际消耗指定数量的调度 runtime tick。
+ *
+ * @param ticks 目标 runtime tick 数，必须为正数。
+ */
+static void
+consume_runtime_ticks(int ticks)
+{
+  struct sched_stats start;
+  struct sched_stats current;
+
+  check(ticks > 0, "runtime tick target is not positive");
+  check(sched_get_stats(&start) == 0, "cannot read initial scheduler stats");
+  do {
+    burn();
+    check(sched_get_stats(&current) == 0, "cannot read current scheduler stats");
+  } while(current.runtime_ticks - start.runtime_ticks < (unsigned long)ticks);
+}
+
+/**
+ * 创建一个先等待 gate、再执行 CPU 工作的子进程。
+ *
+ * @param ticks 子进程需要消耗的 runtime tick 数。
+ * @param release_fd 返回父进程用于释放子进程的 pipe 写端。
+ * @return 新建子进程 PID；基础设施失败时直接终止测试。
+ */
+static int
+start_cpu_worker(int ticks, int *release_fd)
+{
+  int ready[2];
+  int gate[2];
+  int pid;
+  char token;
+
+  check(pipe(ready) == 0, "cannot create ready pipe");
+  check(pipe(gate) == 0, "cannot create worker gate");
+  pid = fork();
+  check(pid >= 0, "cannot fork CPU worker");
+  if(pid == 0){
+    close(ready[0]);
+    close(gate[1]);
+    if(write(ready[1], "r", 1) != 1)
+      exit(1);
+    close(ready[1]);
+    if(read(gate[0], &token, 1) != 1)
+      exit(1);
+    close(gate[0]);
+    consume_runtime_ticks(ticks);
+    exit(0);
+  }
+
+  close(ready[1]);
+  close(gate[0]);
+  check(read(ready[0], &token, 1) == 1, "CPU worker did not become ready");
+  close(ready[0]);
+  *release_fd = gate[1];
+  return pid;
+}
+
+/**
+ * 释放一个等待 gate 的 CPU worker。
+ *
+ * @param release_fd start_cpu_worker() 返回的 pipe 写端；本函数会关闭它。
+ */
+static void
+release_cpu_worker(int release_fd)
+{
+  check(write(release_fd, "x", 1) == 1, "cannot release CPU worker");
+  close(release_fd);
+}
+
+/**
+ * 等待指定子进程成功退出，确保失败不会被另一个子进程的状态掩盖。
+ *
+ * @param pid 需要回收的直接子进程 PID。
+ */
+static void
+wait_successfully(int pid)
+{
+  int status = 0;
+  check(waitpid(pid, &status, 0) == pid, "waitpid returned unexpected child");
+  check(status == 0, "child process exited with failure");
+}
+
+/**
+ * 返回整数位图中置位的数量。
+ *
+ * @param value 需要统计的 CPU 位图。
+ * @return 置位数量。
+ */
+static int
+count_bits(uint value)
+{
+  int count = 0;
+  while(value != 0){
+    count += value & 1;
+    value >>= 1;
+  }
+  return count;
+}
+
+/**
+ * 验证两个 CPU-bound 进程都被调度；单核配置还必须观察到分时复用。
+ *
+ * 测试不要求输出严格交替，也不把当前调度策略当作操作系统通用定义。
+ */
+static void
+test_cpu_virtualization(void)
+{
+  int first_pid;
+  int second_pid;
+  int first_release;
+  int second_release;
+  int first_starts = 0;
+  int first_stops = 0;
+  int second_starts = 0;
+  int second_stops = 0;
+  uint first_cpu_mask = 0;
+  uint second_cpu_mask = 0;
+
+  check(schedtrace(SCHEDTRACE_OP_RESET, 0, 0) == 0, "cannot reset schedtrace");
+  first_pid = start_cpu_worker(4, &first_release);
+  second_pid = start_cpu_worker(4, &second_release);
+  check(schedtrace(SCHEDTRACE_OP_WATCH_PID, 0, first_pid) == 0,
+        "cannot watch first CPU worker");
+  check(schedtrace(SCHEDTRACE_OP_WATCH_PID, 0, second_pid) == 0,
+        "cannot watch second CPU worker");
+  check(schedtrace(SCHEDTRACE_OP_START, 0, 0) == 0, "cannot start schedtrace");
+
+  release_cpu_worker(first_release);
+  release_cpu_worker(second_release);
+  wait_successfully(first_pid);
+  wait_successfully(second_pid);
+
+  check(schedtrace(SCHEDTRACE_OP_STOP, 0, 0) == 0, "cannot stop schedtrace");
+  check(schedtrace(SCHEDTRACE_OP_READ, &trace_snapshot,
+                   SCHEDTRACE_MAX_EVENTS) == 0,
+        "cannot read schedtrace snapshot");
+  check(trace_snapshot.version == SCHEDTRACE_VERSION,
+        "schedtrace version mismatch");
+  check(trace_snapshot.cpus == XV6_CPUS, "schedtrace CPU count mismatch");
+  check(trace_snapshot.active == 0, "schedtrace remained active after stop");
+  check(trace_snapshot.events > 0, "schedtrace recorded no events");
+  check(trace_snapshot.dropped == 0, "schedtrace dropped experiment events");
+
+  for(int i = 0; i < trace_snapshot.events; i++){
+    struct schedtrace_event *event = &trace_snapshot.events_buffer[i];
+    check(event->pid == first_pid || event->pid == second_pid,
+          "unwatched process leaked into schedtrace");
+    check(event->cpu_id >= 0 && event->cpu_id < NCPU,
+          "schedtrace event contains invalid CPU id");
+
+    if(event->pid == first_pid){
+      first_cpu_mask |= 1U << event->cpu_id;
+      if(event->event_type == SCHEDTRACE_EVENT_RUN_START)
+        first_starts++;
+      else if(event->event_type == SCHEDTRACE_EVENT_RUN_STOP)
+        first_stops++;
+    } else {
+      second_cpu_mask |= 1U << event->cpu_id;
+      if(event->event_type == SCHEDTRACE_EVENT_RUN_START)
+        second_starts++;
+      else if(event->event_type == SCHEDTRACE_EVENT_RUN_STOP)
+        second_stops++;
+    }
+  }
+
+  check(first_starts > 0 && second_starts > 0,
+        "one CPU worker was never scheduled");
+  check(first_starts == first_stops && second_starts == second_stops,
+        "RUN_START and RUN_STOP events are not paired");
+
+  // 单核时两个 CPU-bound worker 必须共享同一 CPU，并至少各经历一次重新调度。
+  if(trace_snapshot.cpus == 1){
+    check(count_bits(first_cpu_mask | second_cpu_mask) == 1,
+          "single-core workers used more than one CPU");
+    check(first_starts > 1 && second_starts > 1,
+          "single-core workers were not time-multiplexed");
+  }
+
+  printf("OSTEP CPU cpus=%d first_starts=%d second_starts=%d shared_cpu=%d\n",
+         trace_snapshot.cpus, first_starts, second_starts,
+         (first_cpu_mask & second_cpu_mask) != 0);
+}
+
+/** 验证 fork 后相同虚拟地址的写入彼此隔离，并回收实验页。 */
+static void
+test_memory_virtualization(void)
+{
+  int report[2];
+  int status = 0;
+  int pid;
+  int parent_after;
+  int observation_size = sizeof(struct memory_observation);
+  int *value;
+  char *page;
+  struct memory_observation observation;
+
+  page = sbrk(PGSIZE);
+  check(page != (char *)-1, "cannot allocate memory experiment page");
+  value = (int *)page;
+  *value = 7;
+  check(pipe(report) == 0, "cannot create memory report pipe");
+
+  pid = fork();
+  check(pid >= 0, "cannot fork memory experiment child");
+  if(pid == 0){
+    close(report[0]);
+    observation.address = (uint64)value;
+    observation.before = *value;
+    *value = 99;
+    observation.after = *value;
+    if(write(report[1], &observation, observation_size) != observation_size)
+      exit(1);
+    close(report[1]);
+    exit(0);
+  }
+
+  close(report[1]);
+  check(read(report[0], &observation, observation_size) == observation_size,
+        "cannot read child memory observation");
+  close(report[0]);
+  check(waitpid(pid, &status, 0) == pid, "cannot reap memory experiment child");
+  check(status == 0, "memory experiment child failed");
+  check(observation.address == (uint64)value,
+        "fork changed the observed virtual address");
+  check(observation.before == 7 && observation.after == 99,
+        "child did not update its private view");
+  parent_after = *value;
+  check(parent_after == 7, "child write changed the parent value");
+  check(sbrk(-PGSIZE) != (char *)-1, "cannot release memory experiment page");
+
+  printf("OSTEP MEMORY same_va=1 parent=%d child=%d isolated=1\n",
+         parent_after, observation.after);
+}
+
+/**
+ * 判断两个字节范围是否完全相等。
+ *
+ * @param left 第一个至少包含 length 字节的缓冲区。
+ * @param right 第二个至少包含 length 字节的缓冲区。
+ * @param length 需要比较的字节数，必须非负。
+ * @return 全部字节相等返回 1，否则返回 0。
+ */
+static int
+bytes_equal(char *left, const char *right, int length)
+{
+  for(int i = 0; i < length; i++)
+    if(left[i] != right[i])
+      return 0;
+  return 1;
+}
+
+/**
+ * 读取普通文件直至 EOF 或缓冲区已满。
+ *
+ * @param path 要读取的文件路径。
+ * @param buffer 接收文件内容的可写缓冲区。
+ * @param capacity 缓冲区容量，单位为字节。
+ * @return 实际读取字节数；打开或读取失败时直接终止测试。
+ */
+static int
+read_file(char *path, char *buffer, int capacity)
+{
+  int fd;
+  int total = 0;
+
+  fd = open(path, O_RDONLY);
+  check(fd >= 0, "cannot open experiment file for reading");
+  while(total < capacity){
+    int count = read(fd, buffer + total, capacity - total);
+    check(count >= 0, "experiment file read failed");
+    if(count == 0)
+      break;
+    total += count;
+  }
+  check(close(fd) == 0, "cannot close experiment input file");
+  return total;
+}
+
+/**
+ * 验证 write() 只服从缓冲区与显式长度，并用多写 NUL 的反例击穿字符串直觉。
+ *
+ * 本测试只证明同一次运行中的可见字节语义，不声称数据已经经受掉电持久化。
+ */
+static void
+test_io_abstraction(void)
+{
+  static const char payload[] = "hello world\n";
+  char exact_buffer[32];
+  char nul_buffer[32];
+  char *exact_path = "ostepio-exact";
+  char *nul_path = "ostepio-nul";
+  int exact_bytes = sizeof(payload) - 1;
+  int payload_storage_bytes = sizeof(payload);
+  int fd;
+
+  unlink(exact_path);
+  unlink(nul_path);
+
+  fd = open(exact_path, O_CREATE | O_TRUNC | O_WRONLY);
+  check(fd >= 0, "cannot create exact-length experiment file");
+  check(write(fd, payload, exact_bytes) == exact_bytes,
+        "exact-length write returned a short count");
+  check(close(fd) == 0, "cannot close exact-length experiment file");
+  check(read_file(exact_path, exact_buffer, sizeof(exact_buffer)) == exact_bytes,
+        "exact-length file size mismatch");
+  check(bytes_equal(exact_buffer, payload, exact_bytes),
+        "exact-length file payload mismatch");
+
+  // sizeof(payload) 包含字符串末尾 NUL；内核不会替调用者推断逻辑字符串长度。
+  fd = open(nul_path, O_CREATE | O_TRUNC | O_WRONLY);
+  check(fd >= 0, "cannot create NUL counterexample file");
+  check(write(fd, payload, payload_storage_bytes) == payload_storage_bytes,
+        "NUL counterexample write returned a short count");
+  check(close(fd) == 0, "cannot close NUL counterexample file");
+  check(read_file(nul_path, nul_buffer, sizeof(nul_buffer)) == payload_storage_bytes,
+        "NUL counterexample file size mismatch");
+  check(bytes_equal(nul_buffer, payload, exact_bytes),
+        "NUL counterexample payload prefix mismatch");
+  check(nul_buffer[exact_bytes] == 0,
+        "explicit sizeof(payload) did not write the trailing NUL");
+
+  check(unlink(exact_path) == 0, "cannot remove exact-length experiment file");
+  check(unlink(nul_path) == 0, "cannot remove NUL counterexample file");
+  printf("OSTEP IO payload=%d exact_file=%d sizeof_file=%d trailing_nul=1\n",
+         exact_bytes, exact_bytes, payload_storage_bytes);
+}
+
+/**
+ * 依次执行 CPU、内存与 I/O 三条可观察闭环。
+ *
+ * @return 所有断言成立时以 exit(0) 结束；任一失败由 fail() 以 exit(1) 结束。
+ */
+int
+main(void)
+{
+  test_cpu_virtualization();
+  test_memory_virtualization();
+  test_io_abstraction();
+  printf("ostepintrotest: OK\n");
+  exit(0);
+}

--- a/tests/guest/ostepintrotest.md
+++ b/tests/guest/ostepintrotest.md
@@ -1,0 +1,15 @@
+# ostepintrotest
+
+Issue #133 的 guest-first 概念实验，统一入口：
+
+```text
+/usr/bin/xv6test --run lab3-ostep-intro
+```
+
+它验证三条最小闭环：
+
+- 两个 CPU-bound 进程都获得运行机会；`CPUS=1` 时还必须共享唯一 CPU lane 并各自被重新调度；
+- `fork` 后父子进程在相同虚拟地址观察到彼此隔离的私有值；
+- `write(fd, buffer, n)` 严格服从显式字节数，`sizeof(payload)` 会把结尾 NUL 一并写入。
+
+该实验不要求多核进程落在同一 CPU，不依赖严格交替顺序，也不证明掉电持久化或生产系统调度策略。

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -34,6 +34,7 @@ static char *lab3_memtarget_argv[] = {XV6_TEST_PATH("memtargettest"), 0};
 static char *lab3_pgtbl_argv[] = {XV6_TEST_PATH("pgtbltest"), 0};
 static char *lab3_vaaccess_argv[] = {XV6_TEST_PATH("vaaccesstest"), 0};
 static char *lab3_address_window_argv[] = {XV6_TEST_PATH("addresswindowtest"), 0};
+static char *lab3_ostep_intro_argv[] = {XV6_TEST_PATH("ostepintrotest"), 0};
 static char *lab4_backtrace_argv[] = {XV6_TEST_PATH("bttest"), 0};
 static char *lab4_alarm_argv[] = {XV6_TEST_PATH("alarmtest"), 0};
 static char *lab5_lazytests_argv[] = {XV6_TEST_PATH("lazytests"), 0};
@@ -95,6 +96,7 @@ static struct xv6_test_case tests[] = {
   {"lab3", "lab3-pgtbl", lab3_pgtbl_argv},
   {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
   {"lab3", "lab3-address-window", lab3_address_window_argv},
+  {"lab3", "lab3-ostep-intro", lab3_ostep_intro_argv},
   {"lab4", "lab4-backtrace", lab4_backtrace_argv},
   {"lab4", "lab4-alarm", lab4_alarm_argv},
   {"lab5", "lab5-lazytests", lab5_lazytests_argv},

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -42,6 +42,14 @@ class CiPlanSelectionTests(unittest.TestCase):
         self.assertEqual(PLANNER.VM_SUITES, plan.suites)
         self.assertFalse(plan.run_shell_history)
 
+    def test_ostep_intro_runs_vm_and_core_regression(self) -> None:
+        """概念实验必须进入多核 VM 回归，并触发工作流中的单核 VM 补充验证。"""
+
+        plan = PLANNER.build_ci_plan(("tests/guest/ostepintrotest.c",))
+
+        self.assertEqual(PLANNER.VM_SUITES, plan.suites)
+        self.assertFalse(plan.run_shell_history)
+
     def test_filesystem_change_keeps_bigfile_boundary_test(self) -> None:
         plan = PLANNER.build_ci_plan(("kernel/fs.c",))
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -42,6 +42,7 @@ GUEST_SOURCE_NAMES = (
     "uthreadtest.c",
     "vaaccesstest.c",
     "addresswindowtest.c",
+    "ostepintrotest.c",
     "testlib.c",
     "xv6test.c",
 )

--- a/user/init.c
+++ b/user/init.c
@@ -82,6 +82,7 @@ static struct image_file image_files[] = {
   {"/memtargettest", XV6_TEST_PATH("memtargettest")},
   {"/pgtbltest", XV6_TEST_PATH("pgtbltest")},
   {"/semaphoretest", XV6_TEST_PATH("semaphoretest")},
+  {"/ostepintrotest", XV6_TEST_PATH("ostepintrotest")},
   {"/vaaccesstest", XV6_TEST_PATH("vaaccesstest")},
   {"/addresswindowtest", XV6_TEST_PATH("addresswindowtest")},
   {"/forktest", XV6_TEST_PATH("forktest")},


### PR DESCRIPTION
## PR 信息

- 关联 Issue：Closes #133
- 参考约束：#134
- 对应 Obsidian Issue：mental1104/Obsidian#199
- 对应 Obsidian Draft PR：mental1104/Obsidian#213
- 当前 `main` 基线：`4c4aa9779f6417ce1951ba38dd3453082b0b9c56`
- 当前实现提交：`7b5c4d86ef83a973a34bfffc0c3b6e49ff739f43`
- 分支：`concept/133-os-intro-virtualization`
- 范围：增加教学型 guest 实验、测试注册、运行时镜像映射、CI 风险映射与实验说明；不新增 CPU、内存或文件系统内核机制。

## 中心认知

用一个可重复执行的 xv6 guest 程序，把三个抽象问题闭合为真实状态变化和行为断言：

1. 两个 CPU-bound 进程如何共享有限 CPU；
2. `fork` 后相同虚拟地址为何仍有独立私有内容；
3. `write(fd, buffer, n)` 为何只服从显式字节数，而不理解 C 字符串。

## 实现

新增 `tests/guest/ostepintrotest.c`：

- **CPU 虚拟化**：创建两个受 pipe gate 控制的 CPU-bound worker；通过 `schedtrace` 断言两者均被调度、`RUN_START/RUN_STOP` 配对且无事件丢失。`CPUS=1` 时额外验证分时复用。
- **内存虚拟化**：父进程写入 `7` 后 `fork`，子进程在相同虚拟地址写入 `99`，父进程仍观察到 `7`；随后回收子进程和实验页。
- **I/O 抽象**：对比写入有效载荷长度和 `sizeof(payload)`，证明 `write(fd, buffer, n)` 严格服从显式字节数，后者会把末尾 NUL 写入文件。

配套入口：

- `Makefile`：编入 `_ostepintrotest`；
- `user/init.c`：迁移到 `/usr/lib/xv6/tests/ostepintrotest`；
- `tests/guest/xv6test.c`：注册 `lab3-ostep-intro`；
- `tests/ci_plan.py`：映射到 VM 与 core 回归；
- `tests/test_ci_plan.py`、`tests/test_runner.py`：锁定 CI 选择和源码归属；
- `tests/guest/ostepintrotest.md`：记录入口、断言和教学边界。

## 主线同步与冲突处理

PR 已重新基于当前 `main` 生成单父提交，避免把主线历史混入评审 diff。共享注册文件按当前主线结构合并：

- `Makefile`：保留信号量、文件系统观察等主线入口，仅追加 `_ostepintrotest`；
- `tests/guest/xv6test.c`：保留 `core-semaphore` 等现有注册，仅追加 `lab3-ostep-intro`；
- `tests/test_runner.py`：保留 canonical guest source 清单，仅追加 `ostepintrotest.c`；
- `user/init.c`：保留信号量测试映射、目录迁移和 swap backing 初始化，仅追加实验路径映射。

同步结果：ahead 1、behind 0；PR 为 8 个预期文件、423 additions、0 deletions，可合并且无冲突。

## 如何通过 CLI 回归观察

```text
/usr/bin/xv6test --run lab3-ostep-intro
```

预期稳定输出：

```text
OSTEP CPU cpus=<1|3> first_starts=<正整数> second_starts=<正整数> shared_cpu=<0|1>
OSTEP MEMORY same_va=1 parent=7 child=99 isolated=1
OSTEP IO payload=12 exact_file=12 sizeof_file=13 trailing_nul=1
ostepintrotest: OK
XV6TEST done status=0
```

## 自动化测试结果

GitHub Actions（提交 `7b5c4d86ef83a973a34bfffc0c3b6e49ff739f43`）：

- xv6 CI #545：通过
  - grader 单元测试与默认构建；
  - selected PR QEMU regression；
  - VM regression `CPUS=1`；
  - complete usertests。
- Scheduler family CI #336：通过
  - PR regression 与 complete usertests；
  - RR/FIFO/SJF/STCF/MLFQ/CFS 单核行为测试；
  - RR/MLFQ/CFS 三核 smoke。
- uthread debug #322：通过。

当前环境未执行本地构建；以上结论来自当前提交对应的 GitHub Actions。

## Review 主线

1. `tests/guest/ostepintrotest.c`
   - 检查 CPU 复用、地址空间隔离和文件字节语义三组断言及资源清理。
2. `tests/guest/xv6test.c` 与 `user/init.c`
   - 确认 guest 注册和运行时绝对路径形成完整入口，并保留当前主线已有注册。
3. `tests/ci_plan.py`、`tests/test_ci_plan.py` 与 `tests/test_runner.py`
   - 确认 VM/core 回归选择和测试源码归属被可执行断言锁定。
4. `Makefile`
   - 确认实验二进制进入镜像且不覆盖主线现有构建入口。

## 教学边界

- 不证明严格交替、固定时间片或 Linux 调度语义；
- 不直接展示父子物理页号；
- I/O 实验不证明掉电持久化；
- 未进行 QEMU/GDB 逐指令跟踪；
- 不把 xv6 教学实现写成操作系统通用定义。

当前提交已完成主线同步与 CI 验证，用户已批准合并。