### PR TITLE
chore: sync latest main into concept/145

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ UPROGS=\
 	$U/_vawrite\
 	$U/_vaprobe\
 	$U/_memviztest\
+	$U/_pgtbltest\
 	$U/_vaaccesstest\
 	$U/_addresswindowtest\
 	$U/_wc\

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,13 @@ $T/usertests_2g.o: CFLAGS += -DXV6_USERTESTS_EXEC_ADAPTER
 # memviztest 主体跟随主线，编译时单独注入绝对程序路径适配。
 $T/memviztest.o: CFLAGS += -include $T/memviztest_exec.h
 
+# 地址窗口测试保留既有实现；单独的生命周期入口先验证地址空间，再委托原 main。
+$T/addresswindowtest.o: CFLAGS += -Dmain=addresswindowtest_original_main
+$U/_addresswindowtest: $T/addressspacelifecycle.o $T/addresswindowtest.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $T/addresswindowtest.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/addresswindowtest.sym
+
 # 2 GiB 配置使用容量无关的 C 适配入口；它复用原 usertests.c 的测试全集，
 # 仅替换固定 OOM 假设和破坏式空闲页计数。
 $U/_usertests: $T/usertests_2g.o $(ULIB)

--- a/tests/ci_plan.py
+++ b/tests/ci_plan.py
@@ -72,6 +72,7 @@ VM_PATHS = {
     "kernel/trap.c",
     "kernel/vm.c",
     "kernel/vmcopyin.c",
+    "tests/guest/addressspacelifecycle.c",
     "tests/guest/cowtest.c",
     "tests/guest/lazytests.c",
     "tests/guest/memviztest.c",

--- a/tests/guest/addressspacelifecycle.c
+++ b/tests/guest/addressspacelifecycle.c
@@ -1,0 +1,286 @@
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/memlayout.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+
+/** addresswindowtest.c 经构建规则重命名后的原始入口。 */
+int addresswindowtest_original_main(int argc, char **argv);
+
+static struct memviz_snapshot lifecycle_snapshot;
+static struct memviz_snapshot lifecycle_physical_before;
+static struct memviz_snapshot lifecycle_physical_live;
+static struct memviz_snapshot lifecycle_physical_after;
+
+/** 地址空间闭环中由子进程主动采集并交给父进程的最小证据。 */
+struct address_space_report {
+  int pid;
+  int value;
+  uint64 process_size;
+  uint64 dynamic_page_count;
+  uint64 dynamic_cow_pages;
+  uint64 dynamic_lazy_pages;
+  uint64 user_pagetable;
+  uint64 kernel_pagetable;
+  uint64 trapframe_flags;
+  uint64 trampoline_flags;
+  struct memviz_va_query mapping;
+};
+
+/** 输出稳定失败原因并以非零状态终止测试。 */
+static void
+lifecycle_fail(char *message)
+{
+  printf("addresswindowtest: FAIL: address-space %s\n", message);
+  exit(1);
+}
+
+/**
+ * 从管道完整读取一个固定大小对象。
+ *
+ * @param fd 可读管道描述符。
+ * @param buffer 接收数据的缓冲区。
+ * @param size 需要读取的字节数。
+ * @return 完整读取返回 0；提前 EOF 或读取失败返回 -1。
+ */
+static int
+read_exact(int fd, void *buffer, int size)
+{
+  char *cursor = buffer;
+  int total = 0;
+
+  while(total < size){
+    int count = read(fd, cursor + total, size - total);
+    if(count <= 0)
+      return -1;
+    total += count;
+  }
+  return 0;
+}
+
+/**
+ * 向管道完整写入一个固定大小对象。
+ *
+ * @param fd 可写管道描述符。
+ * @param buffer 待发送数据。
+ * @param size 需要写入的字节数。
+ * @return 完整写入返回 0；写入失败返回 -1。
+ */
+static int
+write_exact(int fd, const void *buffer, int size)
+{
+  const char *cursor = buffer;
+  int total = 0;
+
+  while(total < size){
+    int count = write(fd, cursor + total, size - total);
+    if(count <= 0)
+      return -1;
+    total += count;
+  }
+  return 0;
+}
+
+/**
+ * 采集当前进程地址空间和指定虚拟地址的紧凑证据。
+ *
+ * @param report 接收进程、页表、动态页和 PTE 状态。
+ * @param address 当前进程中需要追踪的可读地址。
+ * @return memsnapshot() 与 vaquery() 都成功时返回 0，否则返回 -1。
+ */
+static int
+capture_report(struct address_space_report *report, char *address)
+{
+  memset(report, 0, sizeof(*report));
+  if(memsnapshot(MEMVIZ_VIEW_USER, &lifecycle_snapshot) < 0)
+    return -1;
+  if(vaquery((uint64)address, &report->mapping) < 0)
+    return -1;
+
+  report->pid = getpid();
+  report->value = address[0];
+  report->process_size = lifecycle_snapshot.process_size;
+  report->dynamic_page_count = lifecycle_snapshot.dynamic_page_count;
+  report->dynamic_cow_pages = lifecycle_snapshot.dynamic_cow_pages;
+  report->dynamic_lazy_pages = lifecycle_snapshot.dynamic_lazy_pages;
+  report->user_pagetable = lifecycle_snapshot.user_pagetable;
+  report->kernel_pagetable = lifecycle_snapshot.kernel_pagetable;
+  report->trapframe_flags = lifecycle_snapshot.trapframe_flags;
+  report->trampoline_flags = lifecycle_snapshot.trampoline_flags;
+  return 0;
+}
+
+/**
+ * 验证建立、fork 共享、COW 分离、惰性扩展和 wait 回收的地址空间闭环。
+ *
+ * 子进程只观察自己的页表，再通过 pipe 交付报告；父进程不跨生命周期读取其他
+ * struct proc。release pipe 让目标保持稳定，直到父进程完成 COW 前后比较。
+ */
+static void
+test_address_space_lifecycle(void)
+{
+  int report_pipe[2];
+  int release_pipe[2];
+  struct address_space_report child_before;
+  struct address_space_report child_after;
+  struct memviz_va_query parent_mapping;
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &lifecycle_physical_before) < 0)
+    lifecycle_fail("initial physical snapshot");
+
+  if(pipe(report_pipe) < 0 || pipe(release_pipe) < 0)
+    lifecycle_fail("pipe creation");
+
+  char *shared = sbrk(PGSIZE);
+  if(shared == (char *)-1)
+    lifecycle_fail("parent page allocation");
+  shared[0] = 11;
+
+  if(memsnapshot(MEMVIZ_VIEW_USER, &lifecycle_snapshot) < 0)
+    lifecycle_fail("parent snapshot");
+  uint64 parent_user_pagetable = lifecycle_snapshot.user_pagetable;
+  uint64 parent_kernel_pagetable = lifecycle_snapshot.kernel_pagetable;
+  uint64 parent_process_size = lifecycle_snapshot.process_size;
+  uint64 parent_dynamic_pages = lifecycle_snapshot.dynamic_page_count;
+
+  int pid = fork();
+  if(pid < 0)
+    lifecycle_fail("fork");
+  if(pid == 0){
+    close(report_pipe[0]);
+    close(release_pipe[1]);
+
+    if(capture_report(&child_before, shared) < 0 ||
+       write_exact(report_pipe[1], &child_before, sizeof(child_before)) < 0)
+      exit(1);
+
+    shared[0] = 22;
+    char *extra = sbrk(2 * PGSIZE);
+    if(extra == (char *)-1)
+      exit(1);
+    extra[0] = 33;
+
+    if(capture_report(&child_after, shared) < 0 ||
+       write_exact(report_pipe[1], &child_after, sizeof(child_after)) < 0)
+      exit(1);
+    close(report_pipe[1]);
+
+    char token;
+    if(read_exact(release_pipe[0], &token, 1) < 0)
+      exit(1);
+    close(release_pipe[0]);
+    exit(0);
+  }
+
+  close(report_pipe[1]);
+  close(release_pipe[0]);
+  if(read_exact(report_pipe[0], &child_before, sizeof(child_before)) < 0 ||
+     read_exact(report_pipe[0], &child_after, sizeof(child_after)) < 0)
+    lifecycle_fail("child reports");
+  close(report_pipe[0]);
+
+  if(vaquery((uint64)shared, &parent_mapping) < 0)
+    lifecycle_fail("parent mapping query");
+
+  if(child_before.pid != pid || child_after.pid != pid)
+    lifecycle_fail("child pid mismatch");
+  if(child_before.user_pagetable == parent_user_pagetable ||
+     child_before.kernel_pagetable == parent_kernel_pagetable)
+    lifecycle_fail("page-table roots shared");
+  if(child_before.process_size != parent_process_size)
+    lifecycle_fail("fork size mismatch");
+  if(child_after.process_size != parent_process_size + 2 * PGSIZE ||
+     child_after.dynamic_page_count != parent_dynamic_pages + 2)
+    lifecycle_fail("child growth mismatch");
+  if(child_after.dynamic_lazy_pages != child_before.dynamic_lazy_pages + 1)
+    lifecycle_fail("untouched child page not lazy");
+
+  uint64 cow_required = PTE_V | PTE_R | PTE_U | PTE_COW;
+  if(!child_before.mapping.present ||
+     (child_before.mapping.flags & cow_required) != cow_required ||
+     (child_before.mapping.flags & PTE_W))
+    lifecycle_fail("child pre-write COW permissions");
+  if(!parent_mapping.present ||
+     (parent_mapping.flags & cow_required) != cow_required ||
+     (parent_mapping.flags & PTE_W))
+    lifecycle_fail("parent COW permissions");
+  if(child_before.mapping.pa != parent_mapping.pa)
+    lifecycle_fail("fork physical page not shared");
+
+  uint64 private_required = PTE_V | PTE_R | PTE_W | PTE_U;
+  if(!child_after.mapping.present ||
+     (child_after.mapping.flags & private_required) != private_required ||
+     (child_after.mapping.flags & PTE_COW))
+    lifecycle_fail("child private permissions");
+  if(child_after.mapping.pa == parent_mapping.pa)
+    lifecycle_fail("COW physical page not split");
+  if(shared[0] != 11 || child_before.value != 11 || child_after.value != 22)
+    lifecycle_fail("parent and child values not isolated");
+
+  uint64 trapframe_required = PTE_V | PTE_R | PTE_W;
+  if((child_after.trapframe_flags & trapframe_required) != trapframe_required ||
+     (child_after.trapframe_flags & (PTE_X | PTE_U)))
+    lifecycle_fail("trapframe permissions");
+  uint64 trampoline_required = PTE_V | PTE_R | PTE_X;
+  if((child_after.trampoline_flags & trampoline_required) !=
+       trampoline_required ||
+     (child_after.trampoline_flags & (PTE_W | PTE_U)))
+    lifecycle_fail("trampoline permissions");
+
+  printf("ADDRESS SPACE stage=parent pid=%d root=%p size=%p va=%p pa=%p value=%d\n",
+         getpid(), parent_user_pagetable, parent_process_size,
+         parent_mapping.va, parent_mapping.pa, shared[0]);
+  printf("ADDRESS SPACE stage=child-before pid=%d root=%p size=%p va=%p pa=%p flags=%p value=%d\n",
+         child_before.pid, child_before.user_pagetable,
+         child_before.process_size, child_before.mapping.va,
+         child_before.mapping.pa, child_before.mapping.flags,
+         child_before.value);
+  printf("ADDRESS SPACE stage=child-after pid=%d root=%p size=%p va=%p pa=%p flags=%p value=%d lazy=%d\n",
+         child_after.pid, child_after.user_pagetable,
+         child_after.process_size, child_after.mapping.va,
+         child_after.mapping.pa, child_after.mapping.flags,
+         child_after.value, (int)child_after.dynamic_lazy_pages);
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &lifecycle_physical_live) < 0)
+    lifecycle_fail("live physical snapshot");
+
+  char token = 'x';
+  if(write_exact(release_pipe[1], &token, 1) < 0)
+    lifecycle_fail("release child");
+  close(release_pipe[1]);
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    lifecycle_fail("wait child");
+  if(wait(0) != -1)
+    lifecycle_fail("reaped child remains waitable");
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &lifecycle_physical_after) < 0)
+    lifecycle_fail("reclaimed physical snapshot");
+  if(lifecycle_physical_after.free_pages <= lifecycle_physical_live.free_pages)
+    lifecycle_fail("child resources not reclaimed");
+
+  if(sbrk(-PGSIZE) == (char *)-1)
+    lifecycle_fail("parent cleanup");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &lifecycle_physical_after) < 0)
+    lifecycle_fail("final physical snapshot");
+  if(lifecycle_physical_after.free_pages != lifecycle_physical_before.free_pages)
+    lifecycle_fail("final page leak");
+
+  printf("ADDRESS SPACE target pid=%d state=REAPED pages_returned=yes\n", pid);
+  printf("ADDRESS SPACE RESULT PASS\n");
+}
+
+/**
+ * 先运行地址空间生命周期闭环，再委托原 addresswindowtest 入口执行既有实验。
+ *
+ * paging 聚焦入口保持原语义，避免一条局部命令意外扩大运行范围。
+ */
+int
+main(int argc, char **argv)
+{
+  if(argc == 1)
+    test_address_space_lifecycle();
+  return addresswindowtest_original_main(argc, argv);
+}

--- a/tests/guest/pgtbltest.c
+++ b/tests/guest/pgtbltest.c
@@ -1,4 +1,5 @@
 #include "kernel/types.h"
+#include "kernel/param.h"
 #include "kernel/memlayout.h"
 #include "kernel/riscv.h"
 #include "kernel/memviz.h"

--- a/tests/guest/pgtbltest.c
+++ b/tests/guest/pgtbltest.c
@@ -1,0 +1,245 @@
+#include "kernel/types.h"
+#include "kernel/memlayout.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "user/user.h"
+
+#define PGTBL_L1_SPAN (512ULL * PGSIZE)
+#define PGTBL_SEARCH_REGIONS 64
+
+// 大型快照和查询结果放在 BSS，避免占用 xv6 单页用户栈。
+static struct memviz_snapshot snapshot;
+static struct memviz_va_query query;
+
+/** 输出稳定失败原因并终止当前测试进程。 */
+static void
+fail(char *message)
+{
+  printf("pgtbltest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 读取并输出一个用户 VA 的真实 Sv39 三级链路。
+ *
+ * @param label 本轮实验中的路径标签。
+ * @param va 待查询的用户虚拟地址。
+ */
+static void
+print_path(char *label, uint64 va)
+{
+  if(vaquery(va, &query) < 0)
+    fail("vaquery");
+
+  printf("PGTBL path label=%s va=%p present=%d\n",
+         label, query.va, query.present);
+  for(int i = 0; i < 3; i++){
+    struct memviz_pte_level *level = &query.levels[i];
+    char *kind = !level->present ? "missing" :
+                 (level->level == 0 ? "leaf" : "branch");
+
+    printf("PGTBL level label=%s level=L%d index=%d present=%d kind=%s pte=%p pa=%p\n",
+           label, level->level, level->index, level->present, kind,
+           level->pte, level->pa);
+    if(!level->present)
+      break;
+  }
+}
+
+/**
+ * 在同一个 L2 分支中寻找两个尚未分配 L0 页表的相邻 2 MiB 区域。
+ *
+ * @param old_break 当前进程逻辑大小的一过地址。
+ * @return 第一段区域的起始 VA；无合适区域时终止测试。
+ */
+static uint64
+find_empty_l1_region(uint64 old_break)
+{
+  uint64 candidate = (old_break + PGTBL_L1_SPAN - 1) &
+                     ~(PGTBL_L1_SPAN - 1);
+
+  for(int attempt = 0; attempt < PGTBL_SEARCH_REGIONS; attempt++){
+    uint64 sparse = candidate + PGTBL_L1_SPAN;
+    if(sparse < candidate || sparse + PGSIZE > USERMAX)
+      break;
+    if(PX(2, candidate) != PX(2, sparse)){
+      candidate += PGTBL_L1_SPAN;
+      continue;
+    }
+
+    if(vaquery(candidate, &query) < 0)
+      fail("dense candidate query");
+    int dense_missing_l1 = query.levels[0].present &&
+                           !query.levels[1].present;
+
+    if(vaquery(sparse, &query) < 0)
+      fail("sparse candidate query");
+    int sparse_missing_l1 = query.levels[0].present &&
+                            !query.levels[1].present;
+
+    if(dense_missing_l1 && sparse_missing_l1)
+      return candidate;
+    candidate += PGTBL_L1_SPAN;
+  }
+
+  fail("no empty L1 region");
+  return 0;
+}
+
+/**
+ * 在子进程中构造密集与稀疏映射，并验证创建、缩容和失败回滚。
+ *
+ * sbrk() 正向扩容只修改逻辑范围。首次写入经 lazy fault 创建数据页和缺失的
+ * 中间页表页；缩容释放 leaf 数据页，但当前 xv6 不立即压缩空中间页表子树。
+ */
+static void
+run_mapping_experiment(void)
+{
+  struct path_identity {
+    uint64 l1_table;
+    uint64 l0_table;
+    uint64 leaf_pa;
+  } dense0, dense1, sparse0;
+
+  // 先写热 COW 缓冲与栈，再记录基线，避免 fork 自身污染物理页差值。
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0 ||
+     vaquery(0, &query) < 0)
+    fail("warmup");
+
+  uint64 old_break = (uint64)sbrk(0);
+  uint64 dense_va = find_empty_l1_region(old_break);
+  uint64 sparse_va = dense_va + PGTBL_L1_SPAN;
+  uint64 reserve_end = sparse_va + PGSIZE;
+  uint64 reserve_size = reserve_end - old_break;
+  if(reserve_size > 0x7fffffffULL)
+    fail("reservation exceeds sbrk argument range");
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("baseline snapshot");
+  uint64 baseline_free = snapshot.free_pages;
+
+  if(sbrk((int)reserve_size) == (char *)-1)
+    fail("lazy reserve");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("reserve snapshot");
+  if(snapshot.free_pages != baseline_free)
+    fail("untouched reservation allocated pages");
+  printf("PGTBL reserve lazy=1 free_unchanged=1 bytes=%d\n",
+         (int)reserve_size);
+
+  print_path("missing", dense_va);
+  if(!query.levels[0].present || query.levels[1].present)
+    fail("missing intermediate path mismatch");
+
+  *(volatile char *)dense_va = 0x11;
+  *(volatile char *)(dense_va + PGSIZE) = 0x22;
+  *(volatile char *)sparse_va = 0x33;
+
+  print_path("dense0", dense_va);
+  if(!query.present)
+    fail("dense0 leaf missing");
+  dense0.l1_table = query.levels[0].pa;
+  dense0.l0_table = query.levels[1].pa;
+  dense0.leaf_pa = query.levels[2].pa;
+
+  print_path("dense1", dense_va + PGSIZE);
+  if(!query.present)
+    fail("dense1 leaf missing");
+  dense1.l1_table = query.levels[0].pa;
+  dense1.l0_table = query.levels[1].pa;
+  dense1.leaf_pa = query.levels[2].pa;
+
+  print_path("sparse0", sparse_va);
+  if(!query.present)
+    fail("sparse leaf missing");
+  sparse0.l1_table = query.levels[0].pa;
+  sparse0.l0_table = query.levels[1].pa;
+  sparse0.leaf_pa = query.levels[2].pa;
+
+  int dense_shared_l1 = dense0.l1_table == dense1.l1_table;
+  int dense_shared_l0 = dense0.l0_table == dense1.l0_table;
+  int dense_distinct_leaf = dense0.leaf_pa != dense1.leaf_pa;
+  if(!dense_shared_l1 || !dense_shared_l0 || !dense_distinct_leaf)
+    fail("dense sharing mismatch");
+  printf("PGTBL relation=dense shared_l1_table=%d shared_l0_table=%d distinct_leaf=%d\n",
+         dense_shared_l1, dense_shared_l0, dense_distinct_leaf);
+
+  int sparse_shared_l1 = dense0.l1_table == sparse0.l1_table;
+  int sparse_shared_l0 = dense0.l0_table == sparse0.l0_table;
+  if(!sparse_shared_l1 || sparse_shared_l0)
+    fail("sparse sharing mismatch");
+  printf("PGTBL relation=sparse shared_l1_table=%d shared_l0_table=%d\n",
+         sparse_shared_l1, sparse_shared_l0);
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("touched snapshot");
+  uint64 touched_free = snapshot.free_pages;
+  if(touched_free >= baseline_free)
+    fail("touch consumed no physical pages");
+
+  if(sbrk(-(int)reserve_size) == (char *)-1)
+    fail("shrink");
+  print_path("after-shrink", dense_va);
+  int leaf_removed = !query.present && !query.levels[2].present;
+  int intermediate_retained = query.levels[0].present &&
+                              query.levels[1].present;
+
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("shrink snapshot");
+  uint64 shrink_free = snapshot.free_pages;
+  int data_reclaimed = shrink_free >= touched_free + 3;
+  if(!leaf_removed || !intermediate_retained || !data_reclaimed ||
+     shrink_free >= baseline_free)
+    fail("shrink lifecycle mismatch");
+  printf("PGTBL release leaf_removed=%d intermediate_retained=%d data_reclaimed=%d\n",
+         leaf_removed, intermediate_retained, data_reclaimed);
+
+  uint64 rollback_break = (uint64)sbrk(0);
+  uint64 rollback_free = shrink_free;
+  if(sbrk(-0x7fffffff) != (char *)-1)
+    fail("overshrink unexpectedly succeeded");
+  if((uint64)sbrk(0) != rollback_break)
+    fail("overshrink changed break");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("rollback snapshot");
+  if(snapshot.free_pages != rollback_free)
+    fail("overshrink changed physical pages");
+  printf("PGTBL rollback operation=overshrink break_unchanged=1 free_unchanged=1\n");
+}
+
+/**
+ * 父进程验证子进程退出后，freewalk() 会递归回收残留中间页表页。
+ */
+static void
+test_process_exit_reclaim(void)
+{
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("parent baseline snapshot");
+  uint64 baseline_free = snapshot.free_pages;
+
+  int pid = fork();
+  if(pid < 0)
+    fail("fork");
+  if(pid == 0){
+    run_mapping_experiment();
+    exit(0);
+  }
+
+  int status = -1;
+  if(wait(&status) != pid || status != 0)
+    fail("mapping experiment child");
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("parent final snapshot");
+  if(snapshot.free_pages != baseline_free)
+    fail("process exit did not restore physical pages");
+
+  printf("PGTBL reclaim process_exit=1 free_restored=1\n");
+  printf("PGTBL result=ok\n");
+}
+
+int
+main(void)
+{
+  test_process_exit_reclaim();
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -30,6 +30,7 @@ static char *lab3_copyout_argv[] = {XV6_TEST_PATH("usertests"), "copyout", 0};
 static char *lab3_copyinstr_argv[] = {XV6_TEST_PATH("usertests"), "copyinstr1", 0};
 static char *lab3_sbrkmuch_argv[] = {XV6_TEST_PATH("usertests"), "sbrkmuch", 0};
 static char *lab3_memviz_argv[] = {XV6_TEST_PATH("memviztest"), 0};
+static char *lab3_pgtbl_argv[] = {XV6_TEST_PATH("pgtbltest"), 0};
 static char *lab3_vaaccess_argv[] = {XV6_TEST_PATH("vaaccesstest"), 0};
 static char *lab3_address_window_argv[] = {XV6_TEST_PATH("addresswindowtest"), 0};
 static char *lab4_backtrace_argv[] = {XV6_TEST_PATH("bttest"), 0};
@@ -87,6 +88,7 @@ static struct xv6_test_case tests[] = {
   {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv},
   {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv},
   {"lab3", "lab3-memviz", lab3_memviz_argv},
+  {"lab3", "lab3-pgtbl", lab3_pgtbl_argv},
   {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
   {"lab3", "lab3-address-window", lab3_address_window_argv},
   {"lab4", "lab4-backtrace", lab4_backtrace_argv},

--- a/tests/host/scheduler_visualizer.c
+++ b/tests/host/scheduler_visualizer.c
@@ -20,7 +20,7 @@
 
 /** 登录 Shell 根目录下的完整 ANSI 提示符，用作 QEMU 输入同步边界。 */
 static const char root_shell_prompt[] =
-  "\033[1;38;5;208mroot@xv6\033[0m:\033[1;34m/\033[0m# ";
+  "\033[1;38;5;208mroot@xv6\033[0m:\033[1;34m/root\033[0m# ";
 
 struct options {
   const char *policy;

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -36,6 +36,12 @@ class CiPlanSelectionTests(unittest.TestCase):
         self.assertNotIn("lab9-bigfile", plan.suites)
         self.assertFalse(plan.run_shell_history)
 
+    def test_address_space_lifecycle_runs_vm_regression(self) -> None:
+        plan = PLANNER.build_ci_plan(("tests/guest/addressspacelifecycle.c",))
+
+        self.assertEqual(PLANNER.VM_SUITES, plan.suites)
+        self.assertFalse(plan.run_shell_history)
+
     def test_filesystem_change_keeps_bigfile_boundary_test(self) -> None:
         plan = PLANNER.build_ci_plan(("kernel/fs.c",))
 

--- a/tests/test_sched_intro_report.py
+++ b/tests/test_sched_intro_report.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证调度入门 trace 报告器的协议与策略判据。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "sched_intro_report.py"
+SPEC = importlib.util.spec_from_file_location("sched_intro_report", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load report module from {MODULE_PATH}")
+REPORT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = REPORT
+SPEC.loader.exec_module(REPORT)
+
+
+def event_line(
+    seq: int,
+    tick: int,
+    pid: int,
+    event_type: str,
+    reason: str,
+    runtime: int,
+    dispatches: int,
+    remaining: int,
+    cpu: int = 0,
+) -> str:
+    """生成最小但完整的 SCHEDTRACE event 测试行。"""
+
+    return (
+        f"SCHEDTRACE event seq={seq} ts={seq * 10} tick={tick} cpu={cpu} "
+        f"pid={pid} type={event_type} reason={reason} state=4 slice=0 "
+        f"runtime={runtime} dispatches={dispatches} remaining={remaining} "
+        "level=0 epoch=1 weight=1024 vruntime=0 name=schedviz"
+    )
+
+
+def trace_text(policy: str, events: list[str], cpus: int = 1, dropped: int = 0) -> str:
+    """封装带版本头和成功结束标记的 trace。"""
+
+    return "\n".join(
+        [
+            f"SCHEDTRACE version=1 policy={policy} cpus={cpus} "
+            f"events={len(events)} dropped={dropped}",
+            *events,
+            "SCHEDTRACE done status=0",
+            "",
+        ]
+    )
+
+
+def legend_text(rows: list[tuple[str, int, int, int]]) -> str:
+    """生成 schedviz legend 测试文本。"""
+
+    return "\n".join(
+        f"  {glyph} = worker{worker} pid={pid} hint={hint} weight=1024"
+        for glyph, worker, pid, hint in rows
+    )
+
+
+class TraceParsingTests(unittest.TestCase):
+    """验证 SCHEDTRACE 协议和 legend 的严格解析。"""
+
+    def test_parse_complete_trace_and_legend(self) -> None:
+        text = trace_text(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 4, 10, "RUN_STOP", "EXIT", 4, 1, 0),
+            ],
+        )
+        trace = REPORT.parse_trace_text(text)
+        legends = REPORT.parse_legend(legend_text([("A", 0, 10, 4)]))
+
+        self.assertEqual("fifo", trace.policy)
+        self.assertEqual(2, len(trace.events))
+        self.assertEqual(0, legends[10].worker)
+        self.assertEqual(4, legends[10].hint)
+
+    def test_dropped_events_fail_closed(self) -> None:
+        text = trace_text(
+            "rr",
+            [event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 4)],
+            dropped=1,
+        )
+        with self.assertRaisesRegex(REPORT.ExperimentError, "dropped 1"):
+            REPORT.parse_trace_text(text)
+
+    def test_non_increasing_sequence_is_rejected(self) -> None:
+        text = trace_text(
+            "fifo",
+            [
+                event_line(2, 0, 10, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 4, 10, "RUN_STOP", "EXIT", 4, 1, 0),
+            ],
+        )
+        with self.assertRaisesRegex(REPORT.ExperimentError, "strictly increasing"):
+            REPORT.parse_trace_text(text)
+
+
+class PolicyEvidenceTests(unittest.TestCase):
+    """验证四类教材策略各自的完成顺序或抢占证据。"""
+
+    def _derive(
+        self,
+        policy: str,
+        events: list[str],
+        rows: list[tuple[str, int, int, int]],
+    ) -> tuple[object, tuple[object, ...]]:
+        trace = REPORT.parse_trace_text(trace_text(policy, events))
+        metrics = REPORT.derive_metrics(trace, REPORT.parse_legend(legend_text(rows)))
+        return trace, metrics
+
+    def test_fifo_follows_enqueue_order(self) -> None:
+        trace, metrics = self._derive(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 8),
+                event_line(2, 8, 10, "RUN_STOP", "EXIT", 8, 1, 0),
+                event_line(3, 8, 11, "RUN_START", "NONE", 0, 1, 2),
+                event_line(4, 10, 11, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(5, 10, 12, "RUN_START", "NONE", 0, 1, 5),
+                event_line(6, 15, 12, "RUN_STOP", "EXIT", 5, 1, 0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2), ("C", 2, 12, 5)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("enqueue order", evidence)
+        self.assertEqual([8, 10, 15], [metric.completion_tick for metric in metrics])
+
+    def test_sjf_follows_burst_hint(self) -> None:
+        trace, metrics = self._derive(
+            "sjf",
+            [
+                event_line(1, 0, 11, "RUN_START", "NONE", 0, 1, 2),
+                event_line(2, 2, 11, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(3, 2, 12, "RUN_START", "NONE", 0, 1, 5),
+                event_line(4, 7, 12, "RUN_STOP", "EXIT", 5, 1, 0),
+                event_line(5, 7, 10, "RUN_START", "NONE", 0, 1, 8),
+                event_line(6, 15, 10, "RUN_STOP", "EXIT", 8, 1, 0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2), ("C", 2, 12, 5)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("burst hint", evidence)
+        by_worker = {metric.worker: metric for metric in metrics}
+        self.assertEqual(7, by_worker[0].response_ticks)
+        self.assertEqual(0, by_worker[1].response_ticks)
+
+    def test_stcf_uses_preemption_tick_as_short_arrival(self) -> None:
+        trace, metrics = self._derive(
+            "stcf",
+            [
+                event_line(1, 0, 20, "RUN_START", "NONE", 0, 1, 12),
+                event_line(2, 2, 20, "RUN_STOP", "STCF_SHORTER_TASK", 2, 1, 10),
+                event_line(3, 2, 21, "RUN_START", "NONE", 0, 1, 2),
+                event_line(4, 4, 21, "RUN_STOP", "EXIT", 2, 1, 0),
+                event_line(5, 4, 20, "RUN_START", "NONE", 2, 2, 10),
+                event_line(6, 14, 20, "RUN_STOP", "EXIT", 12, 2, 0),
+            ],
+            [("A", 0, 20, 12), ("B", 1, 21, 2)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+        by_worker = {metric.worker: metric for metric in metrics}
+
+        self.assertIn("shorter-task preemption", evidence)
+        self.assertEqual(2, by_worker[1].arrival_tick)
+        self.assertEqual(0, by_worker[1].response_ticks)
+        self.assertLess(by_worker[1].completion_tick, by_worker[0].completion_tick)
+
+    def test_rr_requires_quantum_rotation_and_repeat_dispatch(self) -> None:
+        trace, metrics = self._derive(
+            "rr",
+            [
+                event_line(1, 0, 30, "RUN_START", "NONE", 0, 1, 4),
+                event_line(2, 2, 30, "RUN_STOP", "RR_QUANTUM", 2, 1, 2),
+                event_line(3, 2, 31, "RUN_START", "NONE", 0, 1, 4),
+                event_line(4, 4, 31, "RUN_STOP", "RR_QUANTUM", 2, 1, 2),
+                event_line(5, 4, 30, "RUN_START", "NONE", 2, 2, 2),
+                event_line(6, 6, 30, "RUN_STOP", "EXIT", 4, 2, 0),
+                event_line(7, 6, 31, "RUN_START", "NONE", 2, 2, 2),
+                event_line(8, 8, 31, "RUN_STOP", "EXIT", 4, 2, 0),
+            ],
+            [("A", 0, 30, 4), ("B", 1, 31, 4)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, True)
+
+        self.assertIn("RR quantum", evidence)
+        self.assertTrue(all(metric.dispatches == 2 for metric in metrics))
+
+    def test_stcf_smp_metrics_do_not_require_preemption_boundary(self) -> None:
+        trace = REPORT.parse_trace_text(
+            trace_text(
+                "stcf",
+                [
+                    event_line(1, 0, 20, "RUN_START", "NONE", 0, 1, 12, cpu=0),
+                    event_line(2, 0, 21, "RUN_START", "NONE", 0, 1, 2, cpu=1),
+                    event_line(3, 2, 21, "RUN_STOP", "EXIT", 2, 1, 0, cpu=1),
+                    event_line(4, 12, 20, "RUN_STOP", "EXIT", 12, 1, 0, cpu=0),
+                ],
+                cpus=3,
+            )
+        )
+        metrics = REPORT.derive_metrics(
+            trace,
+            REPORT.parse_legend(
+                legend_text([("A", 0, 20, 12), ("B", 1, 21, 2)])
+            ),
+            strict_single_cpu=False,
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, False)
+
+        self.assertIn("SMP smoke", evidence)
+        self.assertTrue(all(metric.arrival_tick == 0 for metric in metrics))
+
+    def test_smp_mode_does_not_apply_single_cpu_order_oracle(self) -> None:
+        trace, metrics = self._derive(
+            "fifo",
+            [
+                event_line(1, 0, 10, "RUN_START", "NONE", 0, 1, 8, cpu=0),
+                event_line(2, 0, 11, "RUN_START", "NONE", 0, 1, 2, cpu=1),
+                event_line(3, 2, 11, "RUN_STOP", "EXIT", 2, 1, 0, cpu=1),
+                event_line(4, 8, 10, "RUN_STOP", "EXIT", 8, 1, 0, cpu=0),
+            ],
+            [("A", 0, 10, 8), ("B", 1, 11, 2)],
+        )
+
+        evidence = REPORT.validate_policy_evidence(trace, metrics, False)
+
+        self.assertIn("SMP smoke", evidence)
+
+
+class CommandContractTests(unittest.TestCase):
+    """验证从干净仓库复现实验的命令参数保持固定。"""
+
+    def test_make_command_reuses_schedviz_long_demo(self) -> None:
+        command = REPORT.build_make_command("sjf", 1)
+
+        self.assertEqual("make", command[0])
+        self.assertIn("schedviz", command)
+        self.assertIn("SCHED_POLICY=sjf", command)
+        self.assertIn("CPUS=1", command)
+        self.assertIn("--seconds 60", command[-1])
+        self.assertIn("--workers 6", command[-1])
+
+    def test_unknown_policy_is_rejected(self) -> None:
+        with self.assertRaisesRegex(REPORT.ExperimentError, "unsupported policy"):
+            REPORT.build_make_command("cfs", 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sched_intro_report.py
+++ b/tools/sched_intro_report.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""运行 xv6 调度入门实验，并把 schedviz trace 收敛为可比较报告。"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT_DIR = REPO_ROOT / "artifacts" / "schedviz"
+POLICIES = ("fifo", "sjf", "stcf", "rr")
+EXPERIMENT_SECONDS = 60
+EXPERIMENT_WORKERS = 6
+LEGEND_PATTERN = re.compile(
+    r"^\s*(?P<glyph>[A-Z]) = worker(?P<worker>\d+) pid=(?P<pid>\d+) "
+    r"hint=(?P<hint>\d+) weight=(?P<weight>\d+)\s*$"
+)
+
+
+class ExperimentError(RuntimeError):
+    """表示命令、trace 协议或调度语义证据不满足实验契约。"""
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    seq: int
+    timestamp: int
+    tick: int
+    cpu: int
+    pid: int
+    event_type: str
+    reason: str
+    runtime: int
+    dispatches: int
+    remaining: int
+    name: str
+
+
+@dataclass(frozen=True)
+class TraceData:
+    version: int
+    policy: str
+    cpus: int
+    expected_events: int
+    dropped: int
+    events: tuple[TraceEvent, ...]
+
+
+@dataclass(frozen=True)
+class WorkerLegend:
+    glyph: str
+    worker: int
+    pid: int
+    hint: int
+    weight: int
+
+
+@dataclass(frozen=True)
+class WorkerMetric:
+    policy: str
+    glyph: str
+    worker: int
+    pid: int
+    hint: int
+    arrival_tick: int
+    first_run_tick: int
+    completion_tick: int
+    response_ticks: int
+    turnaround_ticks: int
+    dispatches: int
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    policy: str
+    command: tuple[str, ...]
+    log_path: Path
+    trace_path: Path
+    svg_path: Path
+    evidence: str
+    metrics: tuple[WorkerMetric, ...]
+
+
+def _parse_key_values(line: str) -> dict[str, str]:
+    """解析由空格分隔的 `key=value` 字段。"""
+
+    return {
+        key: value
+        for token in line.split()
+        if "=" in token
+        for key, value in (token.split("=", 1),)
+    }
+
+
+def parse_trace_text(text: str) -> TraceData:
+    """严格解析完整 SCHEDTRACE 协议，遇到丢事件或不完整协议即失败。"""
+
+    header: dict[str, str] | None = None
+    events: list[TraceEvent] = []
+    done = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("SCHEDTRACE version="):
+            header = _parse_key_values(line)
+        elif line.startswith("SCHEDTRACE event "):
+            fields = _parse_key_values(line)
+            try:
+                events.append(
+                    TraceEvent(
+                        seq=int(fields["seq"]),
+                        timestamp=int(fields["ts"]),
+                        tick=int(fields["tick"]),
+                        cpu=int(fields["cpu"]),
+                        pid=int(fields["pid"]),
+                        event_type=fields["type"],
+                        reason=fields["reason"],
+                        runtime=int(fields["runtime"]),
+                        dispatches=int(fields["dispatches"]),
+                        remaining=int(fields["remaining"]),
+                        name=fields["name"],
+                    )
+                )
+            except (KeyError, ValueError) as error:
+                raise ExperimentError(f"invalid SCHEDTRACE event: {line}") from error
+        elif line == "SCHEDTRACE done status=0":
+            done = True
+
+    if header is None:
+        raise ExperimentError("missing SCHEDTRACE header")
+    try:
+        version = int(header["version"])
+        policy = header["policy"]
+        cpus = int(header["cpus"])
+        expected_events = int(header["events"])
+        dropped = int(header["dropped"])
+    except (KeyError, ValueError) as error:
+        raise ExperimentError(f"invalid SCHEDTRACE header: {header}") from error
+
+    if not done:
+        raise ExperimentError("missing successful SCHEDTRACE done marker")
+    if dropped != 0:
+        raise ExperimentError(f"trace dropped {dropped} event(s)")
+    if expected_events != len(events):
+        raise ExperimentError(
+            f"trace event count mismatch: header={expected_events} parsed={len(events)}"
+        )
+    if any(current.seq <= previous.seq for previous, current in zip(events, events[1:])):
+        raise ExperimentError("trace sequence is not strictly increasing")
+    if policy not in POLICIES:
+        raise ExperimentError(f"unexpected policy in trace: {policy}")
+    if cpus < 1:
+        raise ExperimentError(f"invalid CPU count in trace: {cpus}")
+    return TraceData(version, policy, cpus, expected_events, dropped, tuple(events))
+
+
+def parse_trace_file(path: Path) -> TraceData:
+    """读取并解析 UTF-8 trace 文件。"""
+
+    return parse_trace_text(path.read_text(encoding="utf-8"))
+
+
+def parse_legend(text: str) -> dict[int, WorkerLegend]:
+    """从 schedviz 控制台日志提取 worker 到 PID 的稳定映射。"""
+
+    legends: dict[int, WorkerLegend] = {}
+    for line in text.splitlines():
+        match = LEGEND_PATTERN.match(line)
+        if match is None:
+            continue
+        legend = WorkerLegend(
+            glyph=match.group("glyph"),
+            worker=int(match.group("worker")),
+            pid=int(match.group("pid")),
+            hint=int(match.group("hint")),
+            weight=int(match.group("weight")),
+        )
+        if legend.pid in legends:
+            raise ExperimentError(f"duplicate legend pid: {legend.pid}")
+        legends[legend.pid] = legend
+    if not legends:
+        raise ExperimentError("schedviz log does not contain worker legend")
+    return legends
+
+
+def derive_metrics(
+    trace: TraceData,
+    legends: Mapping[int, WorkerLegend],
+    strict_single_cpu: bool = True,
+) -> tuple[WorkerMetric, ...]:
+    """由 RUN_START/RUN_STOP 和场景 barrier 推导响应、周转与调度次数。
+
+    FIFO、SJF、RR 的 long demo 同时释放 worker，统一用 session 首个 RUN_START tick
+    作为 arrival 原点。单核 STCF 先释放长任务，再释放短任务；第一次
+    `STCF_SHORTER_TASK` 停止点是短任务到达边界。多核只做 lifecycle smoke，不要求
+    出现单核抢占事件，因此把所有 worker 的 arrival 归一化到 session 原点。
+    """
+
+    starts = [event for event in trace.events if event.event_type == "RUN_START"]
+    if not starts:
+        raise ExperimentError("trace does not contain RUN_START")
+    origin_tick = min(event.tick for event in starts)
+    first_pid = starts[0].pid
+    stcf_arrival = next(
+        (
+            event.tick
+            for event in trace.events
+            if event.event_type == "RUN_STOP"
+            and event.reason == "STCF_SHORTER_TASK"
+        ),
+        None,
+    )
+
+    metrics: list[WorkerMetric] = []
+    for legend in sorted(legends.values(), key=lambda item: item.worker):
+        worker_events = [event for event in trace.events if event.pid == legend.pid]
+        worker_starts = [event for event in worker_events if event.event_type == "RUN_START"]
+        exits = [
+            event
+            for event in worker_events
+            if event.event_type == "RUN_STOP" and event.reason == "EXIT"
+        ]
+        if not worker_starts or not exits:
+            raise ExperimentError(
+                f"worker{legend.worker} pid={legend.pid} lacks complete RUN_START/EXIT lifecycle"
+            )
+        if strict_single_cpu and trace.policy == "stcf" and legend.pid != first_pid:
+            if stcf_arrival is None:
+                raise ExperimentError("STCF trace lacks shorter-task preemption boundary")
+            arrival_tick = stcf_arrival
+        else:
+            arrival_tick = origin_tick
+        first_run_tick = worker_starts[0].tick
+        completion = exits[-1]
+        response = first_run_tick - arrival_tick
+        turnaround = completion.tick - arrival_tick
+        if response < 0 or turnaround < response:
+            raise ExperimentError(
+                f"invalid lifecycle ticks for worker{legend.worker}: "
+                f"arrival={arrival_tick} first={first_run_tick} completion={completion.tick}"
+            )
+        metrics.append(
+            WorkerMetric(
+                trace.policy,
+                legend.glyph,
+                legend.worker,
+                legend.pid,
+                legend.hint,
+                arrival_tick,
+                first_run_tick,
+                completion.tick,
+                response,
+                turnaround,
+                completion.dispatches,
+            )
+        )
+    return tuple(metrics)
+
+
+def validate_policy_evidence(
+    trace: TraceData,
+    metrics: Sequence[WorkerMetric],
+    strict_single_cpu: bool,
+) -> str:
+    """校验四类教材策略的关键证据；SMP 不套用单核完成顺序判据。"""
+
+    if not metrics:
+        raise ExperimentError(f"{trace.policy}: no worker metrics")
+    if not strict_single_cpu:
+        return f"SMP smoke: {len(metrics)} workers completed, dropped=0"
+
+    completion_order = [
+        metric.worker
+        for metric in sorted(metrics, key=lambda item: (item.completion_tick, item.worker))
+    ]
+    if trace.policy == "fifo":
+        expected = [metric.worker for metric in sorted(metrics, key=lambda item: item.worker)]
+        if completion_order != expected:
+            raise ExperimentError(
+                f"FIFO completion order mismatch: got={completion_order} expected={expected}"
+            )
+        return f"completion order follows enqueue order {completion_order}"
+    if trace.policy == "sjf":
+        expected = [
+            metric.worker
+            for metric in sorted(metrics, key=lambda item: (item.hint, item.worker))
+        ]
+        if completion_order != expected:
+            raise ExperimentError(
+                f"SJF completion order mismatch: got={completion_order} expected={expected}"
+            )
+        return f"completion order follows burst hint {completion_order}"
+    if trace.policy == "stcf":
+        preemptions = [
+            event
+            for event in trace.events
+            if event.event_type == "RUN_STOP"
+            and event.reason == "STCF_SHORTER_TASK"
+        ]
+        long_worker = max(metrics, key=lambda item: item.hint)
+        earlier_short = any(
+            metric.worker != long_worker.worker
+            and metric.completion_tick < long_worker.completion_tick
+            for metric in metrics
+        )
+        if not preemptions or not earlier_short:
+            raise ExperimentError("STCF trace does not prove shorter-task preemption")
+        return (
+            f"observed {len(preemptions)} shorter-task preemption(s); "
+            f"worker{long_worker.worker} completed after a shorter worker"
+        )
+    if trace.policy == "rr":
+        quantum_stops = [
+            event
+            for event in trace.events
+            if event.event_type == "RUN_STOP" and event.reason == "RR_QUANTUM"
+        ]
+        if not quantum_stops or any(metric.dispatches < 2 for metric in metrics):
+            raise ExperimentError("RR trace does not prove time-slice rotation")
+        return (
+            f"observed {len(quantum_stops)} RR quantum stop(s); "
+            "every worker was dispatched at least twice"
+        )
+    raise ExperimentError(f"unsupported policy: {trace.policy}")
+
+
+def build_make_command(policy: str, cpus: int) -> tuple[str, ...]:
+    """构造复用现有 `make schedviz` 的可复制命令。"""
+
+    if policy not in POLICIES:
+        raise ExperimentError(f"unsupported policy: {policy}")
+    if cpus < 1:
+        raise ExperimentError(f"invalid CPU count: {cpus}")
+    return (
+        "make",
+        "schedviz",
+        f"SCHED_POLICY={policy}",
+        f"CPUS={cpus}",
+        "SCHEDVIZ_SUFFIX=-intro",
+        f"SCHEDVIZ_ARGS=--plain --seconds {EXPERIMENT_SECONDS} "
+        f"--workers {EXPERIMENT_WORKERS}",
+    )
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """在仓库根目录执行命令并合并捕获 stdout/stderr。"""
+
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def run_policy(policy: str, cpus: int, artifact_dir: Path) -> PolicyResult:
+    """运行一个策略，保存日志并消费现有 schedviz trace/SVG 产物。"""
+
+    command = build_make_command(policy, cpus)
+    completed = _run(command)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    log_path = artifact_dir / f"{policy}-cpu{cpus}-intro.log"
+    log_path.write_text(f"$ {' '.join(command)}\n{completed.stdout}", encoding="utf-8")
+    if completed.returncode != 0:
+        raise ExperimentError(
+            f"{policy}: command exited with {completed.returncode}; log={log_path}"
+        )
+
+    generated_trace = DEFAULT_ARTIFACT_DIR / f"{policy}-cpu{cpus}-intro.trace"
+    generated_svg = DEFAULT_ARTIFACT_DIR / f"{policy}-cpu{cpus}-intro.svg"
+    if not generated_trace.is_file() or not generated_svg.is_file():
+        raise ExperimentError(f"{policy}: trace/SVG was not generated")
+    trace_path = artifact_dir / generated_trace.name
+    svg_path = artifact_dir / generated_svg.name
+    if trace_path != generated_trace:
+        shutil.copy2(generated_trace, trace_path)
+    if svg_path != generated_svg:
+        shutil.copy2(generated_svg, svg_path)
+
+    trace = parse_trace_file(trace_path)
+    if trace.policy != policy or trace.cpus != cpus:
+        raise ExperimentError(
+            f"{policy}: artifact header mismatch policy={trace.policy} cpus={trace.cpus}"
+        )
+    strict_single_cpu = cpus == 1
+    metrics = derive_metrics(
+        trace,
+        parse_legend(completed.stdout),
+        strict_single_cpu=strict_single_cpu,
+    )
+    evidence = validate_policy_evidence(trace, metrics, strict_single_cpu)
+    return PolicyResult(
+        policy, command, log_path, trace_path, svg_path, evidence, metrics
+    )
+
+
+def _git_revision() -> str:
+    completed = _run(("git", "rev-parse", "HEAD"))
+    return completed.stdout.strip() if completed.returncode == 0 else "unavailable"
+
+
+def write_reports(
+    artifact_dir: Path,
+    cpus: int,
+    results: Sequence[PolicyResult],
+) -> tuple[Path, Path]:
+    """将 worker 指标写入 CSV，并生成带复现命令和边界的 Markdown。"""
+
+    csv_path = artifact_dir / f"intro-cpu{cpus}-metrics.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(
+            (
+                "policy",
+                "glyph",
+                "worker",
+                "pid",
+                "hint",
+                "arrival_tick",
+                "first_run_tick",
+                "completion_tick",
+                "response_ticks",
+                "turnaround_ticks",
+                "dispatches",
+            )
+        )
+        for result in results:
+            for metric in result.metrics:
+                writer.writerow(tuple(metric.__dict__.values()))
+
+    markdown_path = artifact_dir / f"intro-cpu{cpus}-summary.md"
+    lines = [
+        "# xv6 Scheduling Intro Report",
+        "",
+        f"- Revision: `{_git_revision()}`",
+        f"- CPUs: `{cpus}`",
+        f"- Generated at: `{datetime.now(timezone.utc).isoformat()}`",
+        f"- Shared args: `--seconds {EXPERIMENT_SECONDS} --workers {EXPERIMENT_WORKERS}`",
+        "",
+        "## Policy evidence",
+        "",
+        "| Policy | Evidence |",
+        "|---|---|",
+        *(f"| `{result.policy}` | {result.evidence} |" for result in results),
+        "",
+        "## Worker metrics",
+        "",
+        "| Policy | Worker | Hint | Arrival | First run | Completion | Response | Turnaround | Dispatches |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in results:
+        for metric in result.metrics:
+            lines.append(
+                f"| `{metric.policy}` | {metric.glyph}/worker{metric.worker} | "
+                f"{metric.hint} | {metric.arrival_tick} | {metric.first_run_tick} | "
+                f"{metric.completion_tick} | {metric.response_ticks} | "
+                f"{metric.turnaround_ticks} | {metric.dispatches} |"
+            )
+    lines.extend(("", "## Reproduction commands", ""))
+    for result in results:
+        lines.extend(("```bash", " ".join(result.command), "```", ""))
+    lines.extend(
+        (
+            "## Artifacts",
+            "",
+            *(
+                f"- `{result.policy}`: `{result.log_path.name}`, "
+                f"`{result.trace_path.name}`, `{result.svg_path.name}`"
+                for result in results
+            ),
+            "",
+            "## Measurement boundary",
+            "",
+            "- FIFO、SJF、RR 的 arrival 归一化为共同 barrier 后第一个 RUN_START tick。",
+            "- 单核 STCF 的短任务 arrival 使用第一次 STCF_SHORTER_TASK 停止点；多核 smoke 统一使用 session 原点。",
+            "- `CPUS=1` 验证教材完成顺序和 response/turnaround；SMP 只验证事件完整性、并行运行和资源回收。",
+            "- burst hint 是实验输入，不表示内核能够预测未来 CPU burst；SJF/STCF 均为教学实现。",
+            "",
+        )
+    )
+    markdown_path.write_text("\n".join(lines), encoding="utf-8")
+    return csv_path, markdown_path
+
+
+def run_experiment(cpus: int, artifact_dir: Path) -> tuple[Path, Path]:
+    """顺序运行 FIFO/SJF/STCF/RR，并生成统一报告。"""
+
+    results = tuple(run_policy(policy, cpus, artifact_dir) for policy in POLICIES)
+    return write_reports(artifact_dir, cpus, results)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run FIFO/SJF/STCF/RR schedviz experiments and build reports."
+    )
+    parser.add_argument("--cpus", type=int, default=1)
+    parser.add_argument("--artifacts", type=Path, default=DEFAULT_ARTIFACT_DIR)
+    args = parser.parse_args(argv)
+    if args.cpus < 1:
+        parser.error("--cpus must be positive")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        csv_path, markdown_path = run_experiment(args.cpus, args.artifacts)
+    except ExperimentError as error:
+        print(f"sched_intro_report: FAIL: {error}", file=sys.stderr)
+        return 1
+    print(f"sched_intro_report: wrote {csv_path} and {markdown_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/user/init.c
+++ b/user/init.c
@@ -76,6 +76,7 @@ static struct image_file image_files[] = {
   {"/xv6test", XV6_USR_BIN_PATH("xv6test")},
 
   {"/memviztest", XV6_TEST_PATH("memviztest")},
+  {"/pgtbltest", XV6_TEST_PATH("pgtbltest")},
   {"/vaaccesstest", XV6_TEST_PATH("vaaccesstest")},
   {"/addresswindowtest", XV6_TEST_PATH("addresswindowtest")},
   {"/forktest", XV6_TEST_PATH("forktest")},


### PR DESCRIPTION
同步 `main` 当前基线 `4fe136143f78eaf10457604d1695486038b5f93e` 到 #145 实现分支。`user/init.c` 已先保留 main 新增的 `pgtbltest` 布局入口，并叠加本分支的 swap 后备文件预分配。