### PR TITLE
test: 建立文件 API 状态与生命周期验证闭环

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ UPROGS=\
 	$U/_alarmtest\
 	$U/_lazytests\
 	$U/_cowtest\
+	$U/_fileapitest\
 	$U/_bigfile\
 	$U/_largefile\
 	$U/_symlinktest\

--- a/tests/guest/fileapitest.c
+++ b/tests/guest/fileapitest.c
@@ -1,0 +1,221 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+#define PRIMARY_PATH "fa_primary"
+#define ALIAS_PATH "fa_alias"
+
+/**
+ * 立即报告断言失败并以非零状态终止测试。
+ *
+ * @param reason 可直接定位失败契约的稳定说明文本。
+ */
+static void
+fail(const char *reason)
+{
+  printf("fileapitest: %s\n", reason);
+  exit(1);
+}
+
+/**
+ * 关闭测试持有的文件描述符，并把关闭失败视为资源回收失败。
+ *
+ * @param fd 当前测试独占持有的有效文件描述符。
+ * @param reason close() 失败时输出的定位文本。
+ */
+static void
+close_checked(int fd, const char *reason)
+{
+  if(close(fd) < 0)
+    fail(reason);
+}
+
+/**
+ * 从当前偏移读取一个字节并校验内容。
+ *
+ * @param fd 可读文件描述符；调用后其所属打开文件对象偏移推进一字节。
+ * @param expected 期望读到的单字节内容。
+ * @param reason 读取长度或内容不符合契约时输出的定位文本。
+ */
+static void
+expect_byte(int fd, char expected, const char *reason)
+{
+  char actual = 0;
+
+  if(read(fd, &actual, 1) != 1 || actual != expected)
+    fail(reason);
+}
+
+/** 清除上次运行可能留下的目录项，使测试可在同一 guest 中重复执行。 */
+static void
+cleanup_workspace(void)
+{
+  unlink(PRIMARY_PATH);
+  unlink(ALIAS_PATH);
+}
+
+/**
+ * 验证独立 open 拥有独立偏移，而 dup 与 fork 共享同一个打开文件对象偏移。
+ *
+ * 该测试同时验证失败的 lseek 不得修改原偏移，避免错误路径破坏后续读取位置。
+ */
+static void
+test_offset_ownership(void)
+{
+  int fd;
+  int independent;
+  int shared;
+  int pid;
+  int status = -1;
+
+  fd = open(PRIMARY_PATH, O_CREATE | O_TRUNC | O_RDWR);
+  if(fd < 0)
+    fail("cannot create primary file");
+  if(write(fd, "ABCDE", 5) != 5)
+    fail("initial write did not complete");
+  if(lseek(fd, 0, SEEK_SET) != 0)
+    fail("cannot rewind primary descriptor");
+
+  independent = open(PRIMARY_PATH, O_RDONLY);
+  if(independent < 0)
+    fail("cannot independently reopen primary file");
+
+  expect_byte(fd, 'A', "first open did not read A");
+  expect_byte(independent, 'A', "independent open unexpectedly shared offset");
+
+  shared = dup(fd);
+  if(shared < 0)
+    fail("dup failed");
+  expect_byte(shared, 'B', "dup did not inherit shared offset");
+  expect_byte(fd, 'C', "original descriptor did not observe dup offset advance");
+
+  if(lseek(fd, 0, SEEK_SET) != 0)
+    fail("cannot prepare fork offset test");
+  pid = fork();
+  if(pid < 0)
+    fail("fork failed");
+  if(pid == 0){
+    expect_byte(fd, 'A', "child did not read from inherited offset");
+    exit(0);
+  }
+  if(wait(&status) != pid || status != 0)
+    fail("child offset observation failed");
+  expect_byte(fd, 'B', "parent did not observe child offset advance");
+
+  if(lseek(fd, 4, SEEK_SET) != 4)
+    fail("cannot position before final byte");
+  if(lseek(fd, -5, SEEK_CUR) != -1)
+    fail("negative seek before file start was accepted");
+  if(lseek(fd, 0, SEEK_CUR) != 4)
+    fail("failed seek changed the shared offset");
+  expect_byte(fd, 'E', "failed seek corrupted the next read position");
+
+  close_checked(shared, "cannot close duplicated descriptor");
+  close_checked(independent, "cannot close independent descriptor");
+  close_checked(fd, "cannot close primary descriptor");
+}
+
+/**
+ * 验证目录项、inode 链接计数与打开引用拥有彼此独立的生命周期。
+ *
+ * 最后一个名字删除后，既有 fd 仍须访问旧 inode；在旧 fd 关闭前以同名创建的新文件
+ * 必须获得另一 inode，从而击穿“unlink 会立即销毁已打开文件”的错误直觉。
+ */
+static void
+test_link_unlink_lifetime(void)
+{
+  struct stat original;
+  struct stat linked;
+  struct stat after_failure;
+  struct stat after_unlink;
+  struct stat replacement;
+  int retained;
+  int alias_fd;
+  int replacement_fd;
+  int unexpected;
+  char old_data[5];
+
+  retained = open(PRIMARY_PATH, O_RDONLY);
+  if(retained < 0 || fstat(retained, &original) < 0)
+    fail("cannot inspect original inode");
+
+  if(link(PRIMARY_PATH, ALIAS_PATH) < 0)
+    fail("cannot create hard link");
+  alias_fd = open(ALIAS_PATH, O_RDONLY);
+  if(alias_fd < 0 || fstat(alias_fd, &linked) < 0)
+    fail("cannot inspect linked inode");
+  if(original.dev != linked.dev || original.ino != linked.ino ||
+     linked.nlink != 2)
+    fail("hard link did not reference the same inode");
+  close_checked(alias_fd, "cannot close hard-link descriptor");
+
+  if(link(PRIMARY_PATH, ALIAS_PATH) != -1)
+    fail("link unexpectedly replaced an existing directory entry");
+  if(fstat(retained, &after_failure) < 0 || after_failure.nlink != 2)
+    fail("failed link did not roll back inode link count");
+
+  if(unlink(PRIMARY_PATH) < 0)
+    fail("cannot unlink primary directory entry");
+  unexpected = open(PRIMARY_PATH, O_RDONLY);
+  if(unexpected >= 0){
+    close(unexpected);
+    fail("removed primary path remained resolvable");
+  }
+  if(fstat(retained, &after_unlink) < 0 || after_unlink.nlink != 1)
+    fail("first unlink did not decrement link count");
+
+  if(unlink(ALIAS_PATH) < 0)
+    fail("cannot unlink final directory entry");
+  unexpected = open(ALIAS_PATH, O_RDONLY);
+  if(unexpected >= 0){
+    close(unexpected);
+    fail("removed alias path remained resolvable");
+  }
+  if(fstat(retained, &after_unlink) < 0 || after_unlink.nlink != 0)
+    fail("final unlink did not expose zero link count on open inode");
+  if(lseek(retained, 0, SEEK_SET) != 0 ||
+     read(retained, old_data, sizeof(old_data)) != sizeof(old_data) ||
+     memcmp(old_data, "ABCDE", sizeof(old_data)) != 0)
+    fail("open descriptor lost data after final unlink");
+
+  replacement_fd = open(ALIAS_PATH, O_CREATE | O_TRUNC | O_RDWR);
+  if(replacement_fd < 0 || write(replacement_fd, "Z", 1) != 1 ||
+     fstat(replacement_fd, &replacement) < 0)
+    fail("cannot create replacement file");
+  if(replacement.dev == original.dev && replacement.ino == original.ino)
+    fail("replacement reused inode before final open reference closed");
+
+  if(lseek(retained, 0, SEEK_SET) != 0)
+    fail("cannot rewind unlinked open inode");
+  expect_byte(retained, 'A', "replacement changed retained inode data");
+  if(lseek(replacement_fd, 0, SEEK_SET) != 0)
+    fail("cannot rewind replacement file");
+  expect_byte(replacement_fd, 'Z', "replacement file content is incorrect");
+
+  close_checked(retained, "cannot release final old-inode reference");
+  close_checked(replacement_fd, "cannot close replacement file");
+  if(unlink(ALIAS_PATH) < 0)
+    fail("cannot remove replacement file");
+
+  if(unlink(PRIMARY_PATH) != -1 || link(PRIMARY_PATH, ALIAS_PATH) != -1)
+    fail("missing-path operations unexpectedly succeeded");
+}
+
+/**
+ * 构造文件 API 的状态闭环并通过退出状态向 xv6test 报告结果。
+ *
+ * @return 全部状态、错误和资源回收断言通过时以 exit(0) 终止；失败路径由 fail()
+ *         以 exit(1) 终止。
+ */
+int
+main(void)
+{
+  cleanup_workspace();
+  test_offset_ownership();
+  test_link_unlink_lifetime();
+  cleanup_workspace();
+
+  printf("fileapitest: verified offsets, links, unlink lifetime, and cleanup\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -50,6 +50,7 @@ static char *core_sbrkbugs_argv[] = {XV6_TEST_PATH("usertests"), "sbrkbugs", 0};
 static char *core_forkforkfork_argv[] = {XV6_TEST_PATH("usertests"), "forkforkfork", 0};
 static char *core_linkunlink_argv[] = {XV6_TEST_PATH("usertests"), "linkunlink", 0};
 static char *core_openiput_argv[] = {XV6_TEST_PATH("usertests"), "openiput", 0};
+static char *core_fileapi_argv[] = {XV6_TEST_PATH("fileapitest"), 0};
 static char *core_schedtrace_argv[] = {XV6_TEST_PATH("schedtracetest"), 0};
 static char *core_history_argv[] = {XV6_TEST_PATH("historytest"), 0};
 static char *core_job_control_argv[] = {XV6_TEST_PATH("consolelinetest"), "jobctl", 0};
@@ -108,6 +109,7 @@ static struct xv6_test_case tests[] = {
   {"core", "core-forkforkfork", core_forkforkfork_argv},
   {"core", "core-linkunlink", core_linkunlink_argv},
   {"core", "core-openiput", core_openiput_argv},
+  {"core", "core-fileapi", core_fileapi_argv},
   {"core", "core-schedtrace", core_schedtrace_argv},
   {"core", "core-shell-history", core_history_argv},
   {"core", "core-job-control", core_job_control_argv},

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -33,6 +33,7 @@ GUEST_SOURCE_NAMES = (
     "alarmtest.c",
     "lazytests.c",
     "cowtest.c",
+    "fileapitest.c",
     "bigfile.c",
     "symlinktest.c",
     "mmaptest.c",

--- a/user/init.c
+++ b/user/init.c
@@ -89,6 +89,7 @@ static struct image_file image_files[] = {
   {"/alarmtest", XV6_TEST_PATH("alarmtest")},
   {"/lazytests", XV6_TEST_PATH("lazytests")},
   {"/cowtest", XV6_TEST_PATH("cowtest")},
+  {"/fileapitest", XV6_TEST_PATH("fileapitest")},
   {"/bigfile", XV6_TEST_PATH("bigfile")},
   {"/largefile", XV6_TEST_PATH("largefile")},
   {"/symlinktest", XV6_TEST_PATH("symlinktest")},


### PR DESCRIPTION
## 关联

- Closes #153（代码与实验部分；笔记 PR 完成后关闭 Issue）
- 共享约束：#134
- 基线 Commit：`4fe136143f78eaf10457604d1695486038b5f93e`
- 分支：`concept/153-file-api`

## 中心行为

通过一个 guest-first 黑盒回归，把文件 API 中彼此容易混淆的三类状态分开验证：

1. 路径/目录项到 inode 的命名关系；
2. fd 到共享 `struct file` 的打开关系与偏移；
3. inode 的 `nlink` 与内存引用的独立生命周期。

当前仓库已真实支持 `open/read/write/lseek/link/unlink`，但没有 `fsync` 和 `rename` 系统调用。本 PR 不以 no-op `fsync` 或 `link+unlink` 冒充缺失语义，只为已支持能力建立可重复 oracle；缺失边界将在 Obsidian 更新中明确记录。

## 变更

- 新增 `tests/guest/fileapitest.c`：
  - 两次独立 `open` 各自维护偏移；
  - `dup` 与 `fork` 共享打开文件对象及偏移；
  - 失败的负向 `lseek` 不改变原偏移；
  - 硬链接共享 inode，重复目标失败后 `nlink` 回滚；
  - 最后一个目录项删除后，既有 fd 仍可访问旧 inode；
  - 旧 fd 关闭前创建同名新文件，必须获得不同 inode；
  - 缺失路径错误与清理路径可重复执行。
- 将 `_fileapitest` 加入 `Makefile::UPROGS`。
- 通过 `user/init.c` 将构建期根目录入口迁移到 `/usr/lib/xv6/tests/fileapitest`。
- 在 `xv6test` 注册 `core-fileapi`，因此现有 `usertests-core` 与 PR suite 自动覆盖。
- 将新源码加入 runner 的目录边界自测。

## Golden Trace

```text
create fa_primary → write ABCDE → open twice
→ 独立 offset 各读 A
→ dup/fork 共享 offset
→ link fa_alias（同 inode，nlink=2）
→ 重复 link 失败并回滚 nlink
→ unlink fa_primary（nlink=1）
→ unlink fa_alias（nlink=0，但 retained fd 仍持有 inode）
→ 同名创建新文件（新 inode）
→ 旧 fd 仍读 ABCDE，新 fd 读 Z
→ 关闭旧 fd 触发旧 inode 最终回收
→ 删除新文件并验证重复运行清理
```

## 测试入口

```bash
make clean
make
make test-unit
make qemu CPUS=3
# xv6 shell
xv6test --run core-fileapi
xv6test --run core-fileapi

# PR 集成范围（包含 core-fileapi）
make test CPUS=3
```

该测试不依赖时序竞争；`CPUS=1` 仅作为补充环境观察，不用单核结果替代默认三核验证。

## 验证结果

GitHub Actions `Scheduler family CI` run `30164493374` 在 PR merge ref 上真实执行并通过：

- runner unit tests：通过；
- 默认 RR 构建：通过；
- Shell 交互回归：通过；
- PR 回归 suites（默认 `CPUS=3`，包含 `core-fileapi`）：通过；
- 完整 `usertests`：通过；
- reparent cleanup（`CPUS=1`）：通过；
- RR/FIFO/SJF/STCF/MLFQ/CFS 调度策略及 SMP smoke：全部通过。

首轮 CI 曾准确暴露 `_fileapitest` 只进入 mkfs 根目录、未被 `init` 迁移到稳定测试路径的问题；补齐 `user/init.c::image_files` 注册后，第二轮全绿。未把失败结果覆盖或伪装为通过。

本会话未在本地伪造 RISC-V/QEMU 输出；以上运行证据均来自仓库 CI。

## 教学边界

- 不实现完整 POSIX errno、`fsync`、`fdatasync` 或 `rename`。
- xv6 的日志事务完成不等于生产系统中针对设备缓存与断电模型的完整持久化契约。
- 测试验证功能语义与资源生命周期，不宣称完成崩溃一致性或硬件掉电测试。
