### PR TITLE
feat: 建立调度入门四策略实验报告闭环

### DIFF
--- a/tests/host/scheduler_visualizer.c
+++ b/tests/host/scheduler_visualizer.c
@@ -20,7 +20,7 @@
 
 /** 登录 Shell 根目录下的完整 ANSI 提示符，用作 QEMU 输入同步边界。 */
 static const char root_shell_prompt[] =
-  "\033[1;38;5;208mroot@xv6\033[0m:\033[1;34m/\033[0m# ";
+  "\033[1;38;5;208mroot@xv6\033[0m:\033[1;34m/root\033[0m# ";
 
 struct options {
   const char *policy;

--- a/tests/test_sched_intro_report.py
+++ b/tests/test_sched_intro_report.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证调度入门 trace 报告器的协议与策略判据。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "sched_intro_report.py"
+SPEC = importlib.util.spec_from_file_location("sched_intro_report", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load report module from {MODULE_PATH}")
+REPORT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = REPORT
+SPEC.loader.exec_module(REPORT)
+
+
+def event_line(
+    seq: int,
+    tick: int,
+    pid: int,
+    event_type: str,
+    reason: str,
+    runtime: int,
+    dispatches: int,
+    remaining: int,
+    cpu: int = 0,
+) -> str:
+    """生成最小但完整的 SCHEDTRACE event 测试行。"""
+
+    return (
+        f"SCHEDTRACE event seq={seq} ts={seq * 10} tick={tick} cpu={cpu} "
+        f"pid={pid} type={event_type} reason={reason} state=4 slice=0 "
+        f"runtime={runtime} dispatches={dispatches} remaining={remaining} "
+        "level=0 epoch=1 weight=1024 vruntime=0 name=schedviz"
+    )
+
+
+def trace_text(policy: str, events: list[str], cpus: int = 1, dropped: int = 0) -> str:
+    """封装带版本头和成功结束标记的 trace。"""
+
+    return "\n".join(
+        [
+            f"SCHEDTRACE version=1 policy={policy} cpus={cpus} "
+            f"events={len(events)} dropped={dropped}",
+            *events,
+            "SCHEDTRACE done status=0",
+            "",
+        ]
+    )
+
+
+def legend_text(rows: list[tuple[str, int, int, int]]) -> str:
+    """生成 schedviz legend 测试文本。"""
+
+    return "\n".join(
+        f"  {glyph} = worker{worker} pid={pid} hint={hint} weight=1024"
+        for glyph, worker, pid, hint in rows
+    )
+
+
+class TraceParsingTests(unittest.TestCase):
+    """验证 SCHEDTRACE 协议和 legend 的严格解析。"""
+
+    def test_parse_complete_trace_and_legend(self) -> None:
+        text = trace_text(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 4, 10, "RUN_STOP", "EXIT", 4, 1, 0),
+            ],
+        )
+        trace = REPORT.parse_trace_text(text)
+        legends = REPORT.parse_legend(legend_text([("A", 0, 10, 4)]))
+
+        self.assertEqual("fifo", trace.policy)
+        self.assertEqual(2, len(trace.events))
+        self.assertEqual(0, legends[10].worker)
+        self.assertEqual(4, legends[10].hint)
+
+    def test_dropped_events_fail_closed(self) -> None:
+        text = trace_text(
+            "rr",
+            [event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 4)],
+            dropped=1,
+        )
+        with self.assertRaisesRegex(REPORT.ExperimentError, "dropped 1"):
+            REPORT.parse_trace_text(text)
+
+    def test_non_increasing_sequence_is_rejected(self) -> None:
+        text = trace_text(
+            "fifo",
+            [
+                event_line(2, 0, 10, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 4, 10, "RUN_STOP", "EXIT", 4, 1, 0),
+            ],
+        )
+        with self.assertRaisesRegex(REPORT.ExperimentError, "strictly increasing"):
+            REPORT.parse_trace_text(text)
+
+
+class PolicyEvidenceTests(unittest.TestCase):
+    """验证四类教材策略各自的完成顺序或抢占证据。"""
+
+    def _derive(
+        self,
+        policy: str,
+        events: list[str],
+        rows: list[tuple[str, int, int, int]],
+    ) -> tuple[object, tuple[object, ...]]:
+        trace = REPORT.parse_trace_text(trace_text(policy, events))
+        metrics = REPORT.derive_metrics(trace, REPORT.parse_legend(legend_text(rows)))
+        return trace, metrics
+
+    def test_fifo_follows_enqueue_order(self) -> None:
+        trace, metrics = self._derive(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 8),
+                event_line(2, 8, 10, "RUN_STOP", "EXIT", 8, 1, 0),
+                event_line(3, 8, 11, "RUN_START", "NONE", 0, 1, 2),
+                event_line(4, 10, 11, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(5, 10, 12, "RUN_START", "NONE", 0, 1, 5),
+                event_line(6, 15, 12, "RUN_STOP", "EXIT", 5, 1, 0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2), ("C", 2, 12, 5)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("enqueue order", evidence)
+        self.assertEqual([8, 10, 15], [metric.completion_tick for metric in metrics])
+
+    def test_sjf_follows_burst_hint(self) -> None:
+        trace, metrics = self._derive(
+            "sjf",
+            [
+                event_line(1, 0, 11, "RUN_START", "NONE", 0, 1, 2),
+                event_line(2, 2, 11, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(3, 2, 12, "RUN_START", "NONE", 0, 1, 5),
+                event_line(4, 7, 12, "RUN_STOP", "EXIT", 5, 1, 0),
+                event_line(5, 7, 10, "RUN_START", "NONE", 0, 1, 8),
+                event_line(6, 15, 10, "RUN_STOP", "EXIT", 8, 1, 0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2), ("C", 2, 12, 5)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("burst hint", evidence)
+        by_worker = {metric.worker: metric for metric in metrics}
+        self.assertEqual(7, by_worker[0].response_ticks)
+        self.assertEqual(0, by_worker[1].response_ticks)
+
+    def test_stcf_uses_preemption_tick_as_short_arrival(self) -> None:
+        trace, metrics = self._derive(
+            "stcf",
+            [
+                event_line(1, 0, 20, "RUN_START", "NONE", 0, 1, 12),
+                event_line(2, 2, 20, "RUN_STOP", "STCF_SHORTER_TASK", 2, 1, 10),
+                event_line(3, 2, 21, "RUN_START", "NONE", 0, 1, 2),
+                event_line(4, 4, 21, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(5, 4, 20, "RUN_START", "NONE", 2, 2, 10),
+                event_line(6, 14, 20, "RUN_STOP", "EXIT", 12, 2, 0),
+            ],
+            [("A", 0, 20, 12), ("B", 1, 21, 2)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+        by_worker = {metric.worker: metric for metric in metrics}
+
+        self.assertIn("shorter-task preemption", evidence)
+        self.assertEqual(2, by_worker[1].arrival_tick)
+        self.assertEqual(0, by_worker[1].response_ticks)
+        self.assertLess(by_worker[1].completion_tick, by_worker[0].completion_tick)
+
+    def test_rr_requires_quantum_rotation_and_repeat_dispatch(self) -> None:
+        trace, metrics = self._derive(
+            "rr",
+            [
+                event_line(1, 0, 30, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 2, 30, "RUN_STOP", "RR_QUANTUM", 2, 1, 2),
+                event_line(3, 2, 31, "RUN_START", "NONE", 0, 1, 4),
+                event_line(4, 4, 31, "RUN_STOP", "RR_QUANTUM", 2, 1, 2),
+                event_line(5, 4, 30, "RUN_START", "NONE", 2, 2, 2),
+                event_line(6, 6, 30, "RUN_STOP", "EXIT", 4, 2, 0),
+                event_line(7, 6, 31, "RUN_START", "NONE", 2, 2, 2),
+                event_line(8, 8, 31, "RUN_STOP", "EXIT", 4, 2, 0),
+            ],
+            [("A", 0, 30, 4), ("B", 1, 31, 4)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("RR quantum", evidence)
+        self.assertTrue(all(metric.dispatches == 2 for metric in metrics))
+
+    def test_stcf_smp_metrics_do_not_require_preemption_boundary(self) -> None:
+        trace = REPORT.parse_trace_text(
+            trace_text(
+                "stcf",
+                [
+                    event_line(1, 0, 20, "RUN_START", "NONE", 0, 1, 12, cpu=0),
+                    event_line(2, 0, 21, "RUN_START", "NONE", 0, 1, 2, cpu=1),
+                    event_line(3, 2, 21, "RUN_STOP", "EXIT", 2, 1, 0, cpu=1),
+                    event_line(4, 12, 20, "RUN_STOP", "EXIT", 12, 1, 0, cpu=0),
+                ],
+                cpus=3,
+            )
+        )
+        metrics = REPORT.derive_metrics(
+            trace,
+            REPORT.parse_legend(
+                legend_text([("A", 0, 20, 12), ("B", 1, 21, 2)])
+            ),
+            strict_single_cpu=False,
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, False)
+
+        self.assertIn("SMP smoke", evidence)
+        self.assertTrue(all(metric.arrival_tick == 0 for metric in metrics))
+
+    def test_smp_mode_does_not_apply_single_cpu_order_oracle(self) -> None:
+        trace, metrics = self._derive(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 8, cpu=0),
+                event_line(2, 0, 11, "RUN_START", "NONE", 0, 1, 2, cpu=1),
+                event_line(3, 2, 11, "RUN_STOP", "EXIT", 2, 1, 0, cpu=1),
+                event_line(4, 8, 10, "RUN_STOP", "EXIT", 8, 1, 0, cpu=0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, False)
+
+        self.assertIn("SMP smoke", evidence)
+
+
+class CommandContractTests(unittest.TestCase):
+    """验证从干净仓库复现实验的命令参数保持固定。"""
+
+    def test_make_command_reuses_schedviz_long_demo(self) -> None:
+        command = REPORT.build_make_command("sjf", 1)
+
+        self.assertEqual("make", command[0])
+        self.assertIn("schedviz", command)
+        self.assertIn("SCHED_POLICY=sjf", command)
+        self.assertIn("CPUS=1", command)
+        self.assertIn("--seconds 60", command[-1])
+        self.assertIn("--workers 6", command[-1])
+
+    def test_unknown_policy_is_rejected(self) -> None:
+        with self.assertRaisesRegex(REPORT.ExperimentError, "unsupported policy"):
+            REPORT.build_make_command("cfs", 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sched_intro_report.py
+++ b/tools/sched_intro_report.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""运行 xv6 调度入门实验，并把 schedviz trace 收敛为可比较报告。"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT_DIR = REPO_ROOT / "artifacts" / "schedviz"
+POLICIES = ("fifo", "sjf", "stcf", "rr")
+EXPERIMENT_SECONDS = 60
+EXPERIMENT_WORKERS = 6
+LEGEND_PATTERN = re.compile(
+    r"^\s*(?P<glyph>[A-Z]) = worker(?P<worker>\d+) pid=(?P<pid>\d+) "
+    r"hint=(?P<hint>\d+) weight=(?P<weight>\d+)\s*$"
+)
+
+
+class ExperimentError(RuntimeError):
+    """表示命令、trace 协议或调度语义证据不满足实验契约。"""
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    seq: int
+    timestamp: int
+    tick: int
+    cpu: int
+    pid: int
+    event_type: str
+    reason: str
+    runtime: int
+    dispatches: int
+    remaining: int
+    name: str
+
+
+@dataclass(frozen=True)
+class TraceData:
+    version: int
+    policy: str
+    cpus: int
+    expected_events: int
+    dropped: int
+    events: tuple[TraceEvent, ...]
+
+
+@dataclass(frozen=True)
+class WorkerLegend:
+    glyph: str
+    worker: int
+    pid: int
+    hint: int
+    weight: int
+
+
+@dataclass(frozen=True)
+class WorkerMetric:
+    policy: str
+    glyph: str
+    worker: int
+    pid: int
+    hint: int
+    arrival_tick: int
+    first_run_tick: int
+    completion_tick: int
+    response_ticks: int
+    turnaround_ticks: int
+    dispatches: int
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    policy: str
+    command: tuple[str, ...]
+    log_path: Path
+    trace_path: Path
+    svg_path: Path
+    evidence: str
+    metrics: tuple[WorkerMetric, ...]
+
+
+def _parse_key_values(line: str) -> dict[str, str]:
+    """解析由空格分隔的 `key=value` 字段。"""
+
+    return {
+        key: value
+        for token in line.split()
+        if "=" in token
+        for key, value in (token.split("=", 1),)
+    }
+
+
+def parse_trace_text(text: str) -> TraceData:
+    """严格解析完整 SCHEDTRACE 协议，遇到丢事件或不完整协议即失败。"""
+
+    header: dict[str, str] | None = None
+    events: list[TraceEvent] = []
+    done = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("SCHEDTRACE version="):
+            header = _parse_key_values(line)
+        elif line.startswith("SCHEDTRACE event "):
+            fields = _parse_key_values(line)
+            try:
+                events.append(
+                    TraceEvent(
+                        seq=int(fields["seq"]),
+                        timestamp=int(fields["ts"]),
+                        tick=int(fields["tick"]),
+                        cpu=int(fields["cpu"]),
+                        pid=int(fields["pid"]),
+                        event_type=fields["type"],
+                        reason=fields["reason"],
+                        runtime=int(fields["runtime"]),
+                        dispatches=int(fields["dispatches"]),
+                        remaining=int(fields["remaining"]),
+                        name=fields["name"],
+                    )
+                )
+            except (KeyError, ValueError) as error:
+                raise ExperimentError(f"invalid SCHEDTRACE event: {line}") from error
+        elif line == "SCHEDTRACE done status=0":
+            done = True
+
+    if header is None:
+        raise ExperimentError("missing SCHEDTRACE header")
+    try:
+        version = int(header["version"])
+        policy = header["policy"]
+        cpus = int(header["cpus"])
+        expected_events = int(header["events"])
+        dropped = int(header["dropped"])
+    except (KeyError, ValueError) as error:
+        raise ExperimentError(f"invalid SCHEDTRACE header: {header}") from error
+
+    if not done:
+        raise ExperimentError("missing successful SCHEDTRACE done marker")
+    if dropped != 0:
+        raise ExperimentError(f"trace dropped {dropped} event(s)")
+    if expected_events != len(events):
+        raise ExperimentError(
+            f"trace event count mismatch: header={expected_events} parsed={len(events)}"
+        )
+    if any(current.seq <= previous.seq for previous, current in zip(events, events[1:])):
+        raise ExperimentError("trace sequence is not strictly increasing")
+    if policy not in POLICIES:
+        raise ExperimentError(f"unexpected policy in trace: {policy}")
+    if cpus < 1:
+        raise ExperimentError(f"invalid CPU count in trace: {cpus}")
+    return TraceData(version, policy, cpus, expected_events, dropped, tuple(events))
+
+
+def parse_trace_file(path: Path) -> TraceData:
+    """读取并解析 UTF-8 trace 文件。"""
+
+    return parse_trace_text(path.read_text(encoding="utf-8"))
+
+
+def parse_legend(text: str) -> dict[int, WorkerLegend]:
+    """从 schedviz 控制台日志提取 worker 到 PID 的稳定映射。"""
+
+    legends: dict[int, WorkerLegend] = {}
+    for line in text.splitlines():
+        match = LEGEND_PATTERN.match(line)
+        if match is None:
+            continue
+        legend = WorkerLegend(
+            glyph=match.group("glyph"),
+            worker=int(match.group("worker")),
+            pid=int(match.group("pid")),
+            hint=int(match.group("hint")),
+            weight=int(match.group("weight")),
+        )
+        if legend.pid in legends:
+            raise ExperimentError(f"duplicate legend pid: {legend.pid}")
+        legends[legend.pid] = legend
+    if not legends:
+        raise ExperimentError("schedviz log does not contain worker legend")
+    return legends
+
+
+def derive_metrics(
+    trace: TraceData,
+    legends: Mapping[int, WorkerLegend],
+    strict_single_cpu: bool = True,
+) -> tuple[WorkerMetric, ...]:
+    """由 RUN_START/RUN_STOP 和场景 barrier 推导响应、周转与调度次数。
+
+    FIFO、SJF、RR 的 long demo 同时释放 worker，统一用 session 首个 RUN_START tick
+    作为 arrival 原点。单核 STCF 先释放长任务，再释放短任务；第一次
+    `STCF_SHORTER_TASK` 停止点是短任务到达边界。多核只做 lifecycle smoke，不要求
+    出现单核抢占事件，因此把所有 worker 的 arrival 归一化到 session 原点。
+    """
+
+    starts = [event for event in trace.events if event.event_type == "RUN_START"]
+    if not starts:
+        raise ExperimentError("trace does not contain RUN_START")
+    origin_tick = min(event.tick for event in starts)
+    first_pid = starts[0].pid
+    stcf_arrival = next(
+        (
+            event.tick
+            for event in trace.events
+            if event.event_type == "RUN_STOP"
+            and event.reason == "STCF_SHORTER_TASK"
+        ),
+        None,
+    )
+
+    metrics: list[WorkerMetric] = []
+    for legend in sorted(legends.values(), key=lambda item: item.worker):
+        worker_events = [event for event in trace.events if event.pid == legend.pid]
+        worker_starts = [event for event in worker_events if event.event_type == "RUN_START"]
+        exits = [
+            event
+            for event in worker_events
+            if event.event_type == "RUN_STOP" and event.reason == "EXIT"
+        ]
+        if not worker_starts or not exits:
+            raise ExperimentError(
+                f"worker{legend.worker} pid={legend.pid} lacks complete RUN_START/EXIT lifecycle"
+            )
+        if strict_single_cpu and trace.policy == "stcf" and legend.pid != first_pid:
+            if stcf_arrival is None:
+                raise ExperimentError("STCF trace lacks shorter-task preemption boundary")
+            arrival_tick = stcf_arrival
+        else:
+            arrival_tick = origin_tick
+        first_run_tick = worker_starts[0].tick
+        completion = exits[-1]
+        response = first_run_tick - arrival_tick
+        turnaround = completion.tick - arrival_tick
+        if response < 0 or turnaround < response:
+            raise ExperimentError(
+                f"invalid lifecycle ticks for worker{legend.worker}: "
+                f"arrival={arrival_tick} first={first_run_tick} completion={completion.tick}"
+            )
+        metrics.append(
+            WorkerMetric(
+                trace.policy,
+                legend.glyph,
+                legend.worker,
+                legend.pid,
+                legend.hint,
+                arrival_tick,
+                first_run_tick,
+                completion.tick,
+                response,
+                turnaround,
+                completion.dispatches,
+            )
+        )
+    return tuple(metrics)
+
+
+def validate_policy_evidence(
+    trace: TraceData,
+    metrics: Sequence[WorkerMetric],
+    strict_single_cpu: bool,
+) -> str:
+    """校验四类教材策略的关键证据；SMP 不套用单核完成顺序判据。"""
+
+    if not metrics:
+        raise ExperimentError(f"{trace.policy}: no worker metrics")
+    if not strict_single_cpu:
+        return f"SMP smoke: {len(metrics)} workers completed, dropped=0"
+
+    completion_order = [
+        metric.worker
+        for metric in sorted(metrics, key=lambda item: (item.completion_tick, item.worker))
+    ]
+    if trace.policy == "fifo":
+        expected = [metric.worker for metric in sorted(metrics, key=lambda item: item.worker)]
+        if completion_order != expected:
+            raise ExperimentError(
+                f"FIFO completion order mismatch: got={completion_order} expected={expected}"
+            )
+        return f"completion order follows enqueue order {completion_order}"
+    if trace.policy == "sjf":
+        expected = [
+            metric.worker
+            for metric in sorted(metrics, key=lambda item: (item.hint, item.worker))
+        ]
+        if completion_order != expected:
+            raise ExperimentError(
+                f"SJF completion order mismatch: got={completion_order} expected={expected}"
+            )
+        return f"completion order follows burst hint {completion_order}"
+    if trace.policy == "stcf":
+        preemptions = [
+            event
+            for event in trace.events
+            if event.event_type == "RUN_STOP"
+            and event.reason == "STCF_SHORTER_TASK"
+        ]
+        long_worker = max(metrics, key=lambda item: item.hint)
+        earlier_short = any(
+            metric.worker != long_worker.worker
+            and metric.completion_tick < long_worker.completion_tick
+            for metric in metrics
+        )
+        if not preemptions or not earlier_short:
+            raise ExperimentError("STCF trace does not prove shorter-task preemption")
+        return (
+            f"observed {len(preemptions)} shorter-task preemption(s); "
+            f"worker{long_worker.worker} completed after a shorter worker"
+        )
+    if trace.policy == "rr":
+        quantum_stops = [
+            event
+            for event in trace.events
+            if event.event_type == "RUN_STOP" and event.reason == "RR_QUANTUM"
+        ]
+        if not quantum_stops or any(metric.dispatches < 2 for metric in metrics):
+            raise ExperimentError("RR trace does not prove time-slice rotation")
+        return (
+            f"observed {len(quantum_stops)} RR quantum stop(s); "
+            "every worker was dispatched at least twice"
+        )
+    raise ExperimentError(f"unsupported policy: {trace.policy}")
+
+
+def build_make_command(policy: str, cpus: int) -> tuple[str, ...]:
+    """构造复用现有 `make schedviz` 的可复制命令。"""
+
+    if policy not in POLICIES:
+        raise ExperimentError(f"unsupported policy: {policy}")
+    if cpus < 1:
+        raise ExperimentError(f"invalid CPU count: {cpus}")
+    return (
+        "make",
+        "schedviz",
+        f"SCHED_POLICY={policy}",
+        f"CPUS={cpus}",
+        "SCHEDVIZ_SUFFIX=-intro",
+        f"SCHEDVIZ_ARGS=--plain --seconds {EXPERIMENT_SECONDS} "
+        f"--workers {EXPERIMENT_WORKERS}",
+    )
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """在仓库根目录执行命令并合并捕获 stdout/stderr。"""
+
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def run_policy(policy: str, cpus: int, artifact_dir: Path) -> PolicyResult:
+    """运行一个策略，保存日志并消费现有 schedviz trace/SVG 产物。"""
+
+    command = build_make_command(policy, cpus)
+    completed = _run(command)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    log_path = artifact_dir / f"{policy}-cpu{cpus}-intro.log"
+    log_path.write_text(f"$ {' '.join(command)}\n{completed.stdout}", encoding="utf-8")
+    if completed.returncode != 0:
+        raise ExperimentError(
+            f"{policy}: command exited with {completed.returncode}; log={log_path}"
+        )
+
+    generated_trace = DEFAULT_ARTIFACT_DIR / f"{policy}-cpu{cpus}-intro.trace"
+    generated_svg = DEFAULT_ARTIFACT_DIR / f"{policy}-cpu{cpus}-intro.svg"
+    if not generated_trace.is_file() or not generated_svg.is_file():
+        raise ExperimentError(f"{policy}: trace/SVG was not generated")
+    trace_path = artifact_dir / generated_trace.name
+    svg_path = artifact_dir / generated_svg.name
+    if trace_path != generated_trace:
+        shutil.copy2(generated_trace, trace_path)
+    if svg_path != generated_svg:
+        shutil.copy2(generated_svg, svg_path)
+
+    trace = parse_trace_file(trace_path)
+    if trace.policy != policy or trace.cpus != cpus:
+        raise ExperimentError(
+            f"{policy}: artifact header mismatch policy={trace.policy} cpus={trace.cpus}"
+        )
+    strict_single_cpu = cpus == 1
+    metrics = derive_metrics(
+        trace,
+        parse_legend(completed.stdout),
+        strict_single_cpu=strict_single_cpu,
+    )
+    evidence = validate_policy_evidence(trace, metrics, strict_single_cpu)
+    return PolicyResult(
+        policy, command, log_path, trace_path, svg_path, evidence, metrics
+    )
+
+
+def _git_revision() -> str:
+    completed = _run(("git", "rev-parse", "HEAD"))
+    return completed.stdout.strip() if completed.returncode == 0 else "unavailable"
+
+
+def write_reports(
+    artifact_dir: Path,
+    cpus: int,
+    results: Sequence[PolicyResult],
+) -> tuple[Path, Path]:
+    """将 worker 指标写入 CSV，并生成带复现命令和边界的 Markdown。"""
+
+    csv_path = artifact_dir / f"intro-cpu{cpus}-metrics.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(
+            (
+                "policy",
+                "glyph",
+                "worker",
+                "pid",
+                "hint",
+                "arrival_tick",
+                "first_run_tick",
+                "completion_tick",
+                "response_ticks",
+                "turnaround_ticks",
+                "dispatches",
+            )
+        )
+        for result in results:
+            for metric in result.metrics:
+                writer.writerow(tuple(metric.__dict__.values()))
+
+    markdown_path = artifact_dir / f"intro-cpu{cpus}-summary.md"
+    lines = [
+        "# xv6 Scheduling Intro Report",
+        "",
+        f"- Revision: `{_git_revision()}`",
+        f"- CPUs: `{cpus}`",
+        f"- Generated at: `{datetime.now(timezone.utc).isoformat()}`",
+        f"- Shared args: `--seconds {EXPERIMENT_SECONDS} --workers {EXPERIMENT_WORKERS}`",
+        "",
+        "## Policy evidence",
+        "",
+        "| Policy | Evidence |",
+        "|---|---|",
+        *(f"| `{result.policy}` | {result.evidence} |" for result in results),
+        "",
+        "## Worker metrics",
+        "",
+        "| Policy | Worker | Hint | Arrival | First run | Completion | Response | Turnaround | Dispatches |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in results:
+        for metric in result.metrics:
+            lines.append(
+                f"| `{metric.policy}` | {metric.glyph}/worker{metric.worker} | "
+                f"{metric.hint} | {metric.arrival_tick} | {metric.first_run_tick} | "
+                f"{metric.completion_tick} | {metric.response_ticks} | "
+                f"{metric.turnaround_ticks} | {metric.dispatches} |"
+            )
+    lines.extend(("", "## Reproduction commands", ""))
+    for result in results:
+        lines.extend(("```bash", " ".join(result.command), "```", ""))
+    lines.extend(
+        (
+            "## Artifacts",
+            "",
+            *(
+                f"- `{result.policy}`: `{result.log_path.name}`, "
+                f"`{result.trace_path.name}`, `{result.svg_path.name}`"
+                for result in results
+            ),
+            "",
+            "## Measurement boundary",
+            "",
+            "- FIFO、SJF、RR 的 arrival 归一化为共同 barrier 后第一个 RUN_START tick。",
+            "- 单核 STCF 的短任务 arrival 使用第一次 STCF_SHORTER_TASK 停止点；多核 smoke 统一使用 session 原点。",
+            "- `CPUS=1` 验证教材完成顺序和 response/turnaround；SMP 只验证事件完整性、并行运行和资源回收。",
+            "- burst hint 是实验输入，不表示内核能够预测未来 CPU burst；SJF/STCF 均为教学实现。",
+            "",
+        )
+    )
+    markdown_path.write_text("\n".join(lines), encoding="utf-8")
+    return csv_path, markdown_path
+
+
+def run_experiment(cpus: int, artifact_dir: Path) -> tuple[Path, Path]:
+    """顺序运行 FIFO/SJF/STCF/RR，并生成统一报告。"""
+
+    results = tuple(run_policy(policy, cpus, artifact_dir) for policy in POLICIES)
+    return write_reports(artifact_dir, cpus, results)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run FIFO/SJF/STCF/RR schedviz experiments and build reports."
+    )
+    parser.add_argument("--cpus", type=int, default=1)
+    parser.add_argument("--artifacts", type=Path, default=DEFAULT_ARTIFACT_DIR)
+    args = parser.parse_args(argv)
+    if args.cpus < 1:
+        parser.error("--cpus must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        csv_path, markdown_path = run_experiment(args.cpus, args.artifacts)
+    except ExperimentError as error:
+        print(f"sched_intro_report: FAIL: {error}", file=sys.stderr)
+        return 1
+    print(f"sched_intro_report: wrote {csv_path} and {markdown_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Related to #135
- 变更类型：功能 / 测试
- 影响范围：`schedviz` 宿主机采集、FIFO/SJF/STCF/RR 教学实验、trace 指标汇总
- 实现基线 Commit：`681a622b02680c41a10fffb74f19664fbce26995`
- 一句话摘要：复用现有调度器与 `schedviz`，提供一条可从干净仓库生成 trace、SVG、日志、CSV 和 Markdown 汇总的四策略实验入口。

## 实现了什么

- 新增 `tools/sched_intro_report.py`，顺序运行 FIFO、SJF、STCF、RR 的 60 秒 / 6 worker 长场景，严格解析 `SCHEDTRACE version=1` 协议，并在事件丢失、生命周期不完整或策略证据不足时失败。
- 单核实验验证教材语义：FIFO 按入队顺序完成、SJF 按 burst hint 完成、STCF 出现更短任务抢占、RR 出现时间片轮转；同时计算 response、turnaround 与 dispatches。
- `CPUS>1` 只作为 SMP lifecycle smoke，不套用单核完成顺序判据，也不要求 STCF 必然产生同 CPU 抢占事件。
- 输出 `artifacts/schedviz/` 下的每策略 `.log/.trace/.svg`，以及统一的 `intro-cpu<n>-metrics.csv` 和 `intro-cpu<n>-summary.md`。
- 修正宿主机 visualizer 仍等待 `/` 提示符的问题，使其与当前 init 登录后的 `/root` ANSI 提示符保持一致。

## CLI

```bash
python3 tools/sched_intro_report.py --cpus 1
python3 tools/sched_intro_report.py --cpus 3
```

单核汇总给出 FIFO 入队顺序、SJF burst hint、STCF 更短任务抢占、RR 时间片轮转证据；多核汇总标记为 `SMP smoke`。任一 trace 出现 `dropped>0`、缺少 `EXIT` 或协议不完整时返回非零。

## 验证结果

| 检查项 | 结果 |
|---|---|
| 新增 Python 协议与策略判据测试 | 11/11 通过 |
| Python `py_compile` | 通过 |
| xv6 CI：构建 xv6 | 通过 |
| xv6 CI：selected PR QEMU regression | 通过 |
| xv6 CI：VM regression（单核） | 通过 |
| Scheduler family CI：FIFO/SJF/STCF/RR/MLFQ/CFS 单核行为 | 全部通过 |
| Scheduler family CI：RR/MLFQ/CFS 三核 smoke | 全部通过 |
| Scheduler family CI：完整 `usertests` | 通过 |
| Scheduler family CI：reparent cleanup（单核） | 通过 |
| uthread debug | 通过 |

## Review 主线

1. `tools/sched_intro_report.py`：arrival 观测边界、单核策略 oracle 与 SMP smoke 的职责分离。
2. `tests/test_sched_intro_report.py`：损坏协议、四策略语义和 STCF 多核反例。
3. `tests/host/scheduler_visualizer.c`：仅同步当前 `/root` ANSI 提示符，不改变 trace/SVG 协议。
