### PR TITLE
feat: 增加文件系统块布局局部性实验

### DIFF
--- a/tests/test_fs_locality.py
+++ b/tests/test_fs_locality.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证 xv6 文件系统布局分析器和确定性工作负载。"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "fs_locality.py"
+SPEC = importlib.util.spec_from_file_location("fs_locality", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load locality module from {MODULE_PATH}")
+LOCALITY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = LOCALITY
+SPEC.loader.exec_module(LOCALITY)
+
+
+class PlacementMetricTests(unittest.TestCase):
+    """验证连续区间、间隔和 inode 距离的纯计算契约。"""
+
+    def test_contiguous_blocks_form_one_extent(self) -> None:
+        """连续数据块只能形成一个 extent，块间最大间隔为一。"""
+
+        metrics = LOCALITY.placement_metrics(10, [20, 21, 22, 23])
+
+        self.assertEqual(1, metrics.data_extent_count)
+        self.assertEqual(1, metrics.max_data_gap_blocks)
+        self.assertEqual(4, metrics.allocation_span_blocks)
+        self.assertEqual(10, metrics.inode_first_data_distance_blocks)
+
+    def test_index_gap_splits_data_extents(self) -> None:
+        """索引块插入数据块序列时，不能误报为完整连续数据 extent。"""
+
+        metrics = LOCALITY.placement_metrics(10, [20, 21, 23, 24])
+
+        self.assertEqual(2, metrics.data_extent_count)
+        self.assertEqual(2, metrics.max_data_gap_blocks)
+        self.assertEqual(5, metrics.allocation_span_blocks)
+
+    def test_empty_file_has_no_distance(self) -> None:
+        """空文件没有数据块，也就不存在伪造的元数据距离。"""
+
+        metrics = LOCALITY.placement_metrics(10, [])
+
+        self.assertEqual(0, metrics.data_extent_count)
+        self.assertIsNone(metrics.inode_first_data_distance_blocks)
+
+
+class ImageValidationTests(unittest.TestCase):
+    """验证损坏镜像会快速失败而不是生成误导性指标。"""
+
+    def test_invalid_magic_is_rejected(self) -> None:
+        """全零镜像不应被误识别为可分析的 xv6 文件系统。"""
+
+        with tempfile.TemporaryDirectory(prefix="xv6-fs-invalid-") as directory:
+            image = Path(directory) / "invalid.img"
+            image.write_bytes(bytes(2 * LOCALITY.BSIZE))
+
+            with self.assertRaisesRegex(LOCALITY.ExperimentError, "invalid xv6"):
+                LOCALITY.FsImage(image)
+
+
+class WorkloadContractTests(unittest.TestCase):
+    """验证负载参数确实跨越目录和一级间接块边界。"""
+
+    def test_small_file_count_must_grow_root_directory(self) -> None:
+        """少于 63 个子项无法稳定触发根目录第二个数据块。"""
+
+        with self.assertRaisesRegex(LOCALITY.ExperimentError, "at least 63"):
+            LOCALITY.WorkloadSpec(small_files=62).validate()
+
+    def test_large_file_must_cross_direct_block_boundary(self) -> None:
+        """大文件不跨越 NDIRECT 时不能形成索引块观察。"""
+
+        with self.assertRaisesRegex(LOCALITY.ExperimentError, "exceed NDIRECT"):
+            LOCALITY.WorkloadSpec(large_blocks=LOCALITY.NDIRECT).validate()
+
+
+class MkfsImageIntegrationTests(unittest.TestCase):
+    """使用仓库真实 mkfs 验证单一全局布局的可观察证据。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """生成一次共享实验镜像，避免每个断言重复写入完整磁盘文件。"""
+
+        cls._temporary = tempfile.TemporaryDirectory(prefix="xv6-fs-locality-")
+        cls.output_dir = Path(cls._temporary.name) / "artifacts"
+        cls.spec = LOCALITY.WorkloadSpec()
+        mkfs = REPO_ROOT / "mkfs" / "mkfs"
+        if not mkfs.is_file():
+            # 复用仓库正式构建目标，避免测试复制 mkfs 的编译参数。
+            subprocess.run(
+                ["make", "mkfs/mkfs"],
+                cwd=REPO_ROOT,
+                check=True,
+            )
+        cls.result = LOCALITY.run_experiment(mkfs, cls.output_dir, cls.spec)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """删除测试镜像、负载文件和报告，验证实验不会污染仓库。"""
+
+        temporary = getattr(cls, "_temporary", None)
+        if temporary is not None:
+            temporary.cleanup()
+
+    def test_root_directory_growth_is_measured(self) -> None:
+        """目录项超过单块容量后，报告必须显示两个相隔的数据块。"""
+
+        root = self.result.find(".")
+
+        self.assertEqual(self.spec.small_files + 3, self.result.root_entry_count)
+        self.assertEqual(2, root.metrics.data_block_count)
+        self.assertEqual(2, root.metrics.data_extent_count)
+        self.assertGreater(root.metrics.max_data_gap_blocks, 1)
+
+    def test_large_file_exposes_indirect_metadata_gap(self) -> None:
+        """大文件跨过直接块后，应解析一个一级索引块和两个数据 extent。"""
+
+        large = self.result.find("large")
+
+        self.assertEqual(self.spec.large_bytes, large.size_bytes)
+        self.assertEqual(self.spec.large_blocks, large.metrics.data_block_count)
+        self.assertEqual(1, len(large.index_blocks))
+        self.assertEqual(2, large.metrics.data_extent_count)
+        self.assertEqual(2, large.metrics.max_data_gap_blocks)
+        self.assertEqual(large.data_blocks[LOCALITY.NDIRECT - 1] + 1, large.index_blocks[0])
+        self.assertEqual(large.index_blocks[0] + 1, large.data_blocks[LOCALITY.NDIRECT])
+
+    def test_mkfs_allocates_child_inodes_in_input_order(self) -> None:
+        """输入顺序对应连续 inode 编号，证明 mkfs 没有目录块组选择。"""
+
+        child_layouts = [
+            layout for layout in self.result.layouts if layout.name not in (".", "..")
+        ]
+
+        self.assertEqual(
+            list(range(2, 2 + len(child_layouts))),
+            [layout.inum for layout in child_layouts],
+        )
+
+    def test_report_denies_ffs_and_performance_claims(self) -> None:
+        """报告必须明确块组缺失，并拒绝把块位置直接升级为速度结论。"""
+
+        report = self.result.report_text
+
+        self.assertIn("block_groups=absent", report)
+        self.assertIn("placement_model=single-global-next-free", report)
+        self.assertIn("performance_claim=not-measured", report)
+        self.assertIn("FSLOCALITY done status=0", report)
+
+    def test_report_artifacts_are_reproducible(self) -> None:
+        """实验必须同时产出文本、JSON、mkfs 日志和可复核镜像。"""
+
+        expected = {
+            "fs-locality.img",
+            "mkfs.log",
+            "report.json",
+            "report.txt",
+            "workload",
+        }
+
+        self.assertEqual(expected, {path.name for path in self.output_dir.iterdir()})
+        self.assertEqual(
+            self.result.report_text,
+            (self.output_dir / "report.txt").read_text(encoding="utf-8"),
+        )
+        self.assertTrue((self.output_dir / "fs-locality.img").stat().st_size > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fs_locality.py
+++ b/tools/fs_locality.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""生成并分析 xv6 文件系统镜像中的块放置证据。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import struct
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+BSIZE = 1024
+FSMAGIC = 0x10203040
+DINODE_SIZE = 64
+DIRSIZ = 14
+NDIRECT = 9
+NINDIRECT_LEVELS = 3
+NINDIRECT = BSIZE // 4
+IPB = BSIZE // DINODE_SIZE
+SUPERBLOCK_STRUCT = struct.Struct("<8I")
+DINODE_STRUCT = struct.Struct("<4HQ12I")
+DIRENT_STRUCT = struct.Struct(f"<H{DIRSIZ}s")
+
+
+class ExperimentError(RuntimeError):
+    """表示镜像格式、工作负载或外部命令不满足实验契约。"""
+
+
+@dataclass(frozen=True)
+class Superblock:
+    """保存 xv6 磁盘 superblock 中与布局有关的字段。"""
+
+    magic: int
+    size: int
+    nblocks: int
+    ninodes: int
+    nlog: int
+    logstart: int
+    inodestart: int
+    bmapstart: int
+
+    @property
+    def data_start(self) -> int:
+        """返回首个数据块编号。"""
+
+        return self.size - self.nblocks
+
+
+@dataclass(frozen=True)
+class DiskInode:
+    """保存一个磁盘 inode 的文件类型、大小与块索引根。"""
+
+    type: int
+    major: int
+    minor: int
+    nlink: int
+    size: int
+    addrs: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class PlacementMetrics:
+    """描述一个 inode 的数据块连续性和元数据距离。"""
+
+    data_block_count: int
+    data_extent_count: int
+    max_data_gap_blocks: int
+    allocation_span_blocks: int
+    inode_first_data_distance_blocks: int | None
+
+
+@dataclass(frozen=True)
+class FileLayout:
+    """描述一个目录项对应 inode 的块布局和派生指标。"""
+
+    name: str
+    inum: int
+    inode_block: int
+    file_type: int
+    size_bytes: int
+    data_blocks: tuple[int, ...]
+    index_blocks: tuple[int, ...]
+    metrics: PlacementMetrics
+
+
+@dataclass(frozen=True)
+class WorkloadSpec:
+    """定义用于观察小文件、目录增长和大文件索引的确定性负载。"""
+
+    small_files: int = 72
+    small_bytes: int = 17
+    large_blocks: int = 20
+    large_tail_bytes: int = 0
+
+    def validate(self) -> None:
+        """校验负载能稳定跨越目录块和一级间接块边界。"""
+
+        if self.small_files < 63:
+            raise ExperimentError("small_files must be at least 63 to grow the root directory")
+        if self.small_bytes <= 0 or self.small_bytes > BSIZE:
+            raise ExperimentError("small_bytes must be in [1, 1024]")
+        if self.large_blocks <= NDIRECT:
+            raise ExperimentError("large_blocks must exceed NDIRECT to allocate an index block")
+        if self.large_tail_bytes < 0 or self.large_tail_bytes >= BSIZE:
+            raise ExperimentError("large_tail_bytes must be in [0, 1023]")
+
+    @property
+    def large_bytes(self) -> int:
+        """返回大文件的精确字节数。"""
+
+        return self.large_blocks * BSIZE + self.large_tail_bytes
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    """汇总一次实际 mkfs 镜像实验的布局和对象证据。"""
+
+    image: str
+    superblock: Superblock
+    root_entry_count: int
+    layouts: tuple[FileLayout, ...]
+    report_text: str
+
+    def find(self, name: str) -> FileLayout:
+        """按目录项名称返回布局；不存在时抛出实验错误。"""
+
+        for layout in self.layouts:
+            if layout.name == name:
+                return layout
+        raise ExperimentError(f"missing layout for {name!r}")
+
+
+class FsImage:
+    """只读解析当前 xv6 单分区文件系统镜像。"""
+
+    def __init__(self, path: Path) -> None:
+        """打开并验证镜像的 superblock 与文件长度。"""
+
+        self.path = path
+        self._data = path.read_bytes()
+        if len(self._data) < 2 * BSIZE:
+            raise ExperimentError("image is too small to contain an xv6 superblock")
+        self.superblock = self._read_superblock()
+        expected_size = self.superblock.size * BSIZE
+        if len(self._data) != expected_size:
+            raise ExperimentError(
+                f"image length {len(self._data)} does not match superblock size {expected_size}"
+            )
+
+    def _read_superblock(self) -> Superblock:
+        """从磁盘块 1 解码 superblock，并检查关键范围。"""
+
+        values = SUPERBLOCK_STRUCT.unpack_from(self._data, BSIZE)
+        sb = Superblock(*values)
+        if sb.magic != FSMAGIC:
+            raise ExperimentError(f"invalid xv6 file-system magic: 0x{sb.magic:08x}")
+        if not (2 <= sb.logstart <= sb.inodestart <= sb.bmapstart < sb.data_start < sb.size):
+            raise ExperimentError("superblock regions are not monotonically ordered")
+        return sb
+
+    def read_block(self, block_number: int) -> bytes:
+        """读取一个完整块；越界块号视为镜像损坏。"""
+
+        if block_number < 0 or block_number >= self.superblock.size:
+            raise ExperimentError(f"block {block_number} is outside the image")
+        start = block_number * BSIZE
+        return self._data[start : start + BSIZE]
+
+    def read_inode(self, inum: int) -> DiskInode:
+        """按 inode 编号读取固定 64 字节磁盘 inode。"""
+
+        if inum <= 0 or inum >= self.superblock.ninodes:
+            raise ExperimentError(f"inode {inum} is outside the inode table")
+        block_number = inum // IPB + self.superblock.inodestart
+        offset = (inum % IPB) * DINODE_SIZE
+        values = DINODE_STRUCT.unpack_from(self.read_block(block_number), offset)
+        return DiskInode(
+            type=values[0],
+            major=values[1],
+            minor=values[2],
+            nlink=values[3],
+            size=values[4],
+            addrs=tuple(values[5:]),
+        )
+
+    def inode_block(self, inum: int) -> int:
+        """返回 inode 所在的磁盘块编号。"""
+
+        return inum // IPB + self.superblock.inodestart
+
+    def resolve_inode_blocks(self, inode: DiskInode) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """按逻辑顺序解析 inode 的数据块，并收集经过的索引块。"""
+
+        needed = (inode.size + BSIZE - 1) // BSIZE
+        data_blocks: list[int] = []
+        index_blocks: list[int] = []
+
+        for address in inode.addrs[:NDIRECT]:
+            if len(data_blocks) >= needed:
+                break
+            if address == 0:
+                raise ExperimentError("sparse data block is not supported by this locality experiment")
+            data_blocks.append(address)
+
+        for depth in range(1, NINDIRECT_LEVELS + 1):
+            if len(data_blocks) >= needed:
+                break
+            root = inode.addrs[NDIRECT + depth - 1]
+            if root == 0:
+                raise ExperimentError("inode size requires an absent indirect root")
+            self._walk_indirect(root, depth, needed, data_blocks, index_blocks)
+
+        if len(data_blocks) != needed:
+            raise ExperimentError(
+                f"resolved {len(data_blocks)} data blocks for inode requiring {needed}"
+            )
+        return tuple(data_blocks), tuple(index_blocks)
+
+    def _walk_indirect(
+        self,
+        block_number: int,
+        depth: int,
+        needed: int,
+        data_blocks: list[int],
+        index_blocks: list[int],
+    ) -> None:
+        """深度优先展开一个间接树，直到收集到文件大小需要的块数。"""
+
+        if depth < 1 or depth > NINDIRECT_LEVELS:
+            raise ExperimentError(f"unsupported indirect depth {depth}")
+        index_blocks.append(block_number)
+        entries = struct.unpack(f"<{NINDIRECT}I", self.read_block(block_number))
+        for address in entries:
+            if len(data_blocks) >= needed:
+                return
+            if address == 0:
+                continue
+            if depth == 1:
+                data_blocks.append(address)
+            else:
+                self._walk_indirect(
+                    address,
+                    depth - 1,
+                    needed,
+                    data_blocks,
+                    index_blocks,
+                )
+
+    def read_root_entries(self) -> tuple[tuple[str, int], ...]:
+        """读取根目录中所有非空目录项，并保持磁盘顺序。"""
+
+        root = self.read_inode(1)
+        data_blocks, _ = self.resolve_inode_blocks(root)
+        raw = b"".join(self.read_block(block) for block in data_blocks)[: root.size]
+        entries: list[tuple[str, int]] = []
+        for offset in range(0, len(raw), DIRENT_STRUCT.size):
+            inum, raw_name = DIRENT_STRUCT.unpack_from(raw, offset)
+            if inum == 0:
+                continue
+            name = raw_name.split(b"\0", 1)[0].decode("ascii", errors="strict")
+            entries.append((name, inum))
+        return tuple(entries)
+
+    def layout_for(self, name: str, inum: int) -> FileLayout:
+        """解析一个 inode 并计算连续性与元数据距离指标。"""
+
+        inode = self.read_inode(inum)
+        data_blocks, index_blocks = self.resolve_inode_blocks(inode)
+        inode_block = self.inode_block(inum)
+        return FileLayout(
+            name=name,
+            inum=inum,
+            inode_block=inode_block,
+            file_type=inode.type,
+            size_bytes=inode.size,
+            data_blocks=data_blocks,
+            index_blocks=index_blocks,
+            metrics=placement_metrics(inode_block, data_blocks),
+        )
+
+
+def placement_metrics(inode_block: int, data_blocks: Sequence[int]) -> PlacementMetrics:
+    """从有序数据块列表计算连续区间、最大间隔与 inode 距离。"""
+
+    if not data_blocks:
+        return PlacementMetrics(0, 0, 0, 0, None)
+
+    extent_count = 1
+    max_gap = 0
+    for previous, current in zip(data_blocks, data_blocks[1:]):
+        gap = abs(current - previous)
+        max_gap = max(max_gap, gap)
+        if current != previous + 1:
+            extent_count += 1
+
+    span = max(data_blocks) - min(data_blocks) + 1
+    return PlacementMetrics(
+        data_block_count=len(data_blocks),
+        data_extent_count=extent_count,
+        max_data_gap_blocks=max_gap,
+        allocation_span_blocks=span,
+        inode_first_data_distance_blocks=abs(data_blocks[0] - inode_block),
+    )
+
+
+def write_workload(directory: Path, spec: WorkloadSpec) -> tuple[str, ...]:
+    """在指定目录生成名称稳定、内容确定的 mkfs 输入文件。"""
+
+    spec.validate()
+    directory.mkdir(parents=True, exist_ok=True)
+    names: list[str] = []
+
+    for index in range(spec.small_files):
+        name = f"s{index:02d}"
+        payload = bytes(((index + offset) % 251 for offset in range(spec.small_bytes)))
+        (directory / name).write_bytes(payload)
+        names.append(name)
+
+    large_name = "large"
+    chunk = bytes((offset % 251 for offset in range(BSIZE)))
+    with (directory / large_name).open("wb") as stream:
+        for _ in range(spec.large_blocks):
+            stream.write(chunk)
+        stream.write(chunk[: spec.large_tail_bytes])
+    names.append(large_name)
+    return tuple(names)
+
+
+def build_image(mkfs: Path, image: Path, workload: Path, names: Sequence[str]) -> str:
+    """调用仓库现有 mkfs，保存标准输出并生成实验镜像。"""
+
+    mkfs_path = mkfs.resolve()
+    if not mkfs_path.is_file():
+        raise ExperimentError(f"mkfs executable does not exist: {mkfs_path}")
+    image.parent.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        [str(mkfs_path), str(image.resolve()), *names],
+        cwd=workload,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if completed.returncode != 0:
+        raise ExperimentError(
+            f"mkfs failed with status {completed.returncode}:\n{completed.stdout}"
+        )
+    return completed.stdout
+
+
+def analyze_image(image: Path) -> tuple[FsImage, tuple[tuple[str, int], ...], tuple[FileLayout, ...]]:
+    """解析根目录及其全部命名对象，返回可复核的布局模型。"""
+
+    fs = FsImage(image)
+    entries = fs.read_root_entries()
+    layouts = tuple(fs.layout_for(name, inum) for name, inum in entries)
+    return fs, entries, layouts
+
+
+def format_blocks(blocks: Iterable[int]) -> str:
+    """把块号序列压缩成便于人工核对的连续区间。"""
+
+    values = list(blocks)
+    if not values:
+        return "-"
+    ranges: list[str] = []
+    start = previous = values[0]
+    for current in values[1:]:
+        if current == previous + 1:
+            previous = current
+            continue
+        ranges.append(str(start) if start == previous else f"{start}-{previous}")
+        start = previous = current
+    ranges.append(str(start) if start == previous else f"{start}-{previous}")
+    return ",".join(ranges)
+
+
+def format_report(
+    image: Path,
+    spec: WorkloadSpec,
+    fs: FsImage,
+    entries: Sequence[tuple[str, int]],
+    layouts: Sequence[FileLayout],
+) -> str:
+    """生成机器可匹配、人工可解释的局部性证据报告。"""
+
+    sb = fs.superblock
+    by_name = {layout.name: layout for layout in layouts}
+    root = by_name["."]
+    large = by_name["large"]
+    child_inums = [inum for name, inum in entries if name not in (".", "..")]
+    inodes_sequential = child_inums == list(range(2, 2 + len(child_inums)))
+    small_layouts = [by_name[f"s{index:02d}"] for index in range(spec.small_files)]
+    all_small_files_single_extent = all(
+        layout.metrics.data_extent_count == 1 for layout in small_layouts
+    )
+    first_small = small_layouts[0]
+    last_small = small_layouts[-1]
+
+    lines = [
+        "FSLOCALITY version=1",
+        f"image={image}",
+        (
+            "regions "
+            "boot=[0,1) super=[1,2) "
+            f"log=[{sb.logstart},{sb.logstart + sb.nlog}) "
+            f"inode=[{sb.inodestart},{sb.bmapstart}) "
+            f"bitmap=[{sb.bmapstart},{sb.data_start}) "
+            f"data=[{sb.data_start},{sb.size})"
+        ),
+        (
+            "workload "
+            f"small_files={spec.small_files} small_bytes={spec.small_bytes} "
+            f"large_blocks={spec.large_blocks} large_bytes={spec.large_bytes} "
+            f"root_entries={len(entries)}"
+        ),
+        (
+            "metrics "
+            "data_extent=contiguous-data-run "
+            "max_gap=absolute-distance-between-consecutive-data-blocks"
+        ),
+        (
+            "root "
+            f"inum={root.inum} inode_block={root.inode_block} "
+            f"data_blocks={format_blocks(root.data_blocks)} "
+            f"data_extents={root.metrics.data_extent_count} "
+            f"max_gap={root.metrics.max_data_gap_blocks}"
+        ),
+        (
+            "small_files "
+            f"first={first_small.name}:inum={first_small.inum}:data={format_blocks(first_small.data_blocks)} "
+            f"last={last_small.name}:inum={last_small.inum}:data={format_blocks(last_small.data_blocks)} "
+            f"all_single_extent={str(all_small_files_single_extent).lower()}"
+        ),
+        (
+            "large "
+            f"inum={large.inum} inode_block={large.inode_block} "
+            f"data_blocks={format_blocks(large.data_blocks)} "
+            f"index_blocks={format_blocks(large.index_blocks)} "
+            f"data_extents={large.metrics.data_extent_count} "
+            f"max_gap={large.metrics.max_data_gap_blocks}"
+        ),
+        (
+            "evidence "
+            f"child_inodes_sequential={str(inodes_sequential).lower()} "
+            "block_groups=absent placement_model=single-global-next-free "
+            "performance_claim=not-measured"
+        ),
+        "FSLOCALITY done status=0",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def result_payload(result: ExperimentResult, spec: WorkloadSpec) -> dict[str, object]:
+    """构造可供脚本二次核对的 JSON 数据。"""
+
+    return {
+        "version": 1,
+        "image": result.image,
+        "workload": asdict(spec),
+        "superblock": asdict(result.superblock),
+        "root_entry_count": result.root_entry_count,
+        "layouts": [asdict(layout) for layout in result.layouts],
+        "conclusions": {
+            "block_groups": "absent",
+            "placement_model": "single-global-next-free",
+            "performance_claim": "not-measured",
+        },
+    }
+
+
+def run_experiment(mkfs: Path, output_dir: Path, spec: WorkloadSpec) -> ExperimentResult:
+    """生成工作负载、构建镜像、解析布局并持久化报告。"""
+
+    spec.validate()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    workload = output_dir / "workload"
+    image = output_dir / "fs-locality.img"
+    # 只清理本实验拥有的固定产物，避免误删调用者传入的其他目录内容。
+    if workload.exists():
+        shutil.rmtree(workload)
+    for artifact in (
+        image,
+        output_dir / "mkfs.log",
+        output_dir / "report.txt",
+        output_dir / "report.json",
+    ):
+        if artifact.exists():
+            artifact.unlink()
+
+    names = write_workload(workload, spec)
+    mkfs_log = build_image(mkfs, image, workload, names)
+    fs, entries, layouts = analyze_image(image)
+    report = format_report(image, spec, fs, entries, layouts)
+    result = ExperimentResult(
+        image=str(image),
+        superblock=fs.superblock,
+        root_entry_count=len(entries),
+        layouts=layouts,
+        report_text=report,
+    )
+    (output_dir / "mkfs.log").write_text(mkfs_log, encoding="utf-8")
+    (output_dir / "report.txt").write_text(report, encoding="utf-8")
+    (output_dir / "report.json").write_text(
+        json.dumps(result_payload(result, spec), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """解析实验命令行参数。"""
+
+    parser = argparse.ArgumentParser(
+        description="生成并分析 xv6 单一全局布局的可核对块位置证据",
+    )
+    parser.add_argument("--mkfs", type=Path, default=Path("mkfs/mkfs"))
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/fs-locality"),
+    )
+    parser.add_argument("--small-files", type=int, default=72)
+    parser.add_argument("--small-bytes", type=int, default=17)
+    parser.add_argument("--large-blocks", type=int, default=20)
+    parser.add_argument("--large-tail-bytes", type=int, default=0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """执行完整实验；成功打印报告，失败返回非零状态。"""
+
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    spec = WorkloadSpec(
+        small_files=args.small_files,
+        small_bytes=args.small_bytes,
+        large_blocks=args.large_blocks,
+        large_tail_bytes=args.large_tail_bytes,
+    )
+    try:
+        result = run_experiment(args.mkfs, args.output_dir, spec)
+    except (ExperimentError, OSError) as error:
+        print(f"FSLOCALITY error: {error}", file=sys.stderr)
+        return 1
+    print(result.report_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #157
- Obsidian Issue：mental1104/Obsidian#218
- Obsidian PR：mental1104/Obsidian#229
- 基线 Commit：`2e303a7df4448b3c81920cff3afdd344c0147f84`
- 最终合并 Commit：`6c76f76d4cf53676f269e9a1e25b5aa147b99115`
- 变更类型：功能 / 测试
- 影响范围：宿主机文件系统镜像分析工具与 host 单元测试
- 一句话摘要：复用当前 `mkfs` 自动生成小文件、目录增长和跨直接块边界的大文件负载，并从原始镜像输出可核对的块位置证据。

## 实现了什么

- 新增 `tools/fs_locality.py`，只读解析当前 xv6 的 superblock、固定 64 字节磁盘 inode、目录项以及直接/一至三级间接索引。
- 自动生成 72 个 17 字节小文件和一个 20 KiB 大文件：根目录跨越第二个数据块，大文件跨越 `NDIRECT` 并分配一级索引块。
- 输出 `fs-locality.img`、`workload/`、`mkfs.log`、`report.txt` 与 `report.json`。
- 指标只描述数据 extent、相邻逻辑数据块的物理 gap、allocation span 与 inode/data 距离。
- 明确报告当前镜像没有 FFS block group；本 PR 不修改内核分配器、文件系统格式或 GitHub Actions，也不把块位置直接宣称为性能结果。

## 添加/修改了什么单元测试

| 测试组 | 覆盖场景 | 核心断言 |
|---|---|---|
| `PlacementMetricTests` | 连续、索引块插入、空文件 | extent 数、最大 gap、span 和空文件距离语义准确 |
| `ImageValidationTests` | 非 xv6 镜像 | 非法 magic 必须快速失败 |
| `WorkloadContractTests` | 目录与大文件阈值 | 负载必须跨过根目录单块和 `NDIRECT` 边界 |
| `MkfsImageIntegrationTests` | 仓库真实 `mkfs` 生成镜像 | 根目录两块、大文件一级索引、连续 inode 编号、报告边界和产物闭环均可执行断言 |

## CLI 验收

```bash
make mkfs/mkfs
python3 tools/fs_locality.py \
  --mkfs mkfs/mkfs \
  --output-dir artifacts/fs-locality
cat artifacts/fs-locality/report.txt
```

关键成功协议：

```text
FSLOCALITY version=1
...
root ... data_extents=2 ...
small_files ... all_single_extent=true
large ... index_blocks=<block> data_extents=2 max_gap=2
evidence ... block_groups=absent ... performance_claim=not-measured
FSLOCALITY done status=0
```

## 自动化测试结果

| 检查 | 结果 | 证据 |
|---|---|---|
| `make test-unit` | 通过 | `xv6 CI` run #452；包含 11 个新增测试与真实 `mkfs` 镜像集成断言 |
| `make clean && make -j2` | 通过 | `xv6 CI` run #452 |
| PR QEMU 回归，`CPUS=3` | 通过 | `xv6 CI` run #452，selected PR suites |
| VM 补充回归，`CPUS=1` | 通过 | `xv6 CI` run #452；仅作为兼容性诊断，不用于证明并发正确性 |
| 调度器全族回归 | 通过 | `Scheduler family CI` run #245 |
| uthread 调试回归 | 通过 | `uthread debug` run #230 |

## Review 主线

1. `tools/fs_locality.py::WorkloadSpec` 与 `write_workload`
   - 先确认负载为何稳定跨越根目录单块容量和 `NDIRECT`。
2. `tools/fs_locality.py::FsImage`
   - 检查 superblock、inode、目录项与间接块树的只读解析边界。
3. `tools/fs_locality.py::placement_metrics` 与 `format_report`
   - 确认 extent/gap 只描述块位置，并显式拒绝 FFS 与速度推断。
4. `tests/test_fs_locality.py`
   - 对照真实 `mkfs` 镜像的正常、边界、错误、清理和报告断言完成闭环。
