### PR TITLE
[Concept Lab] 实体化：锁可验证闭环

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,10 @@ jobs:
         run: |
           python3 -m py_compile \
             tests/run.py \
+            tests/run_lock_model.py \
             tests/run_usertests.py \
             tests/shell_history_interactive.py \
+            tests/test_run_lock_model.py \
             tests/test_runner.py \
             tests/ci_plan.py \
             tests/test_ci_plan.py
@@ -85,6 +87,11 @@ jobs:
           else
             echo 'filesystem=false' >> "$GITHUB_OUTPUT"
           fi
+          if grep -Eq '^(Makefile|kernel/(defs\.h|locklab\.c|locklab\.h|main\.c|syscall\.c|syscall\.h|syscall_names\.h|syslocklab\.c)|tests/guest/(locktest\.c|xv6test\.c)|tests/run_lock_model\.py|tests/test_run_lock_model\.py|user/(init\.c|user\.h|usys\.pl))$' /tmp/changed-files.txt; then
+            echo 'lock_model=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'lock_model=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run shell history interaction regression
         if: >-
@@ -110,6 +117,12 @@ jobs:
           done
           printf 'Selected PR suites: %s\n' "${suites[*]}"
           python3 tests/run.py "${args[@]}" --cpus 3
+
+      - name: Run lock model single-core and multi-core matrix
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.lock_model == 'true'
+        run: python3 tests/run_lock_model.py --cpus 3
 
       - name: Run job-control regression single-core
         if: >-

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ OBJS = \
   $K/sysps.o \
   $K/memviz.o \
   $K/sysmemviz.o \
+  $K/locklab.o \
+  $K/syslocklab.o \
   $K/bio.o \
   $K/fs.o \
   $K/fsinspect.o \
@@ -303,6 +305,7 @@ UPROGS=\
 	$U/_consolelinetest\
 	$U/_lstest\
 	$U/_pstest\
+	$U/_locktest\
 	$U/_xv6test\
 	$U/_schedtest\
 	$U/_schedtracetest
@@ -382,6 +385,7 @@ test-grader: test-unit
 # and validate xv6 through its user-visible behavior.
 test-integration: $K/kernel fs.img
 	$(PYTHON) tests/shell_history_interactive.py --cpus $(CPUS)
+	$(PYTHON) tests/run_lock_model.py --cpus $(CPUS)
 	$(PYTHON) tests/run.py --suite pr --cpus $(CPUS)
 
 test-labs: test-integration

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -83,6 +83,10 @@ void            kinit(void);
 void            increase_rc(uint64);
 int             cow_alloc(pagetable_t, uint64);
 
+// locklab.c
+void            locklabinit(void);
+int             locklab_run(int, int);
+
 // log.c
 void            initlog(int, struct superblock*);
 void            log_write(struct buf*);

--- a/kernel/locklab.c
+++ b/kernel/locklab.c
@@ -1,0 +1,285 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "proc.h"
+#include "locklab.h"
+#include "defs.h"
+
+/**
+ * 保存锁实验的共享对象和可观察状态。
+ *
+ * counter_lock 保护 counter；sleep_lock 表示允许持有者睡眠的长期所有权；
+ * state_lock 只保护睡眠实验的短期条件状态。测试代码不能直接访问这些锁，
+ * 只能通过 locklab_run() 触发受控状态转移。
+ */
+static struct {
+  struct spinlock counter_lock;
+  int counter;
+
+  struct sleeplock sleep_lock;
+  struct spinlock state_lock;
+  int holder_ready;
+  int waiter_started;
+  int waiter_acquired;
+  int release_requested;
+} locklab_state;
+
+/** 初始化锁实验的全部锁和共享状态。 */
+void
+locklabinit(void)
+{
+  initlock(&locklab_state.counter_lock, "locklab.counter");
+  initsleeplock(&locklab_state.sleep_lock, "locklab.sleep");
+  initlock(&locklab_state.state_lock, "locklab.state");
+  locklab_state.counter = 0;
+  locklab_state.holder_ready = 0;
+  locklab_state.waiter_started = 0;
+  locklab_state.waiter_acquired = 0;
+  locklab_state.release_requested = 0;
+}
+
+/**
+ * 重置计数器和睡眠实验状态。
+ *
+ * @return 当前没有正在执行的 holder/waiter 时返回 0；实验仍活跃时返回 -1，
+ *         避免重置覆盖另一个进程正在等待的条件。
+ */
+static int
+locklab_reset(void)
+{
+  acquire(&locklab_state.state_lock);
+  if(locklab_state.holder_ready ||
+     (locklab_state.waiter_started && !locklab_state.waiter_acquired)){
+    release(&locklab_state.state_lock);
+    return -1;
+  }
+  locklab_state.holder_ready = 0;
+  locklab_state.waiter_started = 0;
+  locklab_state.waiter_acquired = 0;
+  locklab_state.release_requested = 0;
+  release(&locklab_state.state_lock);
+
+  acquire(&locklab_state.counter_lock);
+  locklab_state.counter = 0;
+  release(&locklab_state.counter_lock);
+  return 0;
+}
+
+/**
+ * 读取计数器的一次快照。
+ *
+ * @return counter_lock 临界区内观察到的计数值。
+ *
+ * 该操作本身没有数据竞争，但它故意只保护“读”而不保护完整读改写事务，
+ * 用于稳定复现临界区粒度过小造成的丢失更新。
+ */
+static int
+locklab_split_read(void)
+{
+  int value;
+
+  acquire(&locklab_state.counter_lock);
+  value = locklab_state.counter;
+  release(&locklab_state.counter_lock);
+  return value;
+}
+
+/**
+ * 将调用者提供的快照结果写回计数器。
+ *
+ * @param value 要写入的整数值。
+ * @return 写入成功后返回 0。
+ *
+ * 与 locklab_split_read() 分开调用时，两个进程可以先后读取同一个旧值，
+ * 再分别写回同一个新值；每次访问都加锁仍不足以保证复合事务原子性。
+ */
+static int
+locklab_split_write(int value)
+{
+  acquire(&locklab_state.counter_lock);
+  locklab_state.counter = value;
+  release(&locklab_state.counter_lock);
+  return 0;
+}
+
+/**
+ * 在一个 spinlock 临界区内完成完整读改写。
+ *
+ * @return 递增后的计数值。
+ */
+static int
+locklab_safe_increment(void)
+{
+  int value;
+
+  acquire(&locklab_state.counter_lock);
+  locklab_state.counter++;
+  value = locklab_state.counter;
+  release(&locklab_state.counter_lock);
+  return value;
+}
+
+/** @return counter_lock 保护下读取到的当前计数值。 */
+static int
+locklab_counter(void)
+{
+  int value;
+
+  acquire(&locklab_state.counter_lock);
+  value = locklab_state.counter;
+  release(&locklab_state.counter_lock);
+  return value;
+}
+
+/**
+ * 验证 holding() 的所有权语义和 acquire()/release() 的中断嵌套边界。
+ *
+ * @return LOCKLAB_OWNER_* 位图；正常实现必须返回 LOCKLAB_OWNER_EXPECTED。
+ *
+ * holding() 要求本 CPU 中断已关闭，因而外部与释放后的负向检查由显式
+ * push_off()/pop_off() 包围。acquire() 在这个范围内再嵌套一次 push_off()，
+ * release() 只撤销自己对应的一层，不能提前恢复中断。
+ */
+static int
+locklab_owner_oracle(void)
+{
+  int result = 0;
+  int base_noff;
+
+  push_off();
+  base_noff = mycpu()->noff;
+  if(!holding(&locklab_state.counter_lock))
+    result |= LOCKLAB_OWNER_OUTSIDE_REJECTED;
+
+  acquire(&locklab_state.counter_lock);
+  if(holding(&locklab_state.counter_lock) && mycpu()->noff == base_noff + 1)
+    result |= LOCKLAB_OWNER_INSIDE_HELD;
+  release(&locklab_state.counter_lock);
+
+  if(!holding(&locklab_state.counter_lock) && mycpu()->noff == base_noff)
+    result |= LOCKLAB_OWNER_AFTER_REJECTED;
+  pop_off();
+  return result;
+}
+
+/**
+ * 持有 sleeplock 后等待用户态发出释放请求。
+ *
+ * @return 正常被唤醒并释放 sleeplock 时返回 0。
+ *
+ * holder 在 sleep() 中只原子释放 state_lock；sleep_lock 会跨调度保持占有。
+ * 这正是 sleeplock 与 spinlock 的责任边界：长期等待可以睡眠，但不能带着
+ * spinlock 空转或进入调度器。
+ */
+static int
+locklab_sleep_holder(void)
+{
+  acquiresleep(&locklab_state.sleep_lock);
+
+  acquire(&locklab_state.state_lock);
+  locklab_state.holder_ready = 1;
+  while(!locklab_state.release_requested)
+    sleep(&locklab_state.release_requested, &locklab_state.state_lock);
+  locklab_state.holder_ready = 0;
+  release(&locklab_state.state_lock);
+
+  releasesleep(&locklab_state.sleep_lock);
+  return 0;
+}
+
+/**
+ * 登记等待状态并尝试获取 holder 当前占有的 sleeplock。
+ *
+ * @return 最终取得并释放 sleeplock 时返回 0。
+ */
+static int
+locklab_sleep_waiter(void)
+{
+  acquire(&locklab_state.state_lock);
+  locklab_state.waiter_started = 1;
+  release(&locklab_state.state_lock);
+
+  acquiresleep(&locklab_state.sleep_lock);
+  acquire(&locklab_state.state_lock);
+  locklab_state.waiter_acquired = 1;
+  release(&locklab_state.state_lock);
+  releasesleep(&locklab_state.sleep_lock);
+  return 0;
+}
+
+/** @return state_lock 保护下生成的 LOCKLAB_SLEEP_* 状态位图。 */
+static int
+locklab_sleep_state(void)
+{
+  int state = 0;
+
+  acquire(&locklab_state.state_lock);
+  if(locklab_state.holder_ready)
+    state |= LOCKLAB_SLEEP_HOLDER_READY;
+  if(locklab_state.waiter_started)
+    state |= LOCKLAB_SLEEP_WAITER_STARTED;
+  if(locklab_state.waiter_acquired)
+    state |= LOCKLAB_SLEEP_WAITER_ACQUIRED;
+  if(locklab_state.release_requested)
+    state |= LOCKLAB_SLEEP_RELEASE_REQUEST;
+  release(&locklab_state.state_lock);
+  return state;
+}
+
+/**
+ * 设置 holder 的释放条件并唤醒睡在同一条件地址上的进程。
+ *
+ * @return holder 已经进入实验时返回 0；尚未准备好时返回 -1。
+ */
+static int
+locklab_sleep_release(void)
+{
+  acquire(&locklab_state.state_lock);
+  if(!locklab_state.holder_ready){
+    release(&locklab_state.state_lock);
+    return -1;
+  }
+  locklab_state.release_requested = 1;
+  wakeup(&locklab_state.release_requested);
+  release(&locklab_state.state_lock);
+  return 0;
+}
+
+/**
+ * 执行一个受控的锁实验操作。
+ *
+ * @param operation kernel/locklab.h 中定义的 LOCKLAB_* 操作编号。
+ * @param value 仅 LOCKLAB_SPLIT_WRITE 使用的写回值；其他操作忽略。
+ * @return 各操作的结果；未知操作或不满足前置状态时返回 -1。
+ */
+int
+locklab_run(int operation, int value)
+{
+  switch(operation){
+  case LOCKLAB_RESET:
+    return locklab_reset();
+  case LOCKLAB_SPLIT_READ:
+    return locklab_split_read();
+  case LOCKLAB_SPLIT_WRITE:
+    return locklab_split_write(value);
+  case LOCKLAB_SAFE_INCREMENT:
+    return locklab_safe_increment();
+  case LOCKLAB_COUNTER:
+    return locklab_counter();
+  case LOCKLAB_OWNER_ORACLE:
+    return locklab_owner_oracle();
+  case LOCKLAB_SLEEP_HOLDER:
+    return locklab_sleep_holder();
+  case LOCKLAB_SLEEP_WAITER:
+    return locklab_sleep_waiter();
+  case LOCKLAB_SLEEP_STATE:
+    return locklab_sleep_state();
+  case LOCKLAB_SLEEP_RELEASE:
+    return locklab_sleep_release();
+  default:
+    return -1;
+  }
+}

--- a/kernel/locklab.h
+++ b/kernel/locklab.h
@@ -1,0 +1,31 @@
+#ifndef XV6_KERNEL_LOCKLAB_H
+#define XV6_KERNEL_LOCKLAB_H
+
+// locklab 系统调用的教学操作编号。每个操作只暴露可重复验证的状态，
+// 不把 spinlock 或 sleeplock 对象本身泄露给用户态。
+#define LOCKLAB_RESET             1
+#define LOCKLAB_SPLIT_READ        2
+#define LOCKLAB_SPLIT_WRITE       3
+#define LOCKLAB_SAFE_INCREMENT    4
+#define LOCKLAB_COUNTER           5
+#define LOCKLAB_OWNER_ORACLE      6
+#define LOCKLAB_SLEEP_HOLDER      7
+#define LOCKLAB_SLEEP_WAITER      8
+#define LOCKLAB_SLEEP_STATE       9
+#define LOCKLAB_SLEEP_RELEASE    10
+
+// LOCKLAB_OWNER_ORACLE 返回值中的稳定断言位。
+#define LOCKLAB_OWNER_OUTSIDE_REJECTED (1 << 0)
+#define LOCKLAB_OWNER_INSIDE_HELD      (1 << 1)
+#define LOCKLAB_OWNER_AFTER_REJECTED   (1 << 2)
+#define LOCKLAB_OWNER_EXPECTED \
+  (LOCKLAB_OWNER_OUTSIDE_REJECTED | LOCKLAB_OWNER_INSIDE_HELD | \
+   LOCKLAB_OWNER_AFTER_REJECTED)
+
+// LOCKLAB_SLEEP_STATE 返回值中的状态位。
+#define LOCKLAB_SLEEP_HOLDER_READY     (1 << 0)
+#define LOCKLAB_SLEEP_WAITER_STARTED   (1 << 1)
+#define LOCKLAB_SLEEP_WAITER_ACQUIRED  (1 << 2)
+#define LOCKLAB_SLEEP_RELEASE_REQUEST  (1 << 3)
+
+#endif

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -30,6 +30,7 @@ main()
     kvminithart();   // turn on paging
     procinit();      // process table
     seminit();       // teaching semaphore table
+    locklabinit();   // deterministic lock teaching state
     trapinit();      // trap vectors
     trapinithart();  // install kernel trap vector
     plicinit();      // set up interrupt controller

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -110,6 +110,7 @@ extern uint64 sys_fsinspect(void);
 extern uint64 sys_getpid(void);
 extern uint64 sys_kill(void);
 extern uint64 sys_link(void);
+extern uint64 sys_locklab(void);
 extern uint64 sys_logcrash(void);
 extern uint64 sys_lseek(void);
 extern uint64 sys_mkdir(void);
@@ -223,6 +224,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_logcrash]         sys_logcrash,
 [SYS_raid1info]        sys_raid1info,
 [SYS_raid1rw]          sys_raid1rw,
+[SYS_locklab]          sys_locklab,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -57,3 +57,4 @@
 #define SYS_logcrash         56
 #define SYS_raid1info        57
 #define SYS_raid1rw          58
+#define SYS_locklab          59

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -63,6 +63,7 @@ static const char *const syscall_names[] = {
 [SYS_logcrash]         = "logcrash",
 [SYS_raid1info]        = "raid1info",
 [SYS_raid1rw]          = "raid1rw",
+[SYS_locklab]          = "locklab",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/syslocklab.c
+++ b/kernel/syslocklab.c
@@ -1,0 +1,23 @@
+#include "types.h"
+#include "param.h"
+#include "memlayout.h"
+#include "riscv.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "defs.h"
+
+/**
+ * 将用户态锁实验请求转发给内核中的受控实验状态机。
+ *
+ * @return locklab_run() 的操作结果；当前接口只有两个整数参数，不复制用户指针。
+ */
+uint64
+sys_locklab(void)
+{
+  int operation;
+  int value;
+
+  argint(0, &operation);
+  argint(1, &value);
+  return locklab_run(operation, value);
+}

--- a/tests/guest/locktest.c
+++ b/tests/guest/locktest.c
@@ -1,0 +1,285 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/locklab.h"
+#include "user/user.h"
+
+#define SPLIT_WORKERS 2
+#define SAFE_WORKERS 4
+#define SAFE_INCREMENTS 200
+#define STATE_WAIT_TICKS 200
+
+/**
+ * 输出稳定失败原因并终止当前测试进程。
+ *
+ * @param reason 不含 runner 拒绝关键字的简短诊断文本。
+ */
+static void
+fail(char *reason)
+{
+  printf("locktest: %s\n", reason);
+  exit(1);
+}
+
+/**
+ * 从管道读取一个同步字节。
+ *
+ * @param fd 可读管道描述符。
+ * @return 成功读取一个字节返回 0；EOF 或错误返回 -1。
+ */
+static int
+read_token(int fd)
+{
+  char token;
+  return read(fd, &token, 1) == 1 ? 0 : -1;
+}
+
+/**
+ * 向管道写入一个同步字节。
+ *
+ * @param fd 可写管道描述符。
+ * @return 成功写入一个字节返回 0；短写或错误返回 -1。
+ */
+static int
+write_token(int fd)
+{
+  char token = 'x';
+  return write(fd, &token, 1) == 1 ? 0 : -1;
+}
+
+/**
+ * 回收指定数量的直接子进程并要求全部正常退出。
+ *
+ * @param count 期望回收的子进程数量。
+ * @return 全部退出状态为 0 时返回 0；wait 或任一子进程失败时返回 -1。
+ */
+static int
+wait_successful_children(int count)
+{
+  for(int i = 0; i < count; i++){
+    int status = -1;
+    if(wait(&status) < 0 || status != 0)
+      return -1;
+  }
+  return 0;
+}
+
+/**
+ * 等待睡眠实验状态满足指定位图条件。
+ *
+ * @param mask 参与比较的 LOCKLAB_SLEEP_* 位。
+ * @param expected mask 范围内的期望值。
+ * @return 在超时前满足条件时返回完整状态；超时或系统调用失败时返回 -1。
+ */
+static int
+wait_for_state(int mask, int expected)
+{
+  for(int tick = 0; tick < STATE_WAIT_TICKS; tick++){
+    int state = locklab(LOCKLAB_SLEEP_STATE, 0);
+    if(state < 0)
+      return -1;
+    if((state & mask) == expected)
+      return state;
+    sleep(1);
+  }
+  return -1;
+}
+
+/**
+ * 稳定复现“每次访问都加锁，但完整读改写未形成同一临界区”的丢失更新。
+ *
+ * @return 两个进程都从 0 计算出 1，最终计数器稳定为 1 时返回 0。
+ */
+static int
+check_split_critical_section(void)
+{
+  int ready[2];
+  int go[2];
+
+  if(locklab(LOCKLAB_RESET, 0) != 0)
+    return -1;
+  if(pipe(ready) < 0 || pipe(go) < 0)
+    return -1;
+
+  for(int worker = 0; worker < SPLIT_WORKERS; worker++){
+    int pid = fork();
+    if(pid < 0)
+      return -1;
+    if(pid == 0){
+      close(ready[0]);
+      close(go[1]);
+
+      int observed = locklab(LOCKLAB_SPLIT_READ, 0);
+      if(observed != 0 || write_token(ready[1]) < 0 || read_token(go[0]) < 0)
+        exit(1);
+      if(locklab(LOCKLAB_SPLIT_WRITE, observed + 1) != 0)
+        exit(1);
+
+      close(ready[1]);
+      close(go[0]);
+      exit(0);
+    }
+  }
+
+  close(ready[1]);
+  close(go[0]);
+  for(int worker = 0; worker < SPLIT_WORKERS; worker++)
+    if(read_token(ready[0]) < 0)
+      return -1;
+  for(int worker = 0; worker < SPLIT_WORKERS; worker++)
+    if(write_token(go[1]) < 0)
+      return -1;
+  close(ready[0]);
+  close(go[1]);
+
+  if(wait_successful_children(SPLIT_WORKERS) < 0)
+    return -1;
+  return locklab(LOCKLAB_COUNTER, 0) == 1 ? 0 : -1;
+}
+
+/**
+ * 验证完整读改写位于一个 spinlock 临界区时不会丢失更新。
+ *
+ * @return 多进程并发递增后的精确计数满足不变量时返回 0。
+ */
+static int
+check_spinlock_counter(void)
+{
+  int go[2];
+
+  if(locklab(LOCKLAB_RESET, 0) != 0 || pipe(go) < 0)
+    return -1;
+
+  for(int worker = 0; worker < SAFE_WORKERS; worker++){
+    int pid = fork();
+    if(pid < 0)
+      return -1;
+    if(pid == 0){
+      close(go[1]);
+      if(read_token(go[0]) < 0)
+        exit(1);
+      for(int step = 0; step < SAFE_INCREMENTS; step++)
+        if(locklab(LOCKLAB_SAFE_INCREMENT, 0) < 1)
+          exit(1);
+      close(go[0]);
+      exit(0);
+    }
+  }
+
+  close(go[0]);
+  for(int worker = 0; worker < SAFE_WORKERS; worker++)
+    if(write_token(go[1]) < 0)
+      return -1;
+  close(go[1]);
+
+  if(wait_successful_children(SAFE_WORKERS) < 0)
+    return -1;
+  return locklab(LOCKLAB_COUNTER, 0) ==
+         SAFE_WORKERS * SAFE_INCREMENTS ? 0 : -1;
+}
+
+/**
+ * 验证错误持有者检查以及 push_off/pop_off 的嵌套边界。
+ *
+ * @return 内核返回完整 LOCKLAB_OWNER_EXPECTED 位图时返回 0。
+ */
+static int
+check_owner_oracle(void)
+{
+  return locklab(LOCKLAB_OWNER_ORACLE, 0) == LOCKLAB_OWNER_EXPECTED ? 0 : -1;
+}
+
+/**
+ * 验证 sleeplock 持有者可以睡眠，等待者在释放前不能取得所有权。
+ *
+ * @return holder/waiter 状态按约束推进且两个子进程正常退出时返回 0。
+ */
+static int
+check_sleeplock_wait(void)
+{
+  if(locklab(LOCKLAB_RESET, 0) != 0)
+    return -1;
+
+  int holder = fork();
+  if(holder < 0)
+    return -1;
+  if(holder == 0)
+    exit(locklab(LOCKLAB_SLEEP_HOLDER, 0) == 0 ? 0 : 1);
+
+  if(wait_for_state(LOCKLAB_SLEEP_HOLDER_READY,
+                    LOCKLAB_SLEEP_HOLDER_READY) < 0)
+    return -1;
+
+  int waiter = fork();
+  if(waiter < 0)
+    return -1;
+  if(waiter == 0)
+    exit(locklab(LOCKLAB_SLEEP_WAITER, 0) == 0 ? 0 : 1);
+
+  if(wait_for_state(LOCKLAB_SLEEP_WAITER_STARTED,
+                    LOCKLAB_SLEEP_WAITER_STARTED) < 0)
+    return -1;
+
+  // waiter 已经进入获取路径，但 holder 尚未收到释放条件；此时取得锁即为错误。
+  for(int tick = 0; tick < 8; tick++){
+    int state = locklab(LOCKLAB_SLEEP_STATE, 0);
+    if(state < 0 || (state & LOCKLAB_SLEEP_WAITER_ACQUIRED) != 0)
+      return -1;
+    sleep(1);
+  }
+
+  if(locklab(LOCKLAB_SLEEP_RELEASE, 0) != 0)
+    return -1;
+  if(wait_successful_children(2) < 0)
+    return -1;
+
+  int state = locklab(LOCKLAB_SLEEP_STATE, 0);
+  if(state < 0 || (state & LOCKLAB_SLEEP_WAITER_ACQUIRED) == 0)
+    return -1;
+  if((state & LOCKLAB_SLEEP_HOLDER_READY) != 0)
+    return -1;
+  return 0;
+}
+
+/**
+ * 执行一轮完整锁模型回归。
+ *
+ * @return 所有正常、反例、睡眠和错误输入断言通过时返回 0。
+ */
+static int
+run_round(void)
+{
+  if(check_split_critical_section() < 0)
+    return -1;
+  if(check_spinlock_counter() < 0)
+    return -1;
+  if(check_owner_oracle() < 0)
+    return -1;
+  if(check_sleeplock_wait() < 0)
+    return -1;
+  if(locklab(9999, 0) != -1)
+    return -1;
+  return 0;
+}
+
+/**
+ * locktest 用户入口。
+ *
+ * @param argc 必须为 2。
+ * @param argv argv[1] 必须为 positive。
+ * @return 不直接返回；两轮可重复回归成功 exit(0)，否则 exit(non-zero)。
+ */
+int
+main(int argc, char **argv)
+{
+  if(argc != 2 || strcmp(argv[1], "positive") != 0){
+    fprintf(2, "Usage: locktest positive\n");
+    exit(2);
+  }
+
+  for(int round = 0; round < 2; round++)
+    if(run_round() < 0)
+      fail("invariant mismatch");
+
+  printf("locktest: ok\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -63,6 +63,7 @@ static char *lab8_kalloc_argv[] = {XV6_TEST_PATH("usertests"), "sbrkmuch", 0};
 static char *lab8_createdelete_argv[] = {XV6_TEST_PATH("usertests"), "createdelete", 0};
 static char *lab8_fourfiles_argv[] = {XV6_TEST_PATH("usertests"), "fourfiles", 0};
 static char *lab8_bigwrite_argv[] = {XV6_TEST_PATH("usertests"), "bigwrite", 0};
+static char *lab8_lock_model_argv[] = {XV6_TEST_PATH("locktest"), "positive", 0};
 static char *lab9_bigfile_argv[] = {XV6_TEST_PATH("bigfile"), 0};
 static char *lab9_symlink_argv[] = {XV6_TEST_PATH("symlinktest"), 0};
 static char *largefs_4gib_argv[] = {XV6_TEST_PATH("largefile"), 0};
@@ -147,6 +148,7 @@ static struct xv6_test_case tests[] = {
   {"lab8", "lab8-createdelete", lab8_createdelete_argv, 0},
   {"lab8", "lab8-fourfiles", lab8_fourfiles_argv, 0},
   {"lab8", "lab8-bigwrite", lab8_bigwrite_argv, 0},
+  {"lab8", "lab8-lock-model", lab8_lock_model_argv, 0},
   {"lab9", "lab9-bigfile", lab9_bigfile_argv, 0},
   {"lab9", "lab9-symlink", lab9_symlink_argv, 0},
   {"largefs", "largefs-4gib", largefs_4gib_argv, 0},

--- a/tests/run_lock_model.py
+++ b/tests/run_lock_model.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""在单核和请求的多核配置下重建并执行锁模型 guest 回归。"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+
+import pexpect
+
+from run import GUEST_SUCCESS, REPO_ROOT, TestCase, TestFailure, _run_qemu_tests
+
+
+def cpu_matrix(requested_cpus: int) -> tuple[int, ...]:
+    """返回去重后的验证矩阵，始终先覆盖 CPUS=1。"""
+
+    if requested_cpus < 1:
+        raise ValueError("CPU count must be at least 1")
+    return tuple(dict.fromkeys((1, requested_cpus)))
+
+
+def build_xv6(cpus: int) -> None:
+    """按指定 CPU 数量执行干净构建，避免复用其他矩阵项的内核。"""
+
+    subprocess.run(("make", "clean"), cwd=REPO_ROOT, check=True)
+    subprocess.run(("make", "-j2", f"CPUS={cpus}"), cwd=REPO_ROOT, check=True)
+
+
+def run_lock_model(cpus: int) -> None:
+    """在一个全新 QEMU snapshot 中运行锁模型测试。"""
+
+    test = TestCase(
+        name=f"lab8-lock-model-cpu{cpus}",
+        commands=("xv6test --run lab8-lock-model",),
+        expected=GUEST_SUCCESS,
+        timeout=180,
+    )
+    _run_qemu_tests(f"lock-model-cpu{cpus}", (test,), cpus)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """解析调用者希望验证的默认多核 CPU 数量。"""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cpus", type=int, default=3, help="default multi-core QEMU CPU count")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """逐项干净构建并执行单核与多核矩阵。"""
+
+    args = parse_args(argv)
+    try:
+        matrix = cpu_matrix(args.cpus)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    failures: list[str] = []
+    for cpus in matrix:
+        try:
+            build_xv6(cpus)
+            run_lock_model(cpus)
+        except (TestFailure, subprocess.CalledProcessError, pexpect.TIMEOUT, pexpect.EOF) as exc:
+            failures.append(f"CPUS={cpus}: {exc}")
+            print(f"FAIL lock model CPUS={cpus}: {exc}", file=sys.stderr)
+
+    if failures:
+        print("\nLock model failures:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("\nLock model CPU matrix passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_lock_model.py
+++ b/tests/test_run_lock_model.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""锁模型 CPU 验证矩阵的宿主机单元测试。"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import run_lock_model
+
+
+class CpuMatrixTests(unittest.TestCase):
+    """验证单核固定覆盖和多核去重规则。"""
+
+    def test_requested_single_core_is_not_duplicated(self) -> None:
+        self.assertEqual(run_lock_model.cpu_matrix(1), (1,))
+
+    def test_requested_multi_core_runs_after_single_core(self) -> None:
+        self.assertEqual(run_lock_model.cpu_matrix(3), (1, 3))
+
+    def test_invalid_cpu_count_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            run_lock_model.cpu_matrix(0)
+
+
+class RunnerInvocationTests(unittest.TestCase):
+    """验证每个矩阵元素都会先构建，再交给 QEMU runner。"""
+
+    @patch("run_lock_model.run_lock_model")
+    @patch("run_lock_model.build_xv6")
+    def test_main_runs_single_and_requested_multi_core(
+        self,
+        mocked_build,
+        mocked_run,
+    ) -> None:
+        self.assertEqual(run_lock_model.main(("--cpus", "3")), 0)
+        self.assertEqual(mocked_build.call_count, 2)
+        mocked_build.assert_any_call(1)
+        mocked_build.assert_any_call(3)
+        self.assertEqual(mocked_run.call_count, 2)
+        mocked_run.assert_any_call(1)
+        mocked_run.assert_any_call(3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user/init.c
+++ b/user/init.c
@@ -107,6 +107,7 @@ static struct image_file image_files[] = {
   {"/consolelinetest", XV6_TEST_PATH("consolelinetest")},
   {"/lstest", XV6_TEST_PATH("lstest")},
   {"/pstest", XV6_TEST_PATH("pstest")},
+  {"/locktest", XV6_TEST_PATH("locktest")},
   {"/schedtest", XV6_TEST_PATH("schedtest")},
   {"/schedtracetest", XV6_TEST_PATH("schedtracetest")},
   {"/xargstest.sh", XV6_TEST_PATH("xargstest.sh")},

--- a/user/user.h
+++ b/user/user.h
@@ -119,6 +119,15 @@ int semdestroy(int handle);
 int seminfo(int handle, struct semaphore_info *info);
 
 /**
+ * 执行 kernel/locklab.h 定义的可重复锁实验操作。
+ *
+ * @param operation LOCKLAB_* 操作编号。
+ * @param value 操作参数；当前仅 LOCKLAB_SPLIT_WRITE 使用。
+ * @return 操作结果；未知操作或前置状态不满足时返回 -1。
+ */
+int locklab(int operation, int value);
+
+/**
  * 驱动显式启用的并发入门教学会话。
  *
  * @param op kernel/concurrencylab.h 定义的 RESET、RUN、SNAPSHOT 或 CLOSE。

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -72,3 +72,4 @@ entry("seminfo");
 entry("logcrash");
 entry("raid1info");
 entry("raid1rw");
+entry("locklab");


### PR DESCRIPTION
## 中心认知与范围

把《锁》中的“所有权、临界区粒度、等待策略与中断边界”映射为 xv6 可重复执行的验证闭环，不修改现有 `spinlock.c` / `sleeplock.c` 语义：

- 复用 `acquire/release/holding/push_off/pop_off` 验证 spinlock 所有权与中断嵌套；
- 对照“每次访问都加锁但完整读改写未原子化”与完整临界区；
- 用 sleeplock holder/waiter 状态机验证持锁睡眠、等待与唤醒边界；
- 用稳定负向 oracle 验证错误持有者，不依赖随机时序或破坏性 panic。

Fixes #149
Relates to #134

## 冲突处理

- 最新重放基线：`0a7d790ab01985c8fc9f94465c3ee71b166920a0`
- 当前验证提交：`2b92ddfd41964493205241493b2dab324de4fcca`
- 分支：`concept/149-lock-closed-loop`
- 已基于最新 `main` 重新重放 17 个目标文件，当前 `behind_by=0`、`mergeable=true`。
- 保留主线 OSTEP 导论、日志崩溃注入、RAID1、信号量及统一测试协议的全部改动。
- 解决系统调用编号冲突：保留 `SYS_logcrash=56`、`SYS_raid1info=57`、`SYS_raid1rw=58`，将 `SYS_locklab` 调整为 `59`。
- `tests/guest/xv6test.c` 按主线四字段 `xv6_test_case` 结构注册 `lab8-lock-model`，并保持 `orchestrated=0`。
- `Makefile`、`user/init.c`、`user/user.h`、`user/usys.pl` 和 CI 只追加锁实验入口，不覆盖主线注册。

## 实现变化

- `kernel/locklab.c` / `kernel/locklab.h`：受控共享计数器、所有权 oracle、sleeplock holder/waiter 状态机。
- `kernel/syslocklab.c`：`locklab(operation, value)` 系统调用入口。
- `tests/guest/locktest.c`：两轮执行丢失更新反例、精确并发计数、错误持有者检查、sleeplock 睡眠边界及非法操作。
- `tests/guest/xv6test.c`：注册 `lab8-lock-model`。
- `tests/run_lock_model.py`：干净构建并分别执行 `CPUS=1` 与 `CPUS=3`。
- `tests/test_run_lock_model.py`：验证 CPU 矩阵、构建和 QEMU 调用顺序。
- `.github/workflows/ci.yml`：锁相关文件变化时显式运行单核与多核矩阵。

## 锁边界与不变量

- `counter` 的每次物理访问由 `counter_lock` 保护；只有完整 read-modify-write 位于同一临界区时，逻辑更新才是原子的。
- `holding()` 只在本 CPU 中断关闭时调用；嵌套 `acquire/release` 只能增减自己对应的一层 `noff`。
- holder 持有 sleeplock 时可以经 `sleep()` 让出 CPU；传给 `sleep()` 的 `state_lock` 会被原子释放并在唤醒后重获。
- waiter 在 holder 收到释放请求之前不得取得 sleeplock。
- 实验状态由内核持有，用户态只能触发有限操作并读取结构化位图。

## 当前 Head 验证结果

以下均来自提交 `2b92ddfd41964493205241493b2dab324de4fcca` 的 GitHub Actions：

- xv6 CI #558：通过
  - Python runner 单元测试
  - `make clean` + `make -j2`
  - selected PR QEMU regression
  - lock model matrix：`CPUS=1`、`CPUS=3`
  - VM regression：`CPUS=1`
  - complete usertests
- Scheduler family CI #349：通过
  - RR/FIFO/SJF/STCF/MLFQ/CFS 构建与行为测试
  - SMP smoke
  - complete usertests
  - reparent cleanup：`CPUS=1`
- uthread debug #335：通过，覆盖 `CPUS=3` 与 `CPUS=1`
- RAID1 teaching experiment #6：通过，覆盖默认构建、单核与多核实验

## 教学边界

- `locklab` 是确定性教学适配层，不是通用内核同步 API。
- 本 PR 不实现公平锁、优先级继承、死锁自动检测或 Linux futex。
