### PR TITLE
test: 实体化 sleep/wakeup 条件等待闭环

### DIFF
--- a/tests/guest/schedtracetest.c
+++ b/tests/guest/schedtracetest.c
@@ -734,7 +734,7 @@ verify_condition_wait_protocol(void)
 /**
  * main 执行 schedtrace、schedviz 或聚焦条件等待的 guest-first 回归。
  *
- * @param argc 参数数量；无参数运行原 schedtrace 回归，`condvar` 只运行条件等待闭环。
+ * @param argc 参数数量；无参数运行完整核心回归，`condvar` 只运行条件等待闭环。
  * @param argv 参数数组。
  * @return 成功 exit(0)，任一断言失败 exit(1)。
  */
@@ -756,6 +756,7 @@ main(int argc, char **argv)
   verify_repeat_reset();
   verify_invalid_inputs();
   verify_schedviz_args();
+  verify_condition_wait_protocol();
   printf("schedtracetest: OK\n");
   exit(0);
 }

--- a/tests/guest/schedtracetest.c
+++ b/tests/guest/schedtracetest.c
@@ -6,7 +6,11 @@
 #include "user/user.h"
 #include "user/paths.h"
 
+#define CONDVAR_CHILDREN 2
+#define CONDVAR_OBSERVE_RETRIES 200
+
 static struct schedtrace_snapshot snapshot;
+static int condvar_live_children[CONDVAR_CHILDREN];
 
 /**
  * fail 打印失败原因并以非零状态退出。
@@ -290,16 +294,460 @@ verify_schedviz_args(void)
     fail("schedviz invalid args returned zero");
 }
 
+/** 子进程通过结果管道返回的一次读取结果。 */
+struct condvar_reader_result {
+  int pid;
+  int bytes;
+  char value;
+};
+
 /**
- * main 执行 schedtrace 和 schedviz 的 guest-first 回归。
+ * condvar_terminate_children 终止并回收条件等待场景中仍可能存活的子进程。
  *
+ * 该函数只用于失败清理；kill() 会让阻塞在 pipe read 的子进程离开睡眠，随后由
+ * wait() 回收，避免失败用例污染后续回归。
+ */
+static void
+condvar_terminate_children(void)
+{
+  for(int i = 0; i < CONDVAR_CHILDREN; i++)
+    if(condvar_live_children[i] > 0)
+      kill(condvar_live_children[i]);
+  for(int i = 0; i < CONDVAR_CHILDREN; i++)
+    if(condvar_live_children[i] > 0)
+      wait(0);
+}
+
+/**
+ * condvar_fail 清理条件等待场景并交给统一失败出口报告。
+ *
+ * @param message 描述未满足的谓词、睡眠、唤醒或重检契约。
+ */
+static void
+condvar_fail(char *message)
+{
+  condvar_terminate_children();
+  fail(message);
+}
+
+/**
+ * condvar_read_exact 从管道读取固定字节数。
+ *
+ * @param fd 可读文件描述符。
+ * @param buffer 接收数据的缓冲区。
+ * @param size 必须读取的字节数。
+ * @return 读满返回 0；遇到 EOF 或错误返回 -1。
+ */
+static int
+condvar_read_exact(int fd, void *buffer, int size)
+{
+  char *cursor = buffer;
+  int total = 0;
+
+  while(total < size){
+    int n = read(fd, cursor + total, size - total);
+    if(n <= 0)
+      return -1;
+    total += n;
+  }
+  return 0;
+}
+
+/**
+ * condvar_write_exact 向管道写入固定字节数。
+ *
+ * @param fd 可写文件描述符。
+ * @param buffer 只读输入缓冲区，所有权仍归调用者。
+ * @param size 必须写入的字节数。
+ * @return 写满返回 0；管道关闭或写入失败返回 -1。
+ */
+static int
+condvar_write_exact(int fd, const void *buffer, int size)
+{
+  const char *cursor = buffer;
+  int total = 0;
+
+  while(total < size){
+    int n = write(fd, cursor + total, size - total);
+    if(n <= 0)
+      return -1;
+    total += n;
+  }
+  return 0;
+}
+
+/**
+ * condvar_trace_start 为指定子进程建立新的调度轨迹会话。
+ *
+ * @param pids 需要观察的子进程 PID 数组。
+ * @param count PID 数量，不能超过 schedtrace 过滤器容量。
+ */
+static void
+condvar_trace_start(int pids[], int count)
+{
+  if(schedtrace(SCHEDTRACE_OP_RESET, 0, 0) < 0)
+    condvar_fail("condvar trace reset");
+  for(int i = 0; i < count; i++)
+    if(schedtrace(SCHEDTRACE_OP_WATCH_PID, 0, pids[i]) < 0)
+      condvar_fail("condvar trace watch pid");
+  if(schedtrace(SCHEDTRACE_OP_START, 0, 0) < 0)
+    condvar_fail("condvar trace start");
+}
+
+/** 停止条件等待场景的调度轨迹会话。 */
+static void
+condvar_trace_stop(void)
+{
+  if(schedtrace(SCHEDTRACE_OP_STOP, 0, 0) < 0)
+    condvar_fail("condvar trace stop");
+}
+
+/** 读取完整调度轨迹，并拒绝任何可能破坏判定的事件丢失。 */
+static void
+condvar_trace_read(void)
+{
+  read_snapshot(SCHEDTRACE_MAX_EVENTS);
+  if(snapshot.dropped != 0)
+    condvar_fail("condvar trace events dropped");
+}
+
+/**
+ * condvar_count_events 统计某进程满足类型与停止原因的调度事件。
+ *
+ * @param pid 目标子进程 PID。
+ * @param event_type SCHEDTRACE_EVENT_*；传 0 表示不限制事件类型。
+ * @param stop_reason SCHEDTRACE_REASON_*；传负数表示不限制停止原因。
+ * @param after_seq 只统计序号严格大于该值的事件。
+ * @return 匹配事件数量。
+ */
+static int
+condvar_count_events(int pid, int event_type, int stop_reason,
+                     unsigned long after_seq)
+{
+  int count = 0;
+
+  for(int i = 0; i < snapshot.events; i++){
+    struct schedtrace_event *event = &snapshot.events_buffer[i];
+    if(event->pid != pid || event->seq <= after_seq)
+      continue;
+    if(event_type != 0 && event->event_type != event_type)
+      continue;
+    if(stop_reason >= 0 && event->stop_reason != stop_reason)
+      continue;
+    count++;
+  }
+  return count;
+}
+
+/** @return 当前快照中的最大事件序号；空快照返回 0。 */
+static unsigned long
+condvar_last_sequence(void)
+{
+  unsigned long result = 0;
+
+  for(int i = 0; i < snapshot.events; i++)
+    if(snapshot.events_buffer[i].seq > result)
+      result = snapshot.events_buffer[i].seq;
+  return result;
+}
+
+/**
+ * condvar_spawn_reader 创建一个由 gate 控制、随后读取共享 data pipe 的子进程。
+ *
+ * @param data_read 子进程读取谓词状态的管道读端。
+ * @param data_write data pipe 写端，子进程会关闭。
+ * @param ready_read ready pipe 读端，子进程会关闭。
+ * @param ready_write 子进程发布“即将等待 gate”的通知端。
+ * @param gate_read 父进程释放阶段屏障的管道读端。
+ * @param gate_write gate pipe 写端，子进程会关闭。
+ * @param result_read result pipe 读端，子进程会关闭。
+ * @param result_write 子进程返回读取结果的管道写端。
+ * @return 子进程 PID；fork 失败时返回 -1。
+ */
+static int
+condvar_spawn_reader(int data_read, int data_write,
+                     int ready_read, int ready_write,
+                     int gate_read, int gate_write,
+                     int result_read, int result_write)
+{
+  int pid = fork();
+
+  if(pid != 0)
+    return pid;
+
+  close(data_write);
+  close(ready_read);
+  close(gate_write);
+  close(result_read);
+
+  char token = 'r';
+  if(condvar_write_exact(ready_write, &token, 1) < 0)
+    exit(1);
+  close(ready_write);
+  if(condvar_read_exact(gate_read, &token, 1) < 0)
+    exit(1);
+  close(gate_read);
+
+  struct condvar_reader_result result;
+  result.pid = getpid();
+  result.bytes = read(data_read, &result.value, 1);
+  close(data_read);
+  if(condvar_write_exact(result_write, &result, sizeof(result)) < 0)
+    exit(1);
+  close(result_write);
+  exit(result.bytes == 1 ? 0 : 1);
+}
+
+/**
+ * condvar_wait_for_initial_sleeps 等待两个 reader 都因空 data pipe 再次睡眠。
+ *
+ * gate 唤醒先产生 RUN_START；随后 piperead() 检查空谓词并调用 sleep()，调度器
+ * 记录 RUN_STOP/SLEEP。轮询依据可观察状态事件，而不是依赖人工抢时机。
+ */
+static void
+condvar_wait_for_initial_sleeps(int pids[])
+{
+  for(int attempt = 0; attempt < CONDVAR_OBSERVE_RETRIES; attempt++){
+    condvar_trace_read();
+    if(condvar_count_events(pids[0], SCHEDTRACE_EVENT_RUN_STOP,
+                            SCHEDTRACE_REASON_SLEEP, 0) > 0 &&
+       condvar_count_events(pids[1], SCHEDTRACE_EVENT_RUN_STOP,
+                            SCHEDTRACE_REASON_SLEEP, 0) > 0)
+      return;
+    sleep(1);
+  }
+  condvar_fail("readers did not reach pipe sleep");
+}
+
+/**
+ * condvar_wait_for_ineffective_wakeup 等待一次写入形成“两者运行、一退一睡”。
+ *
+ * @param pids 两个 reader PID。
+ * @return 被无效唤醒后重新睡眠的 reader 下标；超时直接失败。
+ */
+static int
+condvar_wait_for_ineffective_wakeup(int pids[])
+{
+  for(int attempt = 0; attempt < CONDVAR_OBSERVE_RETRIES; attempt++){
+    condvar_trace_read();
+    if(condvar_count_events(pids[0], SCHEDTRACE_EVENT_RUN_START, -1, 0) > 0 &&
+       condvar_count_events(pids[1], SCHEDTRACE_EVENT_RUN_START, -1, 0) > 0){
+      int slept0 = condvar_count_events(pids[0], SCHEDTRACE_EVENT_RUN_STOP,
+                                        SCHEDTRACE_REASON_SLEEP, 0) > 0;
+      int slept1 = condvar_count_events(pids[1], SCHEDTRACE_EVENT_RUN_STOP,
+                                        SCHEDTRACE_REASON_SLEEP, 0) > 0;
+      int exited0 = condvar_count_events(pids[0], SCHEDTRACE_EVENT_RUN_STOP,
+                                         SCHEDTRACE_REASON_EXIT, 0) > 0;
+      int exited1 = condvar_count_events(pids[1], SCHEDTRACE_EVENT_RUN_STOP,
+                                         SCHEDTRACE_REASON_EXIT, 0) > 0;
+      if(slept0 && exited1 && !exited0 && !slept1)
+        return 0;
+      if(slept1 && exited0 && !exited1 && !slept0)
+        return 1;
+    }
+    sleep(1);
+  }
+  condvar_fail("wakeup did not produce one exit and one re-sleep");
+  return -1;
+}
+
+/**
+ * verify_preexisting_pipe_data 验证谓词已成立时 reader 不依赖历史 wakeup。
+ *
+ * 父进程先写入字节，再释放 reader。调度轨迹应只包含 gate 唤醒后的运行与退出，
+ * 不应出现 data pipe 上的 RUN_STOP/SLEEP。
+ */
+static void
+verify_preexisting_pipe_data(void)
+{
+  int data[2];
+  int ready[2];
+  int gate[2];
+  int result_pipe[2];
+  int status = 0;
+  int pid;
+  char token;
+  struct condvar_reader_result result;
+
+  memset(condvar_live_children, 0, sizeof(condvar_live_children));
+  if(pipe(data) < 0 || pipe(ready) < 0 || pipe(gate) < 0 || pipe(result_pipe) < 0)
+    condvar_fail("preexisting pipe setup");
+
+  pid = condvar_spawn_reader(data[0], data[1], ready[0], ready[1],
+                             gate[0], gate[1], result_pipe[0], result_pipe[1]);
+  if(pid < 0)
+    condvar_fail("preexisting fork");
+  condvar_live_children[0] = pid;
+
+  close(data[0]);
+  close(ready[1]);
+  close(gate[0]);
+  close(result_pipe[1]);
+  if(condvar_read_exact(ready[0], &token, 1) < 0)
+    condvar_fail("preexisting ready");
+  close(ready[0]);
+
+  token = 'P';
+  if(condvar_write_exact(data[1], &token, 1) < 0)
+    condvar_fail("preexisting data write");
+  condvar_trace_start(&pid, 1);
+  token = 'g';
+  if(condvar_write_exact(gate[1], &token, 1) < 0)
+    condvar_fail("preexisting gate release");
+  close(gate[1]);
+  close(data[1]);
+
+  if(wait(&status) != pid || status != 0)
+    condvar_fail("preexisting child status");
+  condvar_live_children[0] = 0;
+  condvar_trace_stop();
+  condvar_trace_read();
+  if(condvar_read_exact(result_pipe[0], &result, sizeof(result)) < 0)
+    condvar_fail("preexisting result");
+  close(result_pipe[0]);
+  if(result.pid != pid || result.bytes != 1 || result.value != 'P')
+    condvar_fail("preexisting predicate result");
+  if(condvar_count_events(pid, SCHEDTRACE_EVENT_RUN_STOP,
+                          SCHEDTRACE_REASON_SLEEP, 0) != 0)
+    condvar_fail("preexisting data unexpectedly slept");
+  if(condvar_count_events(pid, SCHEDTRACE_EVENT_RUN_STOP,
+                          SCHEDTRACE_REASON_EXIT, 0) == 0)
+    condvar_fail("preexisting exit event missing");
+}
+
+/**
+ * verify_pipe_wakeup_rechecks_predicate 验证 pipe 的完整条件等待协议。
+ *
+ * 两个 reader 先稳定睡在同一 data channel。第一次只写一个字节时，wakeup() 会让
+ * 两者都重新运行；一个 reader 消费字节并退出，另一个重新持有 pipe lock 后发现
+ * 谓词仍为假，再次进入 RUN_STOP/SLEEP。第二次写入才让剩余 reader 完成。
+ */
+static void
+verify_pipe_wakeup_rechecks_predicate(void)
+{
+  int data[2];
+  int ready[2];
+  int gate[2];
+  int result_pipe[2];
+  int pids[CONDVAR_CHILDREN];
+  int status;
+  char ready_tokens[CONDVAR_CHILDREN];
+  char gate_tokens[CONDVAR_CHILDREN] = {'g', 'g'};
+  struct condvar_reader_result results[CONDVAR_CHILDREN];
+
+  memset(condvar_live_children, 0, sizeof(condvar_live_children));
+  if(pipe(data) < 0 || pipe(ready) < 0 || pipe(gate) < 0 || pipe(result_pipe) < 0)
+    condvar_fail("recheck pipe setup");
+
+  for(int i = 0; i < CONDVAR_CHILDREN; i++){
+    pids[i] = condvar_spawn_reader(data[0], data[1], ready[0], ready[1],
+                                   gate[0], gate[1], result_pipe[0], result_pipe[1]);
+    if(pids[i] < 0)
+      condvar_fail("recheck fork");
+    condvar_live_children[i] = pids[i];
+  }
+
+  close(data[0]);
+  close(ready[1]);
+  close(gate[0]);
+  close(result_pipe[1]);
+  if(condvar_read_exact(ready[0], ready_tokens, sizeof(ready_tokens)) < 0)
+    condvar_fail("recheck readers ready");
+  close(ready[0]);
+
+  condvar_trace_start(pids, CONDVAR_CHILDREN);
+  if(condvar_write_exact(gate[1], gate_tokens, sizeof(gate_tokens)) < 0)
+    condvar_fail("recheck gate release");
+  close(gate[1]);
+  condvar_wait_for_initial_sleeps(pids);
+  condvar_trace_stop();
+
+  // 清空 gate 阶段轨迹，只观察 data pipe 的一次状态改变和重检结果。
+  condvar_trace_start(pids, CONDVAR_CHILDREN);
+  char first = 'A';
+  if(condvar_write_exact(data[1], &first, 1) < 0)
+    condvar_fail("recheck first write");
+  int loser = condvar_wait_for_ineffective_wakeup(pids);
+  unsigned long first_phase_end = condvar_last_sequence();
+
+  char second = 'B';
+  if(condvar_write_exact(data[1], &second, 1) < 0)
+    condvar_fail("recheck second write");
+  close(data[1]);
+
+  for(int i = 0; i < CONDVAR_CHILDREN; i++){
+    int waited = wait(&status);
+    if(waited < 0 || status != 0)
+      condvar_fail("recheck child status");
+    if(waited == pids[0])
+      condvar_live_children[0] = 0;
+    else if(waited == pids[1])
+      condvar_live_children[1] = 0;
+    else
+      condvar_fail("recheck unexpected child");
+  }
+  condvar_trace_stop();
+  condvar_trace_read();
+
+  if(condvar_count_events(pids[loser], SCHEDTRACE_EVENT_RUN_START,
+                          -1, first_phase_end) == 0)
+    condvar_fail("re-slept reader was not started by second write");
+  if(condvar_count_events(pids[loser], SCHEDTRACE_EVENT_RUN_STOP,
+                          SCHEDTRACE_REASON_EXIT, first_phase_end) == 0)
+    condvar_fail("re-slept reader did not exit after second write");
+
+  if(condvar_read_exact(result_pipe[0], results, sizeof(results)) < 0)
+    condvar_fail("recheck result read");
+  close(result_pipe[0]);
+
+  int saw_a = 0;
+  int saw_b = 0;
+  int saw_pid[CONDVAR_CHILDREN] = {0, 0};
+  for(int i = 0; i < CONDVAR_CHILDREN; i++){
+    if(results[i].bytes != 1)
+      condvar_fail("reader continued after ineffective wakeup");
+    if(results[i].value == 'A')
+      saw_a++;
+    else if(results[i].value == 'B')
+      saw_b++;
+    else
+      condvar_fail("reader returned unexpected byte");
+    if(results[i].pid == pids[0])
+      saw_pid[0]++;
+    else if(results[i].pid == pids[1])
+      saw_pid[1]++;
+    else
+      condvar_fail("result pid not owned by scenario");
+  }
+  if(saw_a != 1 || saw_b != 1 || saw_pid[0] != 1 || saw_pid[1] != 1)
+    condvar_fail("reader results were not one-to-one");
+}
+
+/** 执行条件变量概念对应的 xv6 pipe/sleep/wakeup 验证闭环。 */
+static void
+verify_condition_wait_protocol(void)
+{
+  verify_preexisting_pipe_data();
+  verify_pipe_wakeup_rechecks_predicate();
+}
+
+/**
+ * main 执行 schedtrace、schedviz 或聚焦条件等待的 guest-first 回归。
+ *
+ * @param argc 参数数量；无参数运行原 schedtrace 回归，`condvar` 只运行条件等待闭环。
+ * @param argv 参数数组。
  * @return 成功 exit(0)，任一断言失败 exit(1)。
  */
 int
 main(int argc, char **argv)
 {
-  (void)argc;
-  (void)argv;
+  if(argc == 2 && strcmp(argv[1], "condvar") == 0){
+    verify_condition_wait_protocol();
+    printf("condvartest: OK\n");
+    exit(0);
+  }
+  if(argc != 1)
+    fail("usage: schedtracetest [condvar]");
 
   verify_default_off();
   verify_basic_events();


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #150
- 约束来源：#134
- 启动基线：`4fe136143f78eaf10457604d1695486038b5f93e`
- 分支：`concept/150-condition-variable`
- 变更类型：guest-first 并发实验
- 一句话摘要：复用现有 pipe、`sleep()/wakeup()` 与 `schedtrace`，用确定性双 reader 场景验证谓词检查、睡眠、状态改变、唤醒和 `while` 重检闭环。

## 实现了什么

- 未新增条件变量 API 或并行观测框架；现有机制已经足以表达概念闭环。
- 扩展 `schedtracetest`，增加聚焦入口 `schedtracetest condvar`。
- 场景一先写入 pipe 再释放 reader，验证条件已成立时不依赖历史通知，也不会进入 data pipe 睡眠。
- 场景二让两个 reader 稳定睡在同一空 pipe：第一次只写一个字节，断言两个 reader 都重新运行，其中一个退出、另一个重新睡眠；第二次写入才让剩余 reader 完成。
- 使用 `RUN_START` 与 `RUN_STOP/SLEEP|EXIT` 作为状态 oracle，不依赖人工抢时机或解析自然语言日志。
- 无参数的既有 `core-schedtrace` 回归也会执行该闭环，因此现有 PR suite 自动覆盖。

## 测试覆盖

- 正常路径：两个 reader 分别读取 `A`、`B`，各返回一次且退出状态为 0。
- 边界/反例：数据先于等待者存在时直接消费，不把 wakeup 当作可累计事件。
- 竞争路径：一次 `wakeup()` 后两者都运行，但只有一个 reader 得到字节；另一个必须重新检查谓词并再次睡眠。
- 丢失唤醒负向 oracle：状态事件轮询有固定上限，任一 reader 未进入预期状态或无法完成即失败。
- 资源回收：关闭全部 pipe 端点，失败路径 kill/wait 回收仍存活子进程。

## 可复制验收命令

```bash
make clean
make
make qemu
```

进入 xv6：

```text
/usr/lib/xv6/tests/schedtracetest condvar
xv6test --run core-schedtrace
```

预期关键输出：

```text
condvartest: OK
schedtracetest: OK
XV6TEST done status=0
```

## 自动化结果

- 待 GitHub Actions：`make clean && make -j2`
- 待 GitHub Actions：selected PR suites，`CPUS=3`
- 本 PR 不修改 CI workflow。

## 教学边界

- xv6 的 `sleep(chan, lock)` / `wakeup(chan)` 是内核等待通道原语，不是 POSIX `pthread_cond_t` API。
- `wakeup(chan)` 扫描进程表并唤醒同 channel 的全部睡眠进程；被唤醒只代表重新获得运行资格，不代表谓词已经为真或资源已被预留。
- 防止 lost wakeup 的关键是 `sleep()` 在释放调用者锁前取得 `p->lock`，而 `wakeup()` 也以 `p->lock` 检查和修改睡眠状态；运行测试提供路径证据，锁序正确性仍以实现审计为准。

## Review 主线

1. `kernel/pipe.c`：谓词、pipe lock、channel 与 `while` 重检调用链。
2. `kernel/proc.c`：`sleep()` 的锁交接和 `wakeup()` 的 channel 扫描。
3. `tests/guest/schedtracetest.c`：确定性 gate、状态 oracle、第一次无效唤醒与第二次完成。
