### PR TITLE
[Superseded] WIP：教学型 swap 页换出与按需换入

### DIFF
--- a/kernel/swap.h
+++ b/kernel/swap.h
@@ -1,0 +1,69 @@
+#ifndef XV6_SWAP_H
+#define XV6_SWAP_H
+
+#include "types.h"
+
+struct proc;
+
+// RISC-V 为软件保留 PTE 的第 8、9 位；第 8 位已用于 COW，本机制使用第 9 位。
+#define PTE_SWAP (1L << 9)
+
+// 教学镜像在文件系统块范围之后追加 128 个原始块；4 个 1 KiB 块保存一页。
+#define SWAP_BLOCKS 128
+#define SWAP_PAGE_BLOCKS 4
+#define SWAP_SLOTS (SWAP_BLOCKS / SWAP_PAGE_BLOCKS)
+
+// swapquery() 对一个用户虚拟页返回的稳定状态。
+enum swap_page_state {
+  SWAP_PAGE_INVALID = 0,
+  SWAP_PAGE_LAZY = 1,
+  SWAP_PAGE_RESIDENT = 2,
+  SWAP_PAGE_SWAPPED = 3,
+};
+
+/** 描述一个用户虚拟页当前是否驻留，以及它的 swap 后备位置。 */
+struct swap_page_info {
+  uint64 va;       // 页对齐用户虚拟地址。
+  uint64 flags;    // resident 或 swapped leaf 保存的原始低位 PTE 权限。
+  int state;       // enum swap_page_state。
+  int slot;        // swapped 时为 [0, SWAP_SLOTS)，其他状态为 -1。
+};
+
+/** 初始化 swap slot 元数据；启动阶段只初始化锁，不执行磁盘 I/O。 */
+void swapinit(void);
+
+/**
+ * 将当前进程一个已驻留的匿名用户页写入 swap 并释放物理页框。
+ *
+ * @param p 目标进程，必须是当前执行系统调用的进程。
+ * @param va 目标用户地址；函数内部按页向下对齐。
+ * @return 成功返回 0；地址、页状态、slot 或页面类型不满足约束时返回 -1。
+ */
+int swapout_page(struct proc *p, uint64 va);
+
+/**
+ * 在 page fault 或内核用户指针访问路径中恢复 swapped 页。
+ *
+ * @param p 拥有目标用户页表和 kernel alias 页表的进程。
+ * @param va faulting 用户地址；函数内部按页向下对齐。
+ * @return 恢复成功返回 0；目标不是 swapped 页返回 1；恢复失败返回 -1。
+ */
+int swapin_page(struct proc *p, uint64 va);
+
+/**
+ * 查询用户虚拟页的 lazy、resident、swapped 或 invalid 状态。
+ *
+ * @param p 当前进程。
+ * @param va 目标用户地址；允许尚未建立 leaf PTE。
+ * @param info 接收页状态，不接管任何内核资源。
+ * @return 参数有效时返回 0；地址越界或输出为空时返回 -1。
+ */
+int swapquery_page(struct proc *p, uint64 va, struct swap_page_info *info);
+
+/** 为 fork 后共享的 swapped PTE 增加一个 slot 引用。 */
+int swapretain_pte(uint64 pte);
+
+/** 为被缩容、exec 或 exit 移除的 swapped PTE 释放一个 slot 引用。 */
+void swaprelease_pte(uint64 pte);
+
+#endif

--- a/tests/guest/swaptest.c
+++ b/tests/guest/swaptest.c
@@ -1,0 +1,76 @@
+#include "kernel/types.h"
+#include "kernel/riscv.h"
+#include "kernel/memviz.h"
+#include "kernel/swap.h"
+#include "user/user.h"
+
+static struct memviz_snapshot snapshot;
+static struct swap_page_info info;
+
+/** 输出稳定失败原因并以非零状态终止测试。 */
+static void
+fail(char *message)
+{
+  printf("swaptest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/**
+ * 读取当前 kalloc 空闲页数。
+ *
+ * @return 所有 CPU freelist 中可立即分配的物理页总数。
+ */
+static uint64
+free_pages(void)
+{
+  if(memsnapshot(MEMVIZ_VIEW_PHYS, &snapshot) < 0)
+    fail("physical snapshot");
+  return snapshot.free_pages;
+}
+
+/**
+ * 验证一个匿名页完成 resident -> swapped -> resident 的最小闭环。
+ *
+ * 当前文件先固定 guest 侧 oracle 与稳定输出；内核系统调用接入后该入口才会
+ * 注册到镜像和 xv6test，避免在功能未闭环前产生假阳性测试。
+ */
+static void
+check_basic_cycle(void)
+{
+  uint64 before = free_pages();
+  char *page = sbrk(PGSIZE);
+  if(page == (char *)-1)
+    fail("sbrk");
+
+  page[0] = 0x5a;
+  page[PGSIZE - 1] = 0x6b;
+  if(swapquery((uint64)page, &info) < 0 ||
+     info.state != SWAP_PAGE_RESIDENT)
+    fail("resident query");
+
+  if(swapout((uint64)page) < 0)
+    fail("swapout");
+  if(swapquery((uint64)page, &info) < 0 ||
+     info.state != SWAP_PAGE_SWAPPED || info.slot < 0)
+    fail("swapped query");
+  if(free_pages() < before)
+    fail("pageout did not release memory");
+
+  if(page[0] != 0x5a || page[PGSIZE - 1] != 0x6b)
+    fail("pagein data");
+  if(swapquery((uint64)page, &info) < 0 ||
+     info.state != SWAP_PAGE_RESIDENT || info.slot != -1)
+    fail("pagein query");
+
+  if(sbrk(-PGSIZE) == (char *)-1)
+    fail("shrink");
+  printf("SWAP basic data_preserved=1 pageout=1 pagein=1\n");
+}
+
+int
+main(void)
+{
+  check_basic_cycle();
+  printf("SWAP result=ok\n");
+  exit(0);
+}


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #216
- 变更类型：功能 / 测试
- 基线 Commit：`4fe136143f78eaf10457604d1695486038b5f93e`
- 影响范围：swap 页状态合同、后续 guest 回归入口
- 一句话摘要：先固定教学型 swap 的 PTE 状态、slot 容量和用户态断言合同，后续实现继续收敛在本 Draft PR。

## 实现了什么

- 新增 `kernel/swap.h`，定义 `PTE_SWAP`、32 个教学 slot、`lazy/resident/swapped/invalid` 四种状态及 page-out/page-in 生命周期接口。
- 明确 swapped PTE 必须保留原权限与 COW 语义，并为 `fork()`、缩容、`exec()`、`exit()` 预留 slot 引用管理接口。
- 新增 `tests/guest/swaptest.c`，先固定 `resident -> swapped -> resident` 的 guest oracle：数据保持、状态变化、物理页释放与最终缩容。
- 测试程序暂未加入 `Makefile` 或 `xv6test`，避免核心实现尚未闭环时产生可执行但必然失败的镜像入口。

当前仍待本 PR 继续实现：

- 文件系统镜像尾部 raw swap blocks；
- slot 分配、引用计数和磁盘 I/O；
- swapped PTE 编解码与 page-out/page-in；
- fault、`walkaddr()`、`copyin/copyout`、`uvmcopy/uvmunmap`、kernel alias 生命周期；
- 系统调用、构建注册、完整 guest 用例与多核/单核回归。

## 添加/修改了什么单元测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `check_basic_cycle` | 已写入匿名页换出并再次访问 | 换出后状态为 `SWAP_PAGE_SWAPPED` 且 slot 有效；再次读取恢复原字节并回到 `SWAP_PAGE_RESIDENT` |
| `check_basic_cycle` | page-out 的物理页回收 | 换出后的空闲物理页数不得低于实验基线 |
| `check_basic_cycle` | 结束时释放逻辑范围 | 负向 `sbrk()` 必须成功，避免测试残留用户页 |

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `make clean && make` | 未运行 | 当前 Draft 只提交状态合同与未注册的 guest oracle；核心实现尚未接入构建 |
| `lab-vm CPUS=3` | 未运行 | 等 page-out/page-in 与生命周期闭环后执行 |
| `lab-vm CPUS=1` | 未运行 | 单核仅作为补充诊断，不能替代多核正确性 |

## Review 主线

1. `kernel/swap.h`
   - 先确认 swapped PTE 位、slot 容量、四态模型和生命周期接口是否足以覆盖 #216。
2. `tests/guest/swaptest.c`
   - 再确认 guest oracle 是否只依赖用户可观察行为，并通过退出状态承担失败判定。
3. 后续提交
   - 按磁盘后备区 → slot 管理 → 页表/fault 生命周期 → syscall/测试注册的顺序继续补齐，全部验证通过前保持 Draft。