### PR TITLE
test: 增加 xv6 日志崩溃恢复闭环

### DIFF
--- a/kernel/log.c
+++ b/kernel/log.c
@@ -7,6 +7,7 @@
 #include "fs.h"
 #include "fsinspect.h"
 #include "buf.h"
+#include "log.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
@@ -28,6 +29,7 @@ struct log {
   int header_blocks;
   int outstanding;
   int committing;
+  int crash_phase;   // 一次性教学故障注入点，由 lock 保护。
   int dev;
   struct logheader lh;
 };
@@ -97,6 +99,52 @@ log_data_start(void)
   return log.start + log.header_blocks;
 }
 
+/** 返回故障注入阶段的稳定诊断名称。 */
+static char*
+log_crash_phase_name(int phase)
+{
+  switch(phase){
+  case LOG_CRASH_BEFORE_COMMIT:
+    return "before-commit";
+  case LOG_CRASH_AFTER_COMMIT:
+    return "after-commit";
+  case LOG_CRASH_DURING_INSTALL:
+    return "during-install";
+  default:
+    return "unknown";
+  }
+}
+
+/** 原子消费匹配的一次性故障注入点，并快照当前事务大小。 */
+static int
+log_take_crash_phase(int phase, int *entries)
+{
+  int matched = 0;
+
+  acquire(&log.lock);
+  if(log.crash_phase == phase){
+    log.crash_phase = LOG_CRASH_NONE;
+    *entries = log.lh.n;
+    matched = 1;
+  }
+  release(&log.lock);
+  return matched;
+}
+
+/** 在精确日志阶段触发可观察的教学型内核崩溃。 */
+static void
+log_crash_if_armed(int phase, int installed)
+{
+  int entries;
+
+  if(!log_take_crash_phase(phase, &entries))
+    return;
+
+  printf("LOGCRASH injected phase=%s entries=%d installed=%d\n",
+         log_crash_phase_name(phase), entries, installed);
+  panic("log crash injection");
+}
+
 /** 初始化日志几何信息并恢复已发布但未安装的事务。 */
 void
 initlog(int dev, struct superblock *sb)
@@ -107,6 +155,7 @@ initlog(int dev, struct superblock *sb)
   log.start = sb->logstart;
   log.header_blocks = log_header_block_count();
   log.size = sb->nlog - log.header_blocks;
+  log.crash_phase = LOG_CRASH_NONE;
   log.dev = dev;
 
   if(log.size < MAXOPBLOCKS || log.size > LOGSIZE)
@@ -124,6 +173,12 @@ install_trans(int recovering)
     struct buf *dbuf = bread(log.dev, log.lh.block[tail]);
     memmove(dbuf->data, lbuf->data, BSIZE);
     bwrite(dbuf);
+
+    // bwrite() 已等待 virtio 完成。此时终止可构造“部分 home block 已安装，
+    // commit record 仍存在”的磁盘状态，重启后必须完整重放同一事务。
+    if(!recovering && tail == 0)
+      log_crash_if_armed(LOG_CRASH_DURING_INSTALL, 1);
+
     if(!recovering)
       bunpin(dbuf);
     brelse(lbuf);
@@ -213,6 +268,8 @@ recover_from_log(void)
 {
   read_head();
   int recovered = log.lh.n;
+  if(recovered > 0)
+    printf("LOGRECOVER replay entries=%d\n", recovered);
   install_trans(1);
   log.lh.n = 0;
   write_head();
@@ -284,7 +341,9 @@ commit(void)
   if(log.lh.n > 0){
     int committed = log.lh.n;
     write_log();
+    log_crash_if_armed(LOG_CRASH_BEFORE_COMMIT, 0);
     write_head();
+    log_crash_if_armed(LOG_CRASH_AFTER_COMMIT, 0);
     install_trans(0);
     log.lh.n = 0;
     write_head();
@@ -319,4 +378,42 @@ log_write(struct buf *b)
     log.lh.n++;
   }
   release(&log.lock);
+}
+
+/**
+ * 武装或取消一次性日志崩溃注入点。
+ *
+ * @param phase kernel/log.h 中的 LOG_CRASH_*；LOG_CRASH_NONE 用于取消。
+ * @return 成功返回 0；阶段非法、已有注入点或文件系统操作正在进行时返回 -1。
+ */
+int
+log_arm_crash(int phase)
+{
+  int result = 0;
+
+  if(phase < LOG_CRASH_NONE || phase > LOG_CRASH_DURING_INSTALL)
+    return -1;
+
+  acquire(&log.lock);
+  if(phase == LOG_CRASH_NONE){
+    log.crash_phase = LOG_CRASH_NONE;
+  } else if(log.crash_phase != LOG_CRASH_NONE ||
+            log.outstanding != 0 || log.committing){
+    result = -1;
+  } else {
+    log.crash_phase = phase;
+  }
+  release(&log.lock);
+  return result;
+}
+
+/** 用户态教学实验入口：设置下一次文件系统提交的确定性崩溃阶段。 */
+uint64
+sys_logcrash(void)
+{
+  int phase;
+
+  if(argint(0, &phase) < 0)
+    return -1;
+  return log_arm_crash(phase);
 }

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -1,0 +1,10 @@
+#ifndef XV6_KERNEL_LOG_H
+#define XV6_KERNEL_LOG_H
+
+// 教学实验使用的一次性日志崩溃注入点。编号同时作为用户态 logcrash() 参数。
+#define LOG_CRASH_NONE            0
+#define LOG_CRASH_BEFORE_COMMIT   1
+#define LOG_CRASH_AFTER_COMMIT    2
+#define LOG_CRASH_DURING_INSTALL  3
+
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -88,7 +88,7 @@ argaddr(int n, uint64 *ip)
 
 // Fetch the nth word-sized system call argument as a null-terminated string.
 // Copies into buf, at most max.
-// Returns string length if OK (including nul), -1 if error.
+// Returns string length if OK (including nul), -1 for error.
 int
 argstr(int n, char *buf, int max)
 {
@@ -110,6 +110,7 @@ extern uint64 sys_fsinspect(void);
 extern uint64 sys_getpid(void);
 extern uint64 sys_kill(void);
 extern uint64 sys_link(void);
+extern uint64 sys_logcrash(void);
 extern uint64 sys_lseek(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_mknod(void);
@@ -210,6 +211,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_sempost]          sys_sempost,
 [SYS_semdestroy]       sys_semdestroy,
 [SYS_seminfo]          sys_seminfo,
+[SYS_logcrash]         sys_logcrash,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -54,3 +54,4 @@
 #define SYS_seminfo          55
 #define SYS_fsinspect        49
 #define SYS_memsnapshot_pid  50
+#define SYS_logcrash         56

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -60,6 +60,7 @@ static const char *const syscall_names[] = {
 [SYS_sempost]          = "sempost",
 [SYS_semdestroy]       = "semdestroy",
 [SYS_seminfo]          = "seminfo",
+[SYS_logcrash]         = "logcrash",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -1,7 +1,22 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "kernel/fcntl.h"
+#include "kernel/log.h"
 #include "user/user.h"
 #include "user/paths.h"
+
+#define LOGCRASH_BYTES (2 * BSIZE)
+#define LOGCRASH_OLD   'O'
+#define LOGCRASH_NEW   'N'
+
+/**
+ * 为下一次文件系统提交武装确定性崩溃点。
+ *
+ * @param phase kernel/log.h 中的 LOG_CRASH_*；LOG_CRASH_NONE 取消武装。
+ * @return 成功返回 0；阶段非法、已有注入点或事务进行中返回 -1。
+ */
+int logcrash(int phase);
 
 /**
  * 描述一个由 xv6 用户态执行的回归测试。
@@ -10,12 +25,16 @@
  * 是传给 exec() 的空指针结尾参数数组。argv[0] 必须是镜像内绝对路径，避免
  * 测试结果依赖 Shell 当前目录或不存在的 PATH。测试语义由 tests/guest 下的目标
  * 程序拥有，本入口只负责注册、进程隔离、退出状态传播和统一结果协议。
+ * orchestrated 测试会改变启动边界或依赖前一次磁盘状态，只允许通过 --run 精确选择。
  */
 struct xv6_test_case {
   char *group;
   char *name;
   char **argv;
+  int orchestrated;
 };
+
+static char logcrash_buffer[LOGCRASH_BYTES];
 
 static char *lab1_sleep_argv[] = {XV6_TEST_PATH("lab1test"), "sleep", 0};
 static char *lab1_pingpong_argv[] = {XV6_TEST_PATH("lab1test"), "pingpong", 0};
@@ -64,6 +83,28 @@ static char *legacy_stressfs_argv[] = {XV6_TEST_PATH("stressfs"), 0};
 static char *legacy_grind_argv[] = {XV6_TEST_PATH("grind"), 0};
 static char *full_usertests_argv[] = {XV6_TEST_PATH("usertests"), 0};
 
+static char *logcrash_api_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-api", 0
+};
+static char *logcrash_before_prepare_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-prepare", "before-commit", 0
+};
+static char *logcrash_before_verify_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-verify", "before-commit", 0
+};
+static char *logcrash_after_prepare_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-prepare", "after-commit", 0
+};
+static char *logcrash_after_verify_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-verify", "after-commit", 0
+};
+static char *logcrash_install_prepare_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-prepare", "during-install", 0
+};
+static char *logcrash_install_verify_argv[] = {
+  XV6_USR_BIN_PATH("xv6test"), "--logcrash-verify", "during-install", 0
+};
+
 // usertests 对未知名称会执行零项后成功退出，因此动态入口必须先做白名单校验。
 static char *usertest_names[] = {
   "execout", "copyin", "copyout", "copyinstr1", "copyinstr2", "copyinstr3",
@@ -79,54 +120,243 @@ static char *usertest_names[] = {
 };
 
 static struct xv6_test_case tests[] = {
-  {"lab1", "lab1-sleep", lab1_sleep_argv},
-  {"lab1", "lab1-pingpong", lab1_pingpong_argv},
-  {"lab1", "lab1-primes", lab1_primes_argv},
-  {"lab1", "lab1-find", lab1_find_argv},
-  {"lab1", "lab1-xargs", lab1_xargs_argv},
-  {"lab2", "lab2-tracemask", lab2_tracemask_argv},
-  {"lab2", "lab2-sysinfo", lab2_sysinfo_argv},
-  {"lab2", "lab2-trace-smoke", lab2_trace_smoke_argv},
-  {"lab3", "lab3-copyin", lab3_copyin_argv},
-  {"lab3", "lab3-copyout", lab3_copyout_argv},
-  {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv},
-  {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv},
-  {"lab3", "lab3-memviz", lab3_memviz_argv},
-  {"lab3", "lab3-memtarget", lab3_memtarget_argv},
-  {"lab3", "lab3-pgtbl", lab3_pgtbl_argv},
-  {"lab3", "lab3-vaaccess", lab3_vaaccess_argv},
-  {"lab3", "lab3-address-window", lab3_address_window_argv},
-  {"lab3", "lab3-ostep-intro", lab3_ostep_intro_argv},
-  {"lab4", "lab4-backtrace", lab4_backtrace_argv},
-  {"lab4", "lab4-alarm", lab4_alarm_argv},
-  {"lab5", "lab5-lazytests", lab5_lazytests_argv},
-  {"lab6", "lab6-cowtest", lab6_cowtest_argv},
-  {"lab7", "lab7-uthread", lab7_uthread_argv},
-  {"lab8", "lab8-kalloc-sbrkmuch", lab8_kalloc_argv},
-  {"lab8", "lab8-createdelete", lab8_createdelete_argv},
-  {"lab8", "lab8-fourfiles", lab8_fourfiles_argv},
-  {"lab8", "lab8-bigwrite", lab8_bigwrite_argv},
-  {"lab9", "lab9-bigfile", lab9_bigfile_argv},
-  {"lab9", "lab9-symlink", lab9_symlink_argv},
-  {"largefs", "largefs-4gib", largefs_4gib_argv},
-  {"lab10", "lab10-mmap", lab10_mmap_argv},
-  {"core", "core-sbrkbugs", core_sbrkbugs_argv},
-  {"core", "core-forkforkfork", core_forkforkfork_argv},
-  {"core", "core-linkunlink", core_linkunlink_argv},
-  {"core", "core-openiput", core_openiput_argv},
-  {"core", "core-fileapi", core_fileapi_argv},
-  {"core", "core-schedtrace", core_schedtrace_argv},
-  {"core", "core-shell-history", core_history_argv},
-  {"core", "core-job-control", core_job_control_argv},
-  {"core", "core-ls-options", core_ls_options_argv},
-  {"core", "core-ps", core_ps_argv},
-  {"core", "core-semaphore", core_semaphore_argv},
-  {"legacy", "legacy-forktest", legacy_forktest_argv},
-  {"legacy", "legacy-stressfs", legacy_stressfs_argv},
-  {"legacy", "legacy-grind", legacy_grind_argv},
-  {"regression", "usertests-full", full_usertests_argv},
-  {0, 0, 0},
+  {"lab1", "lab1-sleep", lab1_sleep_argv, 0},
+  {"lab1", "lab1-pingpong", lab1_pingpong_argv, 0},
+  {"lab1", "lab1-primes", lab1_primes_argv, 0},
+  {"lab1", "lab1-find", lab1_find_argv, 0},
+  {"lab1", "lab1-xargs", lab1_xargs_argv, 0},
+  {"lab2", "lab2-tracemask", lab2_tracemask_argv, 0},
+  {"lab2", "lab2-sysinfo", lab2_sysinfo_argv, 0},
+  {"lab2", "lab2-trace-smoke", lab2_trace_smoke_argv, 0},
+  {"lab3", "lab3-copyin", lab3_copyin_argv, 0},
+  {"lab3", "lab3-copyout", lab3_copyout_argv, 0},
+  {"lab3", "lab3-copyinstr1", lab3_copyinstr_argv, 0},
+  {"lab3", "lab3-sbrkmuch", lab3_sbrkmuch_argv, 0},
+  {"lab3", "lab3-memviz", lab3_memviz_argv, 0},
+  {"lab3", "lab3-memtarget", lab3_memtarget_argv, 0},
+  {"lab3", "lab3-pgtbl", lab3_pgtbl_argv, 0},
+  {"lab3", "lab3-vaaccess", lab3_vaaccess_argv, 0},
+  {"lab3", "lab3-address-window", lab3_address_window_argv, 0},
+  {"lab3", "lab3-ostep-intro", lab3_ostep_intro_argv, 0},
+  {"lab4", "lab4-backtrace", lab4_backtrace_argv, 0},
+  {"lab4", "lab4-alarm", lab4_alarm_argv, 0},
+  {"lab5", "lab5-lazytests", lab5_lazytests_argv, 0},
+  {"lab6", "lab6-cowtest", lab6_cowtest_argv, 0},
+  {"lab7", "lab7-uthread", lab7_uthread_argv, 0},
+  {"lab8", "lab8-kalloc-sbrkmuch", lab8_kalloc_argv, 0},
+  {"lab8", "lab8-createdelete", lab8_createdelete_argv, 0},
+  {"lab8", "lab8-fourfiles", lab8_fourfiles_argv, 0},
+  {"lab8", "lab8-bigwrite", lab8_bigwrite_argv, 0},
+  {"lab9", "lab9-bigfile", lab9_bigfile_argv, 0},
+  {"lab9", "lab9-symlink", lab9_symlink_argv, 0},
+  {"largefs", "largefs-4gib", largefs_4gib_argv, 0},
+  {"lab10", "lab10-mmap", lab10_mmap_argv, 0},
+  {"core", "core-sbrkbugs", core_sbrkbugs_argv, 0},
+  {"core", "core-forkforkfork", core_forkforkfork_argv, 0},
+  {"core", "core-linkunlink", core_linkunlink_argv, 0},
+  {"core", "core-openiput", core_openiput_argv, 0},
+  {"core", "core-fileapi", core_fileapi_argv, 0},
+  {"core", "core-schedtrace", core_schedtrace_argv, 0},
+  {"core", "core-shell-history", core_history_argv, 0},
+  {"core", "core-job-control", core_job_control_argv, 0},
+  {"core", "core-ls-options", core_ls_options_argv, 0},
+  {"core", "core-ps", core_ps_argv, 0},
+  {"core", "core-semaphore", core_semaphore_argv, 0},
+  {"legacy", "legacy-forktest", legacy_forktest_argv, 0},
+  {"legacy", "legacy-stressfs", legacy_stressfs_argv, 0},
+  {"legacy", "legacy-grind", legacy_grind_argv, 0},
+  {"regression", "usertests-full", full_usertests_argv, 0},
+  {"logrecovery", "logcrash-api", logcrash_api_argv, 1},
+  {"logrecovery", "logcrash-before-prepare", logcrash_before_prepare_argv, 1},
+  {"logrecovery", "logcrash-before-verify", logcrash_before_verify_argv, 1},
+  {"logrecovery", "logcrash-after-prepare", logcrash_after_prepare_argv, 1},
+  {"logrecovery", "logcrash-after-verify", logcrash_after_verify_argv, 1},
+  {"logrecovery", "logcrash-install-prepare", logcrash_install_prepare_argv, 1},
+  {"logrecovery", "logcrash-install-verify", logcrash_install_verify_argv, 1},
+  {0, 0, 0, 0},
 };
+
+/** 将实验阶段名称解析为内核故障注入编号。 */
+static int
+logcrash_phase(char *name)
+{
+  if(strcmp(name, "before-commit") == 0)
+    return LOG_CRASH_BEFORE_COMMIT;
+  if(strcmp(name, "after-commit") == 0)
+    return LOG_CRASH_AFTER_COMMIT;
+  if(strcmp(name, "during-install") == 0)
+    return LOG_CRASH_DURING_INSTALL;
+  return -1;
+}
+
+/** 返回每个实验阶段独占的持久文件路径。 */
+static char*
+logcrash_path(int phase)
+{
+  switch(phase){
+  case LOG_CRASH_BEFORE_COMMIT:
+    return "/log-before";
+  case LOG_CRASH_AFTER_COMMIT:
+    return "/log-after";
+  case LOG_CRASH_DURING_INSTALL:
+    return "/log-install";
+  default:
+    return 0;
+  }
+}
+
+/** 用稳定字节填充两块事务载荷。 */
+static void
+logcrash_fill(char value)
+{
+  memset(logcrash_buffer, value, sizeof(logcrash_buffer));
+}
+
+/** 完整写入测试载荷；短写视为失败。 */
+static int
+logcrash_write_all(int fd)
+{
+  return write(fd, logcrash_buffer, sizeof(logcrash_buffer)) ==
+         sizeof(logcrash_buffer);
+}
+
+/** 验证故障注入 API 的参数、占用和取消边界。 */
+static int
+logcrash_api_test(void)
+{
+  if(logcrash(-1) != -1 ||
+     logcrash(LOG_CRASH_DURING_INSTALL + 1) != -1){
+    printf("LOGCRASH api invalid phase accepted\n");
+    return 1;
+  }
+  if(logcrash(LOG_CRASH_BEFORE_COMMIT) != 0){
+    printf("LOGCRASH api failed to arm\n");
+    return 1;
+  }
+  if(logcrash(LOG_CRASH_AFTER_COMMIT) != -1){
+    printf("LOGCRASH api replaced an armed phase\n");
+    return 1;
+  }
+  if(logcrash(LOG_CRASH_NONE) != 0){
+    printf("LOGCRASH api failed to disarm\n");
+    return 1;
+  }
+  printf("LOGCRASH api ok\n");
+  return 0;
+}
+
+/**
+ * 建立旧版本文件，武装指定阶段，并用一个多块事务覆盖为新版本。
+ * 正常行为不会从最终 write() 返回；返回即表示预期崩溃没有发生。
+ */
+static int
+logcrash_prepare(int phase)
+{
+  char *path = logcrash_path(phase);
+  int fd;
+
+  if(path == 0)
+    return 2;
+
+  unlink(path);
+  fd = open(path, O_CREATE | O_TRUNC | O_RDWR);
+  if(fd < 0){
+    printf("LOGCRASH prepare open-old failed phase=%d\n", phase);
+    return 1;
+  }
+  logcrash_fill(LOGCRASH_OLD);
+  if(!logcrash_write_all(fd) || close(fd) < 0){
+    printf("LOGCRASH prepare old generation failed phase=%d\n", phase);
+    return 1;
+  }
+
+  fd = open(path, O_WRONLY);
+  if(fd < 0){
+    printf("LOGCRASH prepare reopen failed phase=%d\n", phase);
+    return 1;
+  }
+  if(logcrash(phase) < 0){
+    close(fd);
+    printf("LOGCRASH prepare arm failed phase=%d\n", phase);
+    return 1;
+  }
+
+  printf("LOGCRASH armed phase=%s bytes=%d\n",
+         phase == LOG_CRASH_BEFORE_COMMIT ? "before-commit" :
+         phase == LOG_CRASH_AFTER_COMMIT ? "after-commit" : "during-install",
+         LOGCRASH_BYTES);
+  logcrash_fill(LOGCRASH_NEW);
+  if(logcrash_write_all(fd))
+    printf("LOGCRASH prepare unexpected write return phase=%d\n", phase);
+  else
+    printf("LOGCRASH prepare write failed before injection phase=%d\n", phase);
+  logcrash(LOG_CRASH_NONE);
+  close(fd);
+  return 1;
+}
+
+/**
+ * 从重启后的真实磁盘镜像读取文件，断言事务只呈现完整旧版本或完整新版本。
+ */
+static int
+logcrash_verify(int phase)
+{
+  char *path = logcrash_path(phase);
+  char expected = phase == LOG_CRASH_BEFORE_COMMIT ? LOGCRASH_OLD : LOGCRASH_NEW;
+  struct stat st;
+  int old_count = 0;
+  int new_count = 0;
+  int other_count = 0;
+  int total = 0;
+  int fd;
+  char extra;
+
+  if(path == 0)
+    return 2;
+  fd = open(path, O_RDONLY);
+  if(fd < 0){
+    printf("LOGCRASH verify open failed phase=%d\n", phase);
+    return 1;
+  }
+  if(fstat(fd, &st) < 0 || st.size != LOGCRASH_BYTES){
+    printf("LOGCRASH verify size failed phase=%d size=%d\n", phase, st.size);
+    close(fd);
+    return 1;
+  }
+
+  while(total < LOGCRASH_BYTES){
+    int n = read(fd, logcrash_buffer + total, LOGCRASH_BYTES - total);
+    if(n <= 0){
+      printf("LOGCRASH verify short read phase=%d total=%d\n", phase, total);
+      close(fd);
+      return 1;
+    }
+    total += n;
+  }
+  if(read(fd, &extra, 1) != 0){
+    printf("LOGCRASH verify trailing data phase=%d\n", phase);
+    close(fd);
+    return 1;
+  }
+  close(fd);
+
+  for(int i = 0; i < LOGCRASH_BYTES; i++){
+    if(logcrash_buffer[i] == LOGCRASH_OLD)
+      old_count++;
+    else if(logcrash_buffer[i] == LOGCRASH_NEW)
+      new_count++;
+    else
+      other_count++;
+  }
+
+  printf("LOGCRASH verify phase=%d expected=%c old=%d new=%d other=%d\n",
+         phase, expected, old_count, new_count, other_count);
+  if(other_count != 0)
+    return 1;
+  if(expected == LOGCRASH_OLD)
+    return old_count == LOGCRASH_BYTES && new_count == 0 ? 0 : 1;
+  return new_count == LOGCRASH_BYTES && old_count == 0 ? 0 : 1;
+}
 
 static void
 usage(char *program)
@@ -151,8 +381,8 @@ list_tests(void)
 {
   int count = 0;
   for(struct xv6_test_case *test = tests; test->name != 0; test++){
-    printf("XV6TEST case name=%s group=%s command=%s\n",
-           test->name, test->group, test->argv[0]);
+    printf("XV6TEST case name=%s group=%s command=%s orchestrated=%d\n",
+           test->name, test->group, test->argv[0], test->orchestrated);
     count++;
   }
   printf("XV6TEST listed total=%d\n", count);
@@ -205,6 +435,8 @@ run_selected_tests(char *group_filter, char *name_filter)
          group_filter == 0 ? "*" : group_filter,
          name_filter == 0 ? "*" : name_filter);
   for(struct xv6_test_case *test = tests; test->name != 0; test++){
+    if(test->orchestrated && name_filter == 0)
+      continue;
     if(!matches_filter(test, group_filter, name_filter))
       continue;
     selected++;
@@ -236,7 +468,7 @@ static int
 run_usertest(char *name)
 {
   char *argv[] = {XV6_TEST_PATH("usertests"), name, 0};
-  struct xv6_test_case test = {"regression", name, argv};
+  struct xv6_test_case test = {"regression", name, argv, 0};
   int passed;
   int status;
 
@@ -255,7 +487,15 @@ main(int argc, char *argv[])
   char *group_filter = 0;
   char *name_filter = 0;
 
-  if(argc == 2 && strcmp(argv[1], "--list") == 0){
+  if(argc == 2 && strcmp(argv[1], "--logcrash-api") == 0){
+    exit(logcrash_api_test());
+  } else if(argc == 3 && strcmp(argv[1], "--logcrash-prepare") == 0){
+    int phase = logcrash_phase(argv[2]);
+    exit(phase < 0 ? 2 : logcrash_prepare(phase));
+  } else if(argc == 3 && strcmp(argv[1], "--logcrash-verify") == 0){
+    int phase = logcrash_phase(argv[2]);
+    exit(phase < 0 ? 2 : logcrash_verify(phase));
+  } else if(argc == 2 && strcmp(argv[1], "--list") == 0){
     exit(list_tests() == 0);
   } else if(argc == 1 || (argc == 2 && strcmp(argv[1], "--all") == 0)){
   } else if(argc == 3 && strcmp(argv[1], "--group") == 0){

--- a/tests/run.py
+++ b/tests/run.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -39,6 +41,7 @@ GUEST_SUCCESS = (r"^XV6TEST done status=0$",)
 GUEST_PROGRAM_PATHS = {
     "xv6test": "/usr/bin/xv6test",
 }
+LOG_RECOVERY_MARKER = "LOGRECOVER replay entries="
 
 
 @dataclass(frozen=True)
@@ -63,6 +66,18 @@ class TestCase:
 
 
 @dataclass(frozen=True)
+class CrashRecoveryScenario:
+    """描述一个需要真实磁盘镜像跨 QEMU 重启保存的日志崩溃场景。"""
+
+    name: str
+    prepare_test: str
+    verify_test: str
+    crash_marker: str
+    recovery_expected: bool
+    timeout: int = 120
+
+
+@dataclass(frozen=True)
 class Suite:
     """描述一个原子测试套件或由其他套件组成的聚合套件。"""
 
@@ -70,6 +85,7 @@ class Suite:
     tests: tuple[TestCase, ...] = ()
     includes: tuple[str, ...] = ()
     description: str = ""
+    crash_scenarios: tuple[CrashRecoveryScenario, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -78,6 +94,31 @@ class QemuCommandResult:
 
     output: str
     failure: str | None = None
+
+
+LOG_RECOVERY_SCENARIOS = (
+    CrashRecoveryScenario(
+        name="before-commit",
+        prepare_test="logcrash-before-prepare",
+        verify_test="logcrash-before-verify",
+        crash_marker="LOGCRASH injected phase=before-commit",
+        recovery_expected=False,
+    ),
+    CrashRecoveryScenario(
+        name="after-commit",
+        prepare_test="logcrash-after-prepare",
+        verify_test="logcrash-after-verify",
+        crash_marker="LOGCRASH injected phase=after-commit",
+        recovery_expected=True,
+    ),
+    CrashRecoveryScenario(
+        name="during-install",
+        prepare_test="logcrash-install-prepare",
+        verify_test="logcrash-install-verify",
+        crash_marker="LOGCRASH injected phase=during-install",
+        recovery_expected=True,
+    ),
+)
 
 
 SUITES: dict[str, Suite] = {
@@ -176,7 +217,7 @@ SUITES: dict[str, Suite] = {
     ),
     "lab9-bigfile": Suite(
         name="lab9-bigfile",
-        description="Lab9 large-file test in an isolated disk snapshot",
+        description="Lab9 large-file and persistent journal recovery regression",
         tests=(
             TestCase(
                 "lab9-bigfile",
@@ -184,7 +225,14 @@ SUITES: dict[str, Suite] = {
                 expected=GUEST_SUCCESS,
                 timeout=120,
             ),
+            TestCase(
+                "logcrash-api",
+                ("xv6test --run logcrash-api",),
+                expected=GUEST_SUCCESS,
+                timeout=120,
+            ),
         ),
+        crash_scenarios=LOG_RECOVERY_SCENARIOS,
     ),
     "lab9-symlink": Suite(
         name="lab9-symlink",
@@ -364,13 +412,40 @@ def _run_host_test(suite: str, test: TestCase) -> None:
     print(f"PASS {test.name} {elapsed:.2f}s ({log_path.relative_to(REPO_ROOT)})")
 
 
-def _start_qemu(cpus: int) -> pexpect.spawn:
-    """启动使用 snapshot 的 xv6 QEMU，并等待 Shell 提示符。"""
+def _build_qemu_command(
+    cpus: int,
+    *,
+    fsimg: Path | None = None,
+    snapshot: bool = True,
+) -> str:
+    """构造显式 CPU、磁盘和 snapshot 策略的 QEMU make 命令。
 
-    command = (
-        "make -s --no-print-directory qemu "
-        f"CPUS={cpus} QEMUEXTRA=-snapshot"
-    )
+    Args:
+        cpus: QEMU 虚拟 CPU 数量。
+        fsimg: 需要跨重启保留写入的镜像；为空时使用 Makefile 默认 fs.img。
+        snapshot: 为 True 时把磁盘写入限制在当前 QEMU 进程。
+
+    Returns:
+        可由 ``bash -lc`` 执行的命令文本。
+    """
+
+    parts = ["make", "-s", "--no-print-directory", "qemu", f"CPUS={cpus}"]
+    if fsimg is not None:
+        parts.append(f"FSIMG={shlex.quote(str(fsimg))}")
+    if snapshot:
+        parts.append("QEMUEXTRA=-snapshot")
+    return " ".join(parts)
+
+
+def _start_qemu(
+    cpus: int,
+    *,
+    fsimg: Path | None = None,
+    snapshot: bool = True,
+) -> pexpect.spawn:
+    """启动指定磁盘策略的 xv6 QEMU，并等待 Shell 提示符。"""
+
+    command = _build_qemu_command(cpus, fsimg=fsimg, snapshot=snapshot)
     child = pexpect.spawn(
         "/bin/bash",
         ["-lc", command],
@@ -512,6 +587,154 @@ def _run_qemu_tests(suite: str, tests: Sequence[TestCase], cpus: int) -> None:
         _stop_qemu(child)
 
 
+def _crash_cpu_variants(cpus: int) -> tuple[int, ...]:
+    """多核为主证据，同时补充单核恢复；请求本身为单核时避免重复。"""
+
+    return (cpus,) if cpus == 1 else (cpus, 1)
+
+
+def _run_expected_log_crash(
+    suite: str,
+    scenario: CrashRecoveryScenario,
+    cpus: int,
+    fsimg: Path,
+) -> None:
+    """触发指定提交阶段，并断言 QEMU 只因预期日志注入 panic。"""
+
+    child = _start_qemu(cpus, fsimg=fsimg, snapshot=False)
+    boot_output = child.before
+    command = _absolute_guest_command(f"xv6test --run {scenario.prepare_test}")
+    try:
+        child.timeout = scenario.timeout
+        child.sendline(command)
+        result = _wait_for_qemu_command(child)
+        output = f"{boot_output}\n$ {command}\n{result.output}"
+        log_path = _write_log(
+            suite,
+            f"{scenario.name}-cpu{cpus}-crash",
+            output,
+        )
+        if result.failure != "matched fatal output: panic:":
+            raise TestFailure(
+                f"{scenario.name} did not stop at the expected panic; log: {log_path}"
+            )
+        if scenario.crash_marker not in _normalize_output(output):
+            raise TestFailure(
+                f"{scenario.name} missing crash marker {scenario.crash_marker!r}; "
+                f"log: {log_path}"
+            )
+    finally:
+        _stop_qemu(child)
+
+
+def _run_log_recovery_verification(
+    suite: str,
+    scenario: CrashRecoveryScenario,
+    cpus: int,
+    fsimg: Path,
+    *,
+    first_recovery: bool,
+) -> None:
+    """重启同一镜像，检查恢复触发条件并执行 guest 原子性 oracle。"""
+
+    child = _start_qemu(cpus, fsimg=fsimg, snapshot=False)
+    boot_output = child.before
+    command = _absolute_guest_command(f"xv6test --run {scenario.verify_test}")
+    stage = "recovery" if first_recovery else "idempotent-reboot"
+    try:
+        normalized_boot = _normalize_output(boot_output)
+        should_replay = first_recovery and scenario.recovery_expected
+        if should_replay and LOG_RECOVERY_MARKER not in normalized_boot:
+            log_path = _write_log(
+                suite,
+                f"{scenario.name}-cpu{cpus}-{stage}",
+                boot_output,
+            )
+            raise TestFailure(
+                f"{scenario.name} expected recovery replay but marker was absent; "
+                f"log: {log_path}"
+            )
+        if not should_replay and LOG_RECOVERY_MARKER in normalized_boot:
+            log_path = _write_log(
+                suite,
+                f"{scenario.name}-cpu{cpus}-{stage}",
+                boot_output,
+            )
+            raise TestFailure(
+                f"{scenario.name} replayed an uncommitted or already-cleared log; "
+                f"log: {log_path}"
+            )
+
+        child.timeout = scenario.timeout
+        child.sendline(command)
+        result = _wait_for_qemu_command(child)
+        output = f"{boot_output}\n$ {command}\n{result.output}"
+        log_path = _write_log(
+            suite,
+            f"{scenario.name}-cpu{cpus}-{stage}",
+            output,
+        )
+        if result.failure is not None:
+            raise TestFailure(f"{result.failure}; log: {log_path}")
+        _assert_output(
+            TestCase(
+                name=scenario.verify_test,
+                commands=(command,),
+                expected=GUEST_SUCCESS,
+            ),
+            output,
+        )
+    finally:
+        _stop_qemu(child)
+
+
+def _run_crash_recovery_scenario(
+    suite: str,
+    scenario: CrashRecoveryScenario,
+    cpus: int,
+) -> None:
+    """在独立镜像上完成崩溃、首次恢复和第二次幂等重启闭环。"""
+
+    started = time.perf_counter()
+    directory = RESULT_ROOT / _safe_name(suite)
+    directory.mkdir(parents=True, exist_ok=True)
+    fsimg = directory / f"{_safe_name(scenario.name)}-cpu{cpus}.img"
+    shutil.copyfile(REPO_ROOT / "fs.img", fsimg)
+    try:
+        _run_expected_log_crash(suite, scenario, cpus, fsimg)
+        _run_log_recovery_verification(
+            suite,
+            scenario,
+            cpus,
+            fsimg,
+            first_recovery=True,
+        )
+        _run_log_recovery_verification(
+            suite,
+            scenario,
+            cpus,
+            fsimg,
+            first_recovery=False,
+        )
+    finally:
+        fsimg.unlink(missing_ok=True)
+
+    elapsed = time.perf_counter() - started
+    print(f"PASS log-recovery-{scenario.name}-cpu{cpus} {elapsed:.2f}s")
+
+
+def _run_crash_recovery_scenarios(
+    suite: str,
+    scenarios: Sequence[CrashRecoveryScenario],
+    cpus: int,
+) -> None:
+    """按多核主证据和单核补充证据执行全部持久日志场景。"""
+
+    for cpu_count in _crash_cpu_variants(cpus):
+        for scenario in scenarios:
+            _run_crash_recovery_scenario(suite, scenario, cpu_count)
+
+
 def _expand_suite(name: str, stack: tuple[str, ...] = ()) -> list[str]:
     """递归展开聚合 suite，并检测未知引用和循环依赖。"""
 
@@ -541,7 +764,7 @@ def _deduplicate(values: Iterable[str]) -> list[str]:
 
 
 def run_atomic_suite(name: str, cpus: int) -> None:
-    """执行一个原子 suite，host 测试先于 QEMU 测试运行。"""
+    """执行原子 suite：host、snapshot guest、持久崩溃矩阵依次运行。"""
 
     suite = SUITES[name]
     print(f"\n== Suite {name}: {suite.description} ==")
@@ -551,6 +774,8 @@ def run_atomic_suite(name: str, cpus: int) -> None:
         _run_host_test(name, test)
     if qemu_tests:
         _run_qemu_tests(name, qemu_tests, cpus)
+    if suite.crash_scenarios:
+        _run_crash_recovery_scenarios(name, suite.crash_scenarios, cpus)
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_log_recovery_runner.py
+++ b/tests/test_log_recovery_runner.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""不启动 QEMU，验证日志崩溃恢复编排的静态契约。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+RUNNER_PATH = Path(__file__).with_name("run.py")
+SPEC = importlib.util.spec_from_file_location("xv6_log_recovery_runner", RUNNER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load regression runner from {RUNNER_PATH}")
+RUNNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = RUNNER
+SPEC.loader.exec_module(RUNNER)
+
+
+class LogRecoveryScenarioTests(unittest.TestCase):
+    """验证三阶段矩阵、CPU 证据和持久磁盘命令不会静默退化。"""
+
+    def test_matrix_covers_required_commit_boundaries(self) -> None:
+        self.assertEqual(
+            ("before-commit", "after-commit", "during-install"),
+            tuple(scenario.name for scenario in RUNNER.LOG_RECOVERY_SCENARIOS),
+        )
+        self.assertEqual(
+            (False, True, True),
+            tuple(
+                scenario.recovery_expected
+                for scenario in RUNNER.LOG_RECOVERY_SCENARIOS
+            ),
+        )
+
+    def test_crash_markers_are_phase_specific(self) -> None:
+        markers = tuple(
+            scenario.crash_marker for scenario in RUNNER.LOG_RECOVERY_SCENARIOS
+        )
+        self.assertEqual(len(markers), len(set(markers)))
+        for scenario in RUNNER.LOG_RECOVERY_SCENARIOS:
+            self.assertIn(scenario.name, scenario.crash_marker)
+
+    def test_persistent_qemu_command_uses_explicit_image_without_snapshot(self) -> None:
+        image = Path("test-results/log-recovery.img")
+        command = RUNNER._build_qemu_command(3, fsimg=image, snapshot=False)
+
+        self.assertIn("CPUS=3", command)
+        self.assertIn(f"FSIMG={image}", command)
+        self.assertNotIn("QEMUEXTRA=-snapshot", command)
+
+    def test_normal_qemu_command_keeps_snapshot_isolation(self) -> None:
+        command = RUNNER._build_qemu_command(3)
+
+        self.assertIn("QEMUEXTRA=-snapshot", command)
+        self.assertNotIn("FSIMG=", command)
+
+    def test_multicore_request_adds_single_core_evidence_once(self) -> None:
+        self.assertEqual((3, 1), RUNNER._crash_cpu_variants(3))
+        self.assertEqual((1,), RUNNER._crash_cpu_variants(1))
+
+    def test_storage_suite_owns_recovery_scenarios(self) -> None:
+        suite = RUNNER.SUITES["lab9-bigfile"]
+
+        self.assertEqual(RUNNER.LOG_RECOVERY_SCENARIOS, suite.crash_scenarios)
+        self.assertIn("logcrash-api", tuple(test.name for test in suite.tests))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -69,3 +69,4 @@ entry("semwait");
 entry("sempost");
 entry("semdestroy");
 entry("seminfo");
+entry("logcrash");


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #158
- 变更类型：教学故障注入 / 跨重启回归
- 影响范围：`kernel/log.c`、`logcrash` 系统调用、`xv6test`、持久磁盘镜像 QEMU runner
- 当前 `main` 基线：`c9226149ccf7827885aac765f5eab4cc96d0f8d5`
- 当前提交：`7305203496c55870d2a3a7dd7b6e46a409849923`
- 变更规模：1 commit / 9 files
- 一句话摘要：在日志提交的三个关键阶段确定性触发教学型崩溃，并复用同一磁盘镜像跨重启验证事务原子性和恢复幂等性。

## 同步当前主线

准备合并期间，`main` 继续合入信号量 #235、地址转换 #208 和 OSTEP 导论虚拟化 #210。本轮以最新 `main` 为父提交重新生成单一功能提交：

- 保留信号量系统调用 `51..55`、`core-semaphore` 注册及完整实现；
- 保留 `lab3-ostep-intro` 注册、地址转换实验及其他全部主线改动；
- 将 `SYS_logcrash` 调整为 `56`；
- 日志恢复内部模式直接执行 `/usr/bin/xv6test`，不再修改 `init` 布局或 `user/user.h`；
- 临时重建文件未进入最终提交；旧实现保存在 `backup/226-crash-consistency-pre-main-4c4aa977`；
- 当前分支相对 `main` 仅领先一个提交。

## 实现内容

- 在 `write_log -> write_head -> install_trans` 三个阶段加入一次性、显式武装的教学型故障注入点；未武装时不改变正常提交语义。
- 新增测试专用 `logcrash(phase)` 入口，拒绝非法阶段、覆盖已有注入点以及文件系统事务进行中的武装请求。
- `xv6test` 建立两块预分配文件的旧/新版本 oracle：未提交事务恢复旧版本，已发布事务与部分安装事务恢复完整新版本，任何混合字节均失败。
- runner 为每个阶段复制独立 `fs.img`，依次执行“触发 panic → 同镜像首次重启 → 同镜像第二次重启”，验证恢复结果、commit record 清理和重放幂等性。
- 每个恢复场景覆盖 `CPUS=3` 与 `CPUS=1`。

## 验证矩阵

| 用例 | 场景 | 断言 |
|---|---|---|
| `logcrash-api` | 非法阶段、重复武装、取消 | 非法或冲突请求返回 `-1`，取消返回 `0` |
| `before-commit` | 日志数据写入，commit record 未发布 | 重启不 replay，文件完整保持旧版本 |
| `after-commit` | commit record 已发布，home block 未安装 | 重启 replay，文件完整变为新版本 |
| `during-install` | 首个 home block 已安装，commit record 未清除 | 重启完整重放，不允许新旧混合 |
| `idempotent-reboot` | 恢复后的第二次启动 | 不再 replay，内容保持不变 |
| runner 单元测试 | 磁盘持久化和 CPU 矩阵 | 持久运行不含 `-snapshot`，矩阵固定且复用同一镜像 |

## 本地复现

```bash
make clean
make -j2
make test-unit
python3 tests/run.py --suite lab9-bigfile --cpus 3

make clean
make -j2 CPUS=1
make test-suite SUITE=usertests-core CPUS=1

python3 tests/run_usertests.py --cpus 3
```

预期关键输出：

```text
LOGCRASH injected phase=before-commit ...
LOGCRASH injected phase=after-commit ...
LOGCRASH injected phase=during-install ... installed=1
LOGRECOVER replay entries=...   # 仅 after-commit / during-install 首次恢复启动出现
PASS log-recovery-<phase>-cpu3
PASS log-recovery-<phase>-cpu1
```

## GitHub Actions

当前提交 `7305203496c55870d2a3a7dd7b6e46a409849923` 的全部检查已完成：

| Workflow | 结果 | 关键覆盖 |
|---|---|---|
| xv6 CI #552 | ✅ success | runner 单元测试、构建、选定 PR QEMU 回归、文件系统单核、VM 单核、完整 usertests |
| Scheduler family CI #343 | ✅ success | PR 回归套件、完整 usertests、单核清理、所有调度策略及 SMP smoke |
| uthread debug #329 | ✅ success | Lab7 在 `CPUS=3` 与 `CPUS=1` 下通过 |

这些结果均来自当前 Head；未把历史提交的结果作为当前验证证据。

## Review 主线

1. `kernel/log.h`、`kernel/log.c`：三个注入点的位置和 `log.lock` 保护的一次性状态。
2. `tests/guest/xv6test.c`：日志 oracle、`core-semaphore`、`lab3-ostep-intro` 同时保留；orchestrated 用例不会进入普通 `--all`。
3. `tests/run.py`：临时镜像不使用 `-snapshot`，三次 QEMU 生命周期复用同一镜像，第二次启动拒绝重复 replay。
4. `tests/test_log_recovery_runner.py`：三阶段矩阵、CPU 组合和持久镜像编排契约。
5. 主线兼容：信号量 `51..55` 不变，`logcrash=56`，新合入的虚拟化测试不被覆盖。

## 教学边界

- 这是显式武装的教学型 `panic` 注入，不是完整真实掉电模型。
- 验证 xv6 redo log 的事务发布、重放和幂等性；不模拟扇区撕裂、设备写缓存、flush/barrier、控制器重排序或生产文件系统 `fsck`。
- 不声称代表 Linux 文件系统的完整崩溃一致性保证。