### PR TITLE
[Concept Lab] 实体化：多级页表

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ UPROGS=\
 	$U/_vawrite\
 	$U/_vaprobe\
 	$U/_memviztest\
+	$U/_pgtbltest\
 	$U/_vaaccesstest\
 	$U/_addresswindowtest\
 	$U/_wc\

--- a/tests/guest/pgtbltest.c
+++ b/tests/guest/pgtbltest.c
@@ -1,4 +1,5 @@
 #include "kernel/types.h"
+#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/riscv.h"
 #include "kernel/memviz.h"

--- a/tests/guest/pgtbltest.c
+++ b/tests/guest/pgtbltest.c
@@ -1,0 +1,245 @@
+#include "kernel/types.h"
+#include "kernel/memlayout.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+
+#define PGTBL_L1_SPAN (512ULL * PGSIZE)
+#define PGTBL_SEARCH_REGIONS 64
+
+// 大型快照和查询结果放在 BSS，避免占用 xv6 单页用户栈。
+static struct memviz_snapshot snapshot;
+static struct memviz_va_query query;
+
+/** 输出稳定失败原因并终止当前测试进程。 */
+static void
+fail(char *message)
+{
+  printf("pgtbltest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 读取并输出一个用户 VA 的真实 Sv39 三级链路。
+ *
+ * @param label 本轮实验中的路径标签。
+ * @param va 待查询的用户虚拟地址。
+ */
+static void
+print_path(char *label, uint64 va)
+{
+  if(vaquery(va, &query) < 0)
+    fail("vaquery");
+
+  printf("PGTBL path label=%s va=%p present=%d\n",
+         label, query.va, query.present);
+  for(int i = 0; i < 3; i++){
+    struct memviz_pte_level *level = &query.levels[i];
+    char *kind = !level->present ? "missing" :
+                 (level->level == 0 ? "leaf" : "branch");
+
+    printf("PGTBL level label=%s level=L%d index=%d present=%d kind=%s pte=%p pa=%p\n",
+           label, level->level, level->index, level->present, kind,
+           level->pte, level->pa);
+    if(!level->present)
+      break;
+  }
+}
+
+/**
+ * 在同一个 L2 分支中寻找两个尚未分配 L0 页表的相邻 2 MiB 区域。
+ *
+ * @param old_break 当前进程逻辑大小的一过地址。
+ * @return 第一段区域的起始 VA；无合适区域时终止测试。
+ */
+static uint64
+find_empty_l1_region(uint64 old_break)
+{
+  uint64 candidate = (old_break + PGTBL_L1_SPAN - 1) &
+                     ~(PGTBL_L1_SPAN - 1);
+
+  for(int attempt = 0; attempt < PGTBL_SEARCH_REGIONS; attempt++){
+    uint64 sparse = candidate + PGTBL_L1_SPAN;
+    if(sparse < candidate || sparse + PGSIZE > USERMAX)
+      break;
+    if(PX(2, candidate) != PX(2, sparse)){
+      candidate += PGTBL_L1_SPAN;
+      continue;
+    }
+
+    if(vaquery(candidate, &query) < 0)
+      fail("dense candidate query");
+    int dense_missing_l1 = query.levels[0].present &&
+                           !query.levels[1].present;
+
+    if(vaquery(sparse, &query) < 0)
+      fail("sparse candidate query");
+    int sparse_missing_l1 = query.levels[0].present &&
+                            !query.levels[1].present;
+
+    if(dense_missing_l1 && sparse_missing_l1)
+      return candidate;
+    candidate += PGTBL_L1_SPAN;
+  }
+
+  fail("no empty L1 region");
+  return 0;
+}
+
+/**
+ * 在子进程中构造密集与稀疏映射，并验证创建、缩容和失败回滚。
+ *
+ * sbrk() 正向扩容只修改逻辑范围。首次写入经 lazy fault 创建数据页和缺失的
+ * 中间页表页；缩容释放 leaf 数据页，但当前 xv6 不立即压缩空中间页表子树。
+ */
+static void
+run_mapping_experiment(void)
+{
+  struct path_identity {
+    uint64 l1_table;
+    uint64 l0_table;
+    uint64 leaf_pa;
+  } dense0, dense1, sparse0;
+
+  // 先写热 COW 缓冲与栈，再记录基线，避免 fork 自身污染物理页差值。
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0 ||
+     vaquery(0, &query) < 0)
+    fail("warmup");
+
+  uint64 old_break = (uint64)sbrk(0);
+  uint64 dense_va = find_empty_l1_region(old_break);
+  uint64 sparse_va = dense_va + PGTBL_L1_SPAN;
+  uint64 reserve_end = sparse_va + PGSIZE;
+  uint64 reserve_size = reserve_end - old_break;
+  if(reserve_size > 0x7fffffffULL)
+    fail("reservation exceeds sbrk argument range");
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("baseline snapshot");
+  uint64 baseline_free = snapshot.free_pages;
+
+  if(sbrk((int)reserve_size) == (char *)-1)
+    fail("lazy reserve");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("reserve snapshot");
+  if(snapshot.free_pages != baseline_free)
+    fail("untouched reservation allocated pages");
+  printf("PGTBL reserve lazy=1 free_unchanged=1 bytes=%d\n",
+         (int)reserve_size);
+
+  print_path("missing", dense_va);
+  if(!query.levels[0].present || query.levels[1].present)
+    fail("missing intermediate path mismatch");
+
+  *(volatile char *)dense_va = 0x11;
+  *(volatile char *)(dense_va + PGSIZE) = 0x22;
+  *(volatile char *)sparse_va = 0x33;
+
+  print_path("dense0", dense_va);
+  if(!query.present)
+    fail("dense0 leaf missing");
+  dense0.l1_table = query.levels[0].pa;
+  dense0.l0_table = query.levels[1].pa;
+  dense0.leaf_pa = query.levels[2].pa;
+
+  print_path("dense1", dense_va + PGSIZE);
+  if(!query.present)
+    fail("dense1 leaf missing");
+  dense1.l1_table = query.levels[0].pa;
+  dense1.l0_table = query.levels[1].pa;
+  dense1.leaf_pa = query.levels[2].pa;
+
+  print_path("sparse0", sparse_va);
+  if(!query.present)
+    fail("sparse leaf missing");
+  sparse0.l1_table = query.levels[0].pa;
+  sparse0.l0_table = query.levels[1].pa;
+  sparse0.leaf_pa = query.levels[2].pa;
+
+  int dense_shared_l1 = dense0.l1_table == dense1.l1_table;
+  int dense_shared_l0 = dense0.l0_table == dense1.l0_table;
+  int dense_distinct_leaf = dense0.leaf_pa != dense1.leaf_pa;
+  if(!dense_shared_l1 || !dense_shared_l0 || !dense_distinct_leaf)
+    fail("dense sharing mismatch");
+  printf("PGTBL relation=dense shared_l1_table=%d shared_l0_table=%d distinct_leaf=%d\n",
+         dense_shared_l1, dense_shared_l0, dense_distinct_leaf);
+
+  int sparse_shared_l1 = dense0.l1_table == sparse0.l1_table;
+  int sparse_shared_l0 = dense0.l0_table == sparse0.l0_table;
+  if(!sparse_shared_l1 || sparse_shared_l0)
+    fail("sparse sharing mismatch");
+  printf("PGTBL relation=sparse shared_l1_table=%d shared_l0_table=%d\n",
+         sparse_shared_l1, sparse_shared_l0);
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("touched snapshot");
+  uint64 touched_free = snapshot.free_pages;
+  if(touched_free >= baseline_free)
+    fail("touch consumed no physical pages");
+
+  if(sbrk(-(int)reserve_size) == (char *)-1)
+    fail("shrink");
+  print_path("after-shrink", dense_va);
+  int leaf_removed = !query.present && !query.levels[2].present;
+  int intermediate_retained = query.levels[0].present &&
+                              query.levels[1].present;
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("shrink snapshot");
+  uint64 shrink_free = snapshot.free_pages;
+  int data_reclaimed = shrink_free >= touched_free + 3;
+  if(!leaf_removed || !intermediate_retained || !data_reclaimed ||
+     shrink_free >= baseline_free)
+    fail("shrink lifecycle mismatch");
+  printf("PGTBL release leaf_removed=%d intermediate_retained=%d data_reclaimed=%d\n",
+         leaf_removed, intermediate_retained, data_reclaimed);
+
+  uint64 rollback_break = (uint64)sbrk(0);
+  uint64 rollback_free = shrink_free;
+  if(sbrk(-0x7fffffff) != (char *)-1)
+    fail("overshrink unexpectedly succeeded");
+  if((uint64)sbrk(0) != rollback_break)
+    fail("overshrink changed break");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("rollback snapshot");
+  if(snapshot.free_pages != rollback_free)
+    fail("overshrink changed physical pages");
+  printf("PGTBL rollback operation=overshrink break_unchanged=1 free_unchanged=1\n");
+}
+
+/**
+ * 父进程验证子进程退出后，freewalk() 会递归回收残留中间页表页。
+ */
+static void
+test_process_exit_reclaim(void)
+{
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("parent baseline snapshot");
+  uint64 baseline_free = snapshot.free_pages;
+
+  int pid = fork();
+  if(pid < 0)
+    fail("fork");
+  if(pid == 0){
+    run_mapping_experiment();
+    exit(0);
+  }
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("mapping experiment child");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("parent final snapshot");
+  if(snapshot.free_pages != baseline_free)
+    fail("process exit did not restore physical pages");
+
+  printf("PGTBL reclaim process_exit=1 free_restored=1\n");
+  printf("PGTBL result=ok\n");
+}
+
+int
+main(void)
+{
+  test_process_exit_reclaim();
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -30,6 +30,7 @@ static char *lab3_copyout_argv[] = {XV6_TEST_PATH("usertests"), "copyout", 0};
 static char *lab3_copyinstr_argv[] = {XV6_TEST_PATH("usertests"), "copyinstr1", 0};
 static char *lab3_sbrkmuch_argv[] = {XV6_TEST_PATH("usertests"), "sbrkmuch", 0};
 static char *lab3_memviz_argv[] = {XV6_TEST_PATH("memviztest"), 0};
+static char *lab3_pgtbl_argv[] = {XV6_TEST_PATH("pgtbltest"), 0};
 static char *lab3_vaaccess_argv[] = {XV6_TEST_PATH("vaaccesstest"), 0};
 static char *lab3_address_window_argv[] = {XV6_TEST_PATH("addresswindowtest"), 0};
 static char *lab4_backtrace_argv[] = {XV6_TEST_PATH("bttest"), 0};
@@ -87,6 +88,7 @@ static struct xv6_test_case tests[] = {
   {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv},
   {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv},
   {"lab3", "lab3-memviz", lab3_memviz_argv},
+  {"lab3", "lab3-pgtbl", lab3_pgtbl_argv},
   {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
   {"lab3", "lab3-address-window", lab3_address_window_argv},
   {"lab4", "lab4-backtrace", lab4_backtrace_argv},

--- a/user/init.c
+++ b/user/init.c
@@ -76,6 +76,7 @@ static struct image_file image_files[] = {
   {"/xv6test", XV6_USR_BIN_PATH("xv6test")},
 
   {"/memviztest", XV6_TEST_PATH("memviztest")},
+  {"/pgtbltest", XV6_TEST_PATH("pgtbltest")},
   {"/vaaccesstest", XV6_TEST_PATH("vaaccesstest")},
   {"/addresswindowtest", XV6_TEST_PATH("addresswindowtest")},
   {"/forktest", XV6_TEST_PATH("forktest")},


### PR DESCRIPTION
## 中心认知与范围

把“多级页表通过按需分配下级页表压缩稀疏地址空间”落实为可运行、可观察、可断言的 xv6 闭环。

本 PR 复用现有 `memsnapshot()`、`vaquery()`、lazy allocation、`uvmunmap()` 与 `freewalk()`，不新增内核机制，也不修改 GitHub Actions。

Closes #144

## 基线

- 开工基线：`fa8c205c667fbdd0236df9af3168ed616c64a5db`
- 实现分支同步基线：`023314da5c4cd1918b53ea0466a247b34e486335`
- 合并前 `main`：`474983407ab789add134c3e6967c443a941f6387`
- 分支：`concept/144-multilevel-page-table`

## 实现

新增独立 guest 实验 `tests/guest/pgtbltest.c`，并注册为 `lab3-pgtbl`：

1. 在同一个 Sv39 L2 分支中寻找两个尚未分配下级页表的相邻 2 MiB 区域；
2. 使用 `sbrk()` 仅扩大逻辑地址范围，证明未触页时不消耗物理页；
3. 构造两页密集映射和一页跨 2 MiB 边界的稀疏映射；
4. 通过 `vaquery()` 输出真实 L2/L1/L0 index、PTE、下一层页表 PA 与 leaf PA；
5. 断言密集页共享 L1/L0 页表、稀疏页共享 L1 但使用不同 L0 页表；
6. 缩容后断言 leaf 已移除、数据页已归还、空中间页表仍保留；
7. 子进程退出后断言 `freewalk()` 递归回收中间页表，物理空闲页恢复；
8. 使用非法超量缩容验证失败路径不会修改 break 或物理页计数。

## 可复制实验入口

```text
/usr/lib/xv6/tests/pgtbltest
/usr/bin/xv6test --run lab3-pgtbl
```

稳定观察行以 `PGTBL` 开头：

```text
PGTBL reserve ...
PGTBL level ... level=L2/L1/L0 ...
PGTBL relation=dense ...
PGTBL relation=sparse ...
PGTBL release ...
PGTBL rollback ...
PGTBL reclaim ...
PGTBL result=ok
```

## 测试对象与不变量

- 测试源码：`tests/guest/pgtbltest.c`
- `xv6test`：`lab3-pgtbl`
- Host suite：PR 选择器运行 `lab-vm` / `lab3`
- Snapshot 边界：实验子进程退出后由父进程核对物理页恢复
- 反例：逻辑范围扩大不等于页表/数据页立即分配；缩容也不等于空中间页表立即回收

## 真实验证结果

GitHub Actions 对 head `eb257bc57596706aeade6cfa70e417d7ccde1845` 的结果：

- `make test-unit`：通过；
- `make clean && make -j2`：通过；
- PR 选择的 CPUS=3 QEMU 回归：通过，包含 `lab3-pgtbl`；
- 完整 `usertests`：通过；
- Scheduler family CI：全部策略单核行为测试与三核 smoke 均通过；
- `uthread debug`：通过。

本实验不依赖并发时序。xv6 CI 的独立 `CPUS=1 lab-vm` 步骤未被当前路径选择器触发，因此不把它列为已执行证据。

## 教学边界

- 本实验观察的是当前仓库 Sv39 三级页表，不把三级视为所有体系结构的通用定义。
- `sbrk()` 正向扩容采用 lazy allocation；触页时才形成 leaf 与缺失中间层。
- 当前 `uvmunmap()` 清除 leaf，但不即时压缩空页表子树；完整地址空间销毁时由 `freewalk()` 回收。
- 失败回滚的稳定 oracle 使用 `sys_sbrk()` 超量缩容拒绝；未引入仅供测试的 `kalloc()` 故障注入。

## 关联归档

代码合并后，以固定 Commit 链接更新：

`Atlas/100-Computer Science/130-Operating System/虚拟化/多级页表.md`
