### PR TITLE
[Concept Lab] 实体化：并发入门

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
           else
             echo 'job_control=false' >> "$GITHUB_OUTPUT"
           fi
+          if grep -Eq '^(kernel/(concurrencylab\.h|proc\.c|sleeplock\.c|spinlock\.c|swtch\.S)|tests/guest/uthreadtest\.c|tests/host/(barrier\.c|ph\.c))$' /tmp/changed-files.txt; then
+            echo 'concurrency_single_core=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'concurrency_single_core=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run shell history interaction regression
         if: >-
@@ -104,6 +109,19 @@ jobs:
           done
           printf 'Selected PR suites: %s\n' "${suites[*]}"
           python3 tests/run.py "${args[@]}" --cpus 3
+
+      - name: Run concurrency regression single-core
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.concurrency_single_core == 'true'
+        run: |
+          set -o pipefail
+          mkdir -p test-results/infrastructure
+          rm -rf test-results/lab7-thread
+          # CPUS changes a compile-time kernel constant; force a clean one-CPU image.
+          make clean
+          make -j2 CPUS=1 2>&1 | tee test-results/infrastructure/concurrency-single-core-build.log
+          make test-suite SUITE=lab7-thread CPUS=1 2>&1 | tee test-results/infrastructure/concurrency-single-core-run.log
 
       - name: Run VM regression single-core
         if: >-

--- a/kernel/concurrencylab.h
+++ b/kernel/concurrencylab.h
@@ -1,0 +1,36 @@
+#ifndef XV6_KERNEL_CONCURRENCYLAB_H
+#define XV6_KERNEL_CONCURRENCYLAB_H
+
+#define CONCURRENCYLAB_PARTICIPANTS 2
+
+#define CONCURRENCYLAB_MODE_RACY   1
+#define CONCURRENCYLAB_MODE_LOCKED 2
+
+#define CONCURRENCYLAB_OP_RESET    1
+#define CONCURRENCYLAB_OP_RUN      2
+#define CONCURRENCYLAB_OP_SNAPSHOT 3
+#define CONCURRENCYLAB_OP_CLOSE    4
+
+/** 描述一个实验参与者对共享计数器执行读—改—写时留下的结构化轨迹。 */
+struct concurrencylab_worker_snapshot {
+  int role;
+  int observed;
+  int written;
+  int read_order;
+  int write_order;
+  int read_cpu;
+  int write_cpu;
+};
+
+/** 描述一次两参与者并发实验完成后的共享状态与顺序证据。 */
+struct concurrencylab_snapshot {
+  int session;
+  int mode;
+  int configured_cpus;
+  int active;
+  int completed;
+  int counter;
+  struct concurrencylab_worker_snapshot workers[CONCURRENCYLAB_PARTICIPANTS];
+};
+
+#endif

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -6,6 +6,9 @@
 
 volatile static int started = 0;
 
+// 并发入门探针由 spinlock.c 持有，只在启动 CPU 上初始化一次。
+extern void concurrencylab_init(void);
+
 // start() jumps here in supervisor mode on all CPUs.
 void
 main()
@@ -30,6 +33,7 @@ main()
     binit();         // buffer cache
     iinit();         // inode cache
     fileinit();      // file table
+    concurrencylab_init(); // explicit, inactive teaching probe
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process
     vma_init();

--- a/kernel/spinlock.c
+++ b/kernel/spinlock.c
@@ -6,6 +6,7 @@
 #include "spinlock.h"
 #include "riscv.h"
 #include "proc.h"
+#include "concurrencylab.h"
 #include "defs.h"
 
 void
@@ -107,4 +108,366 @@ pop_off(void)
   c->noff -= 1;
   if(c->noff == 0 && c->intena)
     intr_on();
+}
+
+/*
+ * 并发入门教学探针
+ *
+ * 该探针和自旋锁实现放在同一编译单元，只为直接复用本文件定义的互斥原语，避免
+ * 修改教学内核的链接清单。它由显式系统调用会话启用，关闭后不参与正常内核路径。
+ */
+
+/**
+ * 保存并发入门实验的唯一活动会话。
+ *
+ * control_lock 保护会话生命周期、轨迹和屏障；counter_lock 只在受保护模式中
+ * 把共享计数器的完整读—改—写串行化。RACY 模式故意不使用 counter_lock，
+ * 但仍使用原子单次读写避免把 C 数据竞争本身当成实验前提。
+ */
+static struct {
+  struct spinlock control_lock;
+  struct spinlock counter_lock;
+  int active;
+  int session;
+  int mode;
+  int counter;
+  int started[CONCURRENCYLAB_PARTICIPANTS];
+  int barrier_arrived;
+  int barrier_generation;
+  int completed;
+  int event_order;
+  struct concurrencylab_worker_snapshot workers[CONCURRENCYLAB_PARTICIPANTS];
+} concurrencylab;
+
+/** 初始化教学探针的锁和空闲会话状态。 */
+void
+concurrencylab_init(void)
+{
+  initlock(&concurrencylab.control_lock, "concurrencylab");
+  initlock(&concurrencylab.counter_lock, "concurrencycounter");
+  concurrencylab.active = 0;
+  concurrencylab.session = 0;
+}
+
+/**
+ * 判断会话编号是否仍指向当前活动实验。
+ *
+ * @param session 用户态在 RESET 时取得的正整数会话编号。
+ * @return 当前活动会话匹配时返回 1，否则返回 0。
+ *
+ * 调用方必须持有 control_lock。
+ */
+static int
+session_matches(int session)
+{
+  return concurrencylab.active && session > 0 && concurrencylab.session == session;
+}
+
+/**
+ * 清空一次实验的可观察状态，同时保留已经初始化的两把锁。
+ *
+ * @param mode CONCURRENCYLAB_MODE_RACY 或 CONCURRENCYLAB_MODE_LOCKED。
+ *
+ * 调用方必须持有 control_lock，且已经确认没有其他活动会话。
+ */
+static void
+reset_state(int mode)
+{
+  concurrencylab.mode = mode;
+  concurrencylab.counter = 0;
+  concurrencylab.barrier_arrived = 0;
+  concurrencylab.barrier_generation++;
+  concurrencylab.completed = 0;
+  concurrencylab.event_order = 0;
+  memset(concurrencylab.started, 0, sizeof(concurrencylab.started));
+  memset(concurrencylab.workers, 0, sizeof(concurrencylab.workers));
+  for(int role = 0; role < CONCURRENCYLAB_PARTICIPANTS; role++){
+    concurrencylab.workers[role].role = role;
+    concurrencylab.workers[role].read_cpu = -1;
+    concurrencylab.workers[role].write_cpu = -1;
+  }
+}
+
+/**
+ * 创建一个尚未运行参与者的教学实验会话。
+ *
+ * @param mode 指定无锁复合更新或自旋锁保护的复合更新。
+ * @return 成功返回新的正整数会话编号；模式非法或已有活动会话时返回 -1。
+ */
+static int
+start_session(int mode)
+{
+  int session;
+
+  if(mode != CONCURRENCYLAB_MODE_RACY && mode != CONCURRENCYLAB_MODE_LOCKED)
+    return -1;
+
+  acquire(&concurrencylab.control_lock);
+  if(concurrencylab.active){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+
+  concurrencylab.session++;
+  if(concurrencylab.session <= 0)
+    concurrencylab.session = 1;
+  reset_state(mode);
+  concurrencylab.active = 1;
+  session = concurrencylab.session;
+  release(&concurrencylab.control_lock);
+  return session;
+}
+
+/**
+ * 在 RACY 模式中等待两个参与者都完成共享值读取。
+ *
+ * @param session 当前活动会话编号。
+ * @return 两个参与者均到达时返回 0；会话在等待期间被关闭时返回 -1。
+ *
+ * 调用方进入和返回时都持有 control_lock。屏障只固定“两个读取都先于任一写入”
+ * 这一竞争窗口，不规定两个参与者各自的先后次序或所在 CPU。
+ */
+static int
+wait_for_both_reads(int session)
+{
+  int generation = concurrencylab.barrier_generation;
+
+  concurrencylab.barrier_arrived++;
+  if(concurrencylab.barrier_arrived == CONCURRENCYLAB_PARTICIPANTS){
+    concurrencylab.barrier_arrived = 0;
+    concurrencylab.barrier_generation++;
+    wakeup(&concurrencylab.barrier_generation);
+    return 0;
+  }
+
+  while(session_matches(session) &&
+        concurrencylab.barrier_generation == generation)
+    sleep(&concurrencylab.barrier_generation, &concurrencylab.control_lock);
+
+  return session_matches(session) ? 0 : -1;
+}
+
+/**
+ * 执行一次被刻意拆开的无锁共享计数器更新。
+ *
+ * @param session 当前活动会话编号。
+ * @param role 两个唯一参与者之一，取值为 0 或 1。
+ * @param result 接收当前参与者完成后的结构化轨迹。
+ * @return 完整执行并记录轨迹时返回 0；会话、模式、角色或生命周期非法时返回 -1。
+ *
+ * 两个参与者先各自读取 0，再越过屏障并分别写入 1，因此最终值稳定为 1。
+ * 该路径用原子单次 load/store 排除未定义的撕裂访问，但没有把两次访问组合成
+ * 原子读—改—写，正好保留 lost update 所需的竞态窗口。
+ */
+static int
+run_racy_worker(int session, int role,
+                struct concurrencylab_worker_snapshot *result)
+{
+  int observed;
+
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session) ||
+     concurrencylab.mode != CONCURRENCYLAB_MODE_RACY ||
+     role < 0 || role >= CONCURRENCYLAB_PARTICIPANTS ||
+     concurrencylab.started[role]){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+
+  concurrencylab.started[role] = 1;
+  observed = __atomic_load_n(&concurrencylab.counter, __ATOMIC_RELAXED);
+  concurrencylab.workers[role].observed = observed;
+  concurrencylab.workers[role].read_order = ++concurrencylab.event_order;
+  concurrencylab.workers[role].read_cpu = cpuid();
+
+  if(wait_for_both_reads(session) < 0){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+  release(&concurrencylab.control_lock);
+
+  __atomic_store_n(&concurrencylab.counter, observed + 1, __ATOMIC_RELAXED);
+
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session) || concurrencylab.mode != CONCURRENCYLAB_MODE_RACY){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+  concurrencylab.workers[role].written = observed + 1;
+  concurrencylab.workers[role].write_order = ++concurrencylab.event_order;
+  concurrencylab.workers[role].write_cpu = cpuid();
+  concurrencylab.completed++;
+  *result = concurrencylab.workers[role];
+  release(&concurrencylab.control_lock);
+  return 0;
+}
+
+/**
+ * 在自旋锁保护下执行一次完整共享计数器更新。
+ *
+ * @param session 当前活动会话编号。
+ * @param role 两个唯一参与者之一，取值为 0 或 1。
+ * @param result 接收当前参与者完成后的结构化轨迹。
+ * @return 完整执行并记录轨迹时返回 0；会话、模式、角色或生命周期非法时返回 -1。
+ *
+ * counter_lock 覆盖读取、计算和写回的完整临界区；control_lock 仅在内部记录轨迹。
+ * 所有调用都按 counter_lock → control_lock 的固定顺序加锁，避免教学探针自身引入
+ * 反向加锁死锁。
+ */
+static int
+run_locked_worker(int session, int role,
+                  struct concurrencylab_worker_snapshot *result)
+{
+  int observed;
+
+  acquire(&concurrencylab.counter_lock);
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session) ||
+     concurrencylab.mode != CONCURRENCYLAB_MODE_LOCKED ||
+     role < 0 || role >= CONCURRENCYLAB_PARTICIPANTS ||
+     concurrencylab.started[role]){
+    release(&concurrencylab.control_lock);
+    release(&concurrencylab.counter_lock);
+    return -1;
+  }
+
+  concurrencylab.started[role] = 1;
+  observed = concurrencylab.counter;
+  concurrencylab.workers[role].observed = observed;
+  concurrencylab.workers[role].read_order = ++concurrencylab.event_order;
+  concurrencylab.workers[role].read_cpu = cpuid();
+
+  concurrencylab.counter = observed + 1;
+  concurrencylab.workers[role].written = observed + 1;
+  concurrencylab.workers[role].write_order = ++concurrencylab.event_order;
+  concurrencylab.workers[role].write_cpu = cpuid();
+  concurrencylab.completed++;
+  *result = concurrencylab.workers[role];
+
+  release(&concurrencylab.control_lock);
+  release(&concurrencylab.counter_lock);
+  return 0;
+}
+
+/**
+ * 按活动会话模式分派一个参与者的读—改—写操作。
+ *
+ * @param session 当前活动会话编号。
+ * @param role 参与者角色，必须为 0 或 1 且只能运行一次。
+ * @param result 接收结构化轨迹。
+ * @return 参与者成功完成返回 0，否则返回 -1。
+ */
+static int
+run_worker(int session, int role, struct concurrencylab_worker_snapshot *result)
+{
+  int mode;
+
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session)){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+  mode = concurrencylab.mode;
+  release(&concurrencylab.control_lock);
+
+  if(mode == CONCURRENCYLAB_MODE_RACY)
+    return run_racy_worker(session, role, result);
+  if(mode == CONCURRENCYLAB_MODE_LOCKED)
+    return run_locked_worker(session, role, result);
+  return -1;
+}
+
+/**
+ * 读取一个已经完成两个参与者的活动会话快照。
+ *
+ * @param session 当前活动会话编号。
+ * @param snapshot 接收共享终值和两条参与者轨迹。
+ * @return 两个参与者都完成时返回 0；过早读取或会话失效时返回 -1。
+ */
+static int
+snapshot_session(int session, struct concurrencylab_snapshot *snapshot)
+{
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session) ||
+     concurrencylab.completed != CONCURRENCYLAB_PARTICIPANTS){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+
+  snapshot->session = concurrencylab.session;
+  snapshot->mode = concurrencylab.mode;
+  snapshot->configured_cpus = XV6_CPUS;
+  snapshot->active = concurrencylab.active;
+  snapshot->completed = concurrencylab.completed;
+  snapshot->counter = __atomic_load_n(&concurrencylab.counter, __ATOMIC_RELAXED);
+  for(int role = 0; role < CONCURRENCYLAB_PARTICIPANTS; role++)
+    snapshot->workers[role] = concurrencylab.workers[role];
+  release(&concurrencylab.control_lock);
+  return 0;
+}
+
+/**
+ * 关闭活动会话并唤醒可能仍停在教学屏障上的参与者。
+ *
+ * @param session 当前活动会话编号。
+ * @return 成功关闭返回 0；会话不存在或编号过期时返回 -1。
+ */
+static int
+close_session(int session)
+{
+  acquire(&concurrencylab.control_lock);
+  if(!session_matches(session)){
+    release(&concurrencylab.control_lock);
+    return -1;
+  }
+  concurrencylab.active = 0;
+  concurrencylab.barrier_generation++;
+  wakeup(&concurrencylab.barrier_generation);
+  release(&concurrencylab.control_lock);
+  return 0;
+}
+
+/**
+ * 暴露并发入门教学探针的会话式系统调用。
+ *
+ * RESET: arg0=mode，返回正 session；RUN: arg0=session、arg1=role，并复制 worker；
+ * SNAPSHOT: arg0=session，并复制完整 snapshot；CLOSE: arg0=session。
+ *
+ * @return 各操作的成功值；参数、会话、用户地址或状态非法时返回 -1。
+ */
+uint64
+sys_concurrencylab(void)
+{
+  int op;
+  int arg0;
+  int arg1;
+  uint64 user_result;
+  struct proc *p = myproc();
+
+  argint(0, &op);
+  argint(1, &arg0);
+  argint(2, &arg1);
+  argaddr(3, &user_result);
+
+  if(op == CONCURRENCYLAB_OP_RESET)
+    return start_session(arg0);
+  if(op == CONCURRENCYLAB_OP_RUN){
+    struct concurrencylab_worker_snapshot worker;
+    if(run_worker(arg0, arg1, &worker) < 0)
+      return -1;
+    if(copyout(p->pagetable, user_result, (char *)&worker, sizeof(worker)) < 0)
+      return -1;
+    return 0;
+  }
+  if(op == CONCURRENCYLAB_OP_SNAPSHOT){
+    struct concurrencylab_snapshot snapshot;
+    if(snapshot_session(arg0, &snapshot) < 0)
+      return -1;
+    if(copyout(p->pagetable, user_result, (char *)&snapshot, sizeof(snapshot)) < 0)
+      return -1;
+    return 0;
+  }
+  if(op == CONCURRENCYLAB_OP_CLOSE)
+    return close_session(arg0);
+  return -1;
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -145,6 +145,7 @@ extern uint64 sys_tcsetpgrp(void);
 extern uint64 sys_getprocs(void);
 extern uint64 sys_swapout(void);
 extern uint64 sys_swapinfo(void);
+extern uint64 sys_concurrencylab(void);
 
 static uint64 (*syscalls[])(void) = {
 [SYS_fork]    sys_fork,
@@ -194,6 +195,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_getprocs]         sys_getprocs,
 [SYS_swapout]          sys_swapout,
 [SYS_swapinfo]         sys_swapinfo,
+[SYS_concurrencylab]   sys_concurrencylab,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -46,3 +46,4 @@
 #define SYS_getprocs         45
 #define SYS_swapout          46
 #define SYS_swapinfo         47
+#define SYS_concurrencylab   48

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -52,6 +52,7 @@ static const char *const syscall_names[] = {
 [SYS_getprocs]         = "getprocs",
 [SYS_swapout]          = "swapout",
 [SYS_swapinfo]         = "swapinfo",
+[SYS_concurrencylab]   = "concurrencylab",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/tests/guest/uthreadtest.c
+++ b/tests/guest/uthreadtest.c
@@ -1,24 +1,20 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "kernel/concurrencylab.h"
 #include "user/user.h"
 #include "user/paths.h"
 #include "tests/guest/testlib.h"
 
 #define OUTPUT_SIZE 4096
+#define CONCURRENCY_ROUNDS 2
 
 /**
  * 执行可抢占 uthread 用户程序，并验证线程 API 与调度生命周期闭环。
  *
- * 子程序必须正常退出，同时输出八条稳定结果：工作线程与主线程共享地址空间和
- * PID；入口参数按借用指针传递；self/duplicate/invalid join 明确失败；两个线程
- * 使用不同栈且局部状态跨切换保持；不主动 yield 的线程仍可抢占；16 个工作槽位
- * 可用且第 17 次创建失败；退出槽位可连续三轮复用；最终主线程能够正常收尾。
- * 完整输出检查可避免只完成部分阶段的假阳性。
- *
- * @return 本函数通过 exit() 返回：全部结果符合预期为 0，否则为 1。
+ * @return 完整输出和退出状态均符合预期返回 0，否则返回 -1。
  */
-int
-main(void)
+static int
+run_uthread_regression(void)
 {
   char *argv[] = {XV6_USR_BIN_PATH("uthread"), 0};
   char *output = malloc(OUTPUT_SIZE);
@@ -26,12 +22,12 @@ main(void)
 
   if(output == 0){
     printf("uthreadtest: malloc failed\n");
-    exit(1);
+    return -1;
   }
   if(xv6_test_run_capture(argv, 0, output, OUTPUT_SIZE, &status) < 0){
     printf("uthreadtest: capture infrastructure failed\n");
     free(output);
-    exit(1);
+    return -1;
   }
 
   if(status != 0 ||
@@ -45,10 +41,389 @@ main(void)
      !xv6_test_contains(output, "uthread: all tests OK\n")){
     printf("uthreadtest: unexpected scheduling result status=%d\n%s", status, output);
     free(output);
-    exit(1);
+    return -1;
   }
 
   free(output);
+  printf("uthreadtest: preemptive runtime OK\n");
+  return 0;
+}
+
+/** 读取恰好 n 个字节，避免 pipe 短读把不完整轨迹误判为有效结果。 */
+static int
+read_full(int fd, void *buffer, int n)
+{
+  int offset = 0;
+
+  while(offset < n){
+    int received = read(fd, (char *)buffer + offset, n - offset);
+    if(received <= 0)
+      return -1;
+    offset += received;
+  }
+  return 0;
+}
+
+/** 写入恰好 n 个字节，保证子进程的结构化轨迹完整交给父进程。 */
+static int
+write_full(int fd, void *buffer, int n)
+{
+  int offset = 0;
+
+  while(offset < n){
+    int written = write(fd, (char *)buffer + offset, n - offset);
+    if(written <= 0)
+      return -1;
+    offset += written;
+  }
+  return 0;
+}
+
+/**
+ * 创建一个只执行指定实验角色的子进程。
+ *
+ * @param session 活动教学会话编号。
+ * @param role 唯一角色 0 或 1。
+ * @param pid_out 接收子进程 PID。
+ * @param read_fd_out 接收父进程读取结构化轨迹的 pipe 端点。
+ * @return 创建完成返回 0；pipe 或 fork 失败返回 -1。
+ */
+static int
+start_worker(int session, int role, int *pid_out, int *read_fd_out)
+{
+  int fds[2];
+  int pid;
+
+  if(pipe(fds) < 0)
+    return -1;
+  pid = fork();
+  if(pid < 0){
+    close(fds[0]);
+    close(fds[1]);
+    return -1;
+  }
+  if(pid == 0){
+    struct concurrencylab_worker_snapshot worker;
+
+    close(fds[0]);
+    if(concurrencylab(CONCURRENCYLAB_OP_RUN, session, role, &worker) < 0 ||
+       write_full(fds[1], &worker, sizeof(worker)) < 0){
+      close(fds[1]);
+      exit(1);
+    }
+    close(fds[1]);
+    exit(0);
+  }
+
+  close(fds[1]);
+  *pid_out = pid;
+  *read_fd_out = fds[0];
+  return 0;
+}
+
+/**
+ * 在父进程错误路径上关闭会话并回收已经创建的工作进程。
+ *
+ * @param session 需要取消的活动会话编号。
+ * @param pids 已创建的 PID 数组。
+ * @param read_fds 父进程持有的 pipe 读取端数组。
+ * @param count 数组中有效元素数量。
+ */
+static void
+abort_workers(int session, int *pids, int *read_fds, int count)
+{
+  concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+  for(int i = 0; i < count; i++){
+    if(read_fds[i] >= 0)
+      close(read_fds[i]);
+    if(pids[i] > 0)
+      kill(pids[i]);
+  }
+  for(int i = 0; i < count; i++){
+    if(pids[i] > 0)
+      waitpid(pids[i], 0, 0);
+  }
+}
+
+/** 判断子进程返回的参与者轨迹是否与内核会话快照完全一致。 */
+static int
+worker_matches(struct concurrencylab_worker_snapshot *left,
+               struct concurrencylab_worker_snapshot *right)
+{
+  return left->role == right->role &&
+         left->observed == right->observed &&
+         left->written == right->written &&
+         left->read_order == right->read_order &&
+         left->write_order == right->write_order &&
+         left->read_cpu == right->read_cpu &&
+         left->write_cpu == right->write_cpu;
+}
+
+/**
+ * 验证两种模式共用的会话、角色、CPU 范围和结果传递不变量。
+ *
+ * @return 所有公共不变量成立返回 0，否则打印具体字段并返回 -1。
+ */
+static int
+validate_common(int session, int mode,
+                struct concurrencylab_worker_snapshot *workers,
+                struct concurrencylab_snapshot *snapshot)
+{
+  if(snapshot->session != session || snapshot->mode != mode ||
+     snapshot->configured_cpus != XV6_CPUS || snapshot->active != 1 ||
+     snapshot->completed != CONCURRENCYLAB_PARTICIPANTS){
+    printf("uthreadtest: common state session=%d/%d mode=%d/%d cpus=%d/%d active=%d completed=%d\n",
+           snapshot->session, session, snapshot->mode, mode,
+           snapshot->configured_cpus, XV6_CPUS, snapshot->active,
+           snapshot->completed);
+    return -1;
+  }
+
+  for(int role = 0; role < CONCURRENCYLAB_PARTICIPANTS; role++){
+    if(workers[role].role != role ||
+       !worker_matches(&workers[role], &snapshot->workers[role]) ||
+       workers[role].read_cpu < 0 || workers[role].read_cpu >= XV6_CPUS ||
+       workers[role].write_cpu < 0 || workers[role].write_cpu >= XV6_CPUS){
+      printf("uthreadtest: worker mismatch role=%d child_role=%d read_cpu=%d write_cpu=%d\n",
+             role, workers[role].role,
+             workers[role].read_cpu, workers[role].write_cpu);
+      return -1;
+    }
+    if(XV6_CPUS == 1 &&
+       (workers[role].read_cpu != 0 || workers[role].write_cpu != 0)){
+      printf("uthreadtest: single cpu mismatch role=%d read_cpu=%d write_cpu=%d\n",
+             role, workers[role].read_cpu, workers[role].write_cpu);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * 验证 RACY 模式固定两个读取先发生、两个写入都覆盖为 1 的 lost update。
+ *
+ * @return 竞争窗口和最终计数器均符合实验契约返回 0，否则返回 -1。
+ */
+static int
+validate_racy(struct concurrencylab_worker_snapshot *workers,
+              struct concurrencylab_snapshot *snapshot)
+{
+  int read_sum = workers[0].read_order + workers[1].read_order;
+  int read_product = workers[0].read_order * workers[1].read_order;
+  int write_sum = workers[0].write_order + workers[1].write_order;
+  int write_product = workers[0].write_order * workers[1].write_order;
+
+  if(workers[0].observed != 0 || workers[1].observed != 0 ||
+     workers[0].written != 1 || workers[1].written != 1 ||
+     snapshot->counter != 1 || read_sum != 3 || read_product != 2 ||
+     write_sum != 7 || write_product != 12){
+    printf("uthreadtest: racy mismatch observed=%d,%d written=%d,%d final=%d order=%d/%d,%d/%d\n",
+           workers[0].observed, workers[1].observed,
+           workers[0].written, workers[1].written, snapshot->counter,
+           workers[0].read_order, workers[0].write_order,
+           workers[1].read_order, workers[1].write_order);
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * 验证 LOCKED 模式把两个临界区串行化为 0→1 和 1→2。
+ *
+ * @param first_role 接收首先取得 counter_lock 的角色编号。
+ * @return 顺序、计数和临界区边界全部成立返回 0，否则返回 -1。
+ */
+static int
+validate_locked(struct concurrencylab_worker_snapshot *workers,
+                struct concurrencylab_snapshot *snapshot, int *first_role)
+{
+  int first = workers[0].observed == 0 ? 0 : 1;
+  int second = 1 - first;
+
+  if(snapshot->counter != 2 ||
+     workers[first].observed != 0 || workers[first].written != 1 ||
+     workers[first].read_order != 1 || workers[first].write_order != 2 ||
+     workers[second].observed != 1 || workers[second].written != 2 ||
+     workers[second].read_order != 3 || workers[second].write_order != 4){
+    printf("uthreadtest: locked mismatch first=%d observed=%d,%d written=%d,%d final=%d order=%d/%d,%d/%d\n",
+           first, workers[0].observed, workers[1].observed,
+           workers[0].written, workers[1].written, snapshot->counter,
+           workers[0].read_order, workers[0].write_order,
+           workers[1].read_order, workers[1].write_order);
+    return -1;
+  }
+  *first_role = first;
+  return 0;
+}
+
+/**
+ * 执行一次完整会话，覆盖前置拒绝、两个参与者、快照、关闭和过期句柄。
+ *
+ * @param mode RACY 或 LOCKED。
+ * @param round 从 1 开始的重复轮次，仅用于稳定输出。
+ * @param session_out 接收本轮会话编号，供主函数验证生命周期单调前进。
+ * @return 全部断言通过返回 0；任一创建、退出状态或行为断言失败返回 -1。
+ */
+static int
+run_concurrency_round(int mode, int round, int *session_out)
+{
+  int session;
+  int pids[CONCURRENCYLAB_PARTICIPANTS] = {-1, -1};
+  int read_fds[CONCURRENCYLAB_PARTICIPANTS] = {-1, -1};
+  int statuses[CONCURRENCYLAB_PARTICIPANTS] = {-1, -1};
+  int active_reset;
+  int premature_snapshot;
+  int invalid_role;
+  int stale_snapshot;
+  int duplicate_close;
+  int first_role = -1;
+  struct concurrencylab_worker_snapshot workers[CONCURRENCYLAB_PARTICIPANTS];
+  struct concurrencylab_worker_snapshot invalid_worker;
+  struct concurrencylab_snapshot snapshot;
+
+  session = concurrencylab(CONCURRENCYLAB_OP_RESET, mode, 0, 0);
+  if(session <= 0){
+    printf("uthreadtest: reset failed mode=%d session=%d\n", mode, session);
+    return -1;
+  }
+
+  active_reset = concurrencylab(CONCURRENCYLAB_OP_RESET, mode, 0, 0);
+  premature_snapshot = concurrencylab(CONCURRENCYLAB_OP_SNAPSHOT,
+                                      session, 0, &snapshot);
+  invalid_role = concurrencylab(CONCURRENCYLAB_OP_RUN,
+                                session, CONCURRENCYLAB_PARTICIPANTS,
+                                &invalid_worker);
+  if(active_reset != -1 || premature_snapshot != -1 || invalid_role != -1){
+    printf("uthreadtest: negative precondition active_reset=%d premature_snapshot=%d invalid_role=%d\n",
+           active_reset, premature_snapshot, invalid_role);
+    concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+    return -1;
+  }
+
+  if(start_worker(session, 0, &pids[0], &read_fds[0]) < 0){
+    concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+    return -1;
+  }
+  if(start_worker(session, 1, &pids[1], &read_fds[1]) < 0){
+    abort_workers(session, pids, read_fds, 1);
+    return -1;
+  }
+
+  for(int role = 0; role < CONCURRENCYLAB_PARTICIPANTS; role++){
+    if(read_full(read_fds[role], &workers[role], sizeof(workers[role])) < 0){
+      abort_workers(session, pids, read_fds, CONCURRENCYLAB_PARTICIPANTS);
+      return -1;
+    }
+    close(read_fds[role]);
+    read_fds[role] = -1;
+  }
+  for(int role = 0; role < CONCURRENCYLAB_PARTICIPANTS; role++){
+    int waited = waitpid(pids[role], &statuses[role], 0);
+    if(waited != pids[role] || statuses[role] != 0){
+      printf("uthreadtest: wait mismatch role=%d expected=%d actual=%d status=%d\n",
+             role, pids[role], waited, statuses[role]);
+      concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+      return -1;
+    }
+    pids[role] = -1;
+  }
+
+  if(concurrencylab(CONCURRENCYLAB_OP_SNAPSHOT, session, 0, &snapshot) < 0 ||
+     validate_common(session, mode, workers, &snapshot) < 0){
+    concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+    return -1;
+  }
+  if(mode == CONCURRENCYLAB_MODE_RACY){
+    if(validate_racy(workers, &snapshot) < 0){
+      concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+      return -1;
+    }
+  } else if(validate_locked(workers, &snapshot, &first_role) < 0){
+    concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+    return -1;
+  }
+
+  if(concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0) < 0)
+    return -1;
+  stale_snapshot = concurrencylab(CONCURRENCYLAB_OP_SNAPSHOT,
+                                  session, 0, &snapshot);
+  duplicate_close = concurrencylab(CONCURRENCYLAB_OP_CLOSE, session, 0, 0);
+  if(stale_snapshot != -1 || duplicate_close != -1){
+    printf("uthreadtest: negative lifecycle stale_snapshot=%d duplicate_close=%d\n",
+           stale_snapshot, duplicate_close);
+    return -1;
+  }
+
+  if(mode == CONCURRENCYLAB_MODE_RACY){
+    printf("CONCURRENCY RACY round=%d cpus=%d session=%d read_cpu=%d,%d write_cpu=%d,%d order=%d/%d,%d/%d final=1 lost_update=1\n",
+           round, XV6_CPUS, session,
+           workers[0].read_cpu, workers[1].read_cpu,
+           workers[0].write_cpu, workers[1].write_cpu,
+           workers[0].read_order, workers[0].write_order,
+           workers[1].read_order, workers[1].write_order);
+  } else {
+    printf("CONCURRENCY LOCKED round=%d cpus=%d session=%d first_role=%d read_cpu=%d,%d write_cpu=%d,%d order=%d/%d,%d/%d final=2 atomic=1\n",
+           round, XV6_CPUS, session, first_role,
+           workers[0].read_cpu, workers[1].read_cpu,
+           workers[0].write_cpu, workers[1].write_cpu,
+           workers[0].read_order, workers[0].write_order,
+           workers[1].read_order, workers[1].write_order);
+  }
+  printf("CONCURRENCY NEGATIVE round=%d active_reset=-1 premature_snapshot=-1 invalid_role=-1 stale_snapshot=-1 duplicate_close=-1\n",
+         round);
+  *session_out = session;
+  return 0;
+}
+
+/**
+ * 重复运行无锁和加锁会话，验证结果、负向 oracle 与资源复用。
+ *
+ * @return 四轮会话全部通过且 session 单调增长返回 0，否则返回 -1。
+ */
+static int
+run_concurrency_regression(void)
+{
+  int previous_session = 0;
+  int session = -1;
+
+  if(concurrencylab(CONCURRENCYLAB_OP_RESET, 99, 0, 0) != -1){
+    printf("uthreadtest: invalid mode accepted\n");
+    return -1;
+  }
+
+  for(int round = 1; round <= CONCURRENCY_ROUNDS; round++){
+    session = -1;
+    if(run_concurrency_round(CONCURRENCYLAB_MODE_RACY, round, &session) < 0 ||
+       session <= previous_session){
+      printf("uthreadtest: racy FAILED round=%d session=%d previous=%d\n",
+             round, session, previous_session);
+      return -1;
+    }
+    previous_session = session;
+  }
+  for(int round = 1; round <= CONCURRENCY_ROUNDS; round++){
+    session = -1;
+    if(run_concurrency_round(CONCURRENCYLAB_MODE_LOCKED, round, &session) < 0 ||
+       session <= previous_session){
+      printf("uthreadtest: locked FAILED round=%d session=%d previous=%d\n",
+             round, session, previous_session);
+      return -1;
+    }
+    previous_session = session;
+  }
+
+  printf("uthreadtest: concurrency intro OK rounds=%d sessions=%d\n",
+         CONCURRENCY_ROUNDS * 2, previous_session);
+  return 0;
+}
+
+/** 运行用户线程调度与共享状态原子性两组并发回归。 */
+int
+main(void)
+{
+  if(run_uthread_regression() < 0 || run_concurrency_regression() < 0)
+    exit(1);
+
   printf("uthreadtest: OK\n");
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -74,6 +74,17 @@ int sched_get_stats(struct sched_stats *stats);
 int schedtrace(int op, struct schedtrace_snapshot *snapshot, int arg);
 
 /**
+ * 驱动显式启用的并发入门教学会话。
+ *
+ * @param op kernel/concurrencylab.h 定义的 RESET、RUN、SNAPSHOT 或 CLOSE。
+ * @param arg0 RESET 时为模式，其他操作时为会话编号。
+ * @param arg1 RUN 时为唯一参与者角色，其他操作忽略。
+ * @param result RUN 或 SNAPSHOT 的用户态输出缓冲区；其他操作可传 0。
+ * @return RESET 成功返回正会话编号；其他操作成功返回 0；失败返回 -1。
+ */
+int concurrencylab(int op, int arg0, int arg1, void *result);
+
+/**
  * Explicitly move one current-process anonymous user page to the teaching
  * swap backing file. This exposes mechanism only; no automatic replacement
  * policy is implied.

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -61,3 +61,4 @@ entry("tcsetpgrp");
 entry("getprocs");
 entry("swapout");
 entry("swapinfo");
+entry("concurrencylab");


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #147
- 对应笔记 Issue：mental1104/Obsidian#219
- 基线 Commit：`6c76f76d4cf53676f269e9a1e25b5aa147b99115`
- 验证 Head：`c724164804c4e3e87cabab81d166186a169fad91`
- 变更类型：教学实验 / 系统调用 / guest 回归
- 影响范围：`spinlock`、系统调用分派、`uthreadtest` 并发回归、聚焦单核 CI
- 一句话摘要：用两个 xv6 进程稳定复现 lost update，并以同一共享状态上的自旋锁路径证明完整读—改—写临界区恢复确定性。

## 实现了什么

- 新增显式启用、会话式的 `concurrencylab` 教学接口；正常内核路径不主动进入该探针，`CLOSE` 后会话失效并可重复初始化。
- RACY 路径使用 `sleep/wakeup` 屏障固定“两个读取都先于任一写入”的竞争窗口：两个参与者分别读取 `0`、分别写入 `1`，最终稳定得到 `1`，不依赖偶然调度命中。
- LOCKED 路径使用 `counter_lock` 覆盖完整读—改—写临界区，轨迹只能形成 `0→1`、`1→2` 两段连续状态转换，最终稳定得到 `2`。
- 结构化快照记录参与者角色、观察值、写入值、事件顺序和读写 CPU；默认多核不强迫两个进程落在不同 CPU，`CPUS=1` 用于证明单核调度交错同样足以触发 lost update。
- 复用现有 `lab7-uthread` guest 入口和统一 runner，不新增独立测试协议或宿主机业务正则。
- CI 在默认 `CPUS=3` 回归之后执行干净的 `CPUS=1` 重建，避免编译期 `XV6_CPUS` 被旧内核产物污染。

## 添加/修改了什么单元测试

| 测试用例 | 覆盖场景 | 核心断言 |
|---|---|---|
| `lab7-uthread / RACY` | 两个进程先读取、后覆盖同一计数器 | 两条轨迹均为 `0→1`，读取事件为 `{1,2}`、写入事件为 `{3,4}`，最终值必须为 `1` |
| `lab7-uthread / LOCKED` | 自旋锁保护完整复合更新 | 两个临界区必须连续形成 `0→1` 与 `1→2`，事件顺序为 `1/2`、`3/4`，最终值必须为 `2` |
| `lab7-uthread / negative oracle` | 活动会话重置、过早快照、非法角色、过期会话、重复关闭 | 五类非法操作全部返回 `-1`，不得提前发布成功快照或复用旧 session |
| `lab7-uthread / repeatability` | RACY 与 LOCKED 各重复两轮 | 四个 session 严格递增，证明关闭和资源复用路径可重复执行 |
| `lab7-uthread / CPU boundary` | 默认多核与 `CPUS=1` | CPU 编号必须位于构建范围；单核构建所有读写 CPU 必须为 `0`，但 lost update oracle 保持不变 |

## 如何通过 CLI 回归观察此 PR 现象

```bash
make clean
make
make test-suite SUITE=lab7-thread CPUS=3
make clean
make -j2 CPUS=1
make test-suite SUITE=lab7-thread CPUS=1
```

也可进入 QEMU 后只运行聚焦 guest 用例：

```text
/usr/bin/xv6test --run lab7-uthread
```

稳定 oracle：

```text
CONCURRENCY RACY ... final=1 lost_update=1
CONCURRENCY LOCKED ... final=2 atomic=1
CONCURRENCY NEGATIVE ... active_reset=-1 ... duplicate_close=-1
uthreadtest: concurrency intro OK rounds=4 ...
XV6TEST done status=0
```

事件中哪个角色先读、先取得锁以及多核下实际 CPU 编号允许变化；共享终值、事件集合和负向 oracle 不允许变化。

## 自动化测试结果

GitHub Actions `xv6 CI` run `30165542133`：成功。

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `make clean && make -j2` | PASS | `Build xv6` 成功，真实 RISC-V 交叉编译完成 |
| selected PR suites，`CPUS=3` | PASS | `Run selected PR QEMU regression` 成功；包含 `lab7-thread` |
| 干净重建 `make -j2 CPUS=1` + `lab7-thread` | PASS | `Run concurrency regression single-core` 成功 |
| `lab-vm CPUS=1` | PASS | `Run VM regression single-core` 成功，未破坏相邻 VM 回归 |
| runner 单元测试 | PASS | `Unit-test regression grader` 成功 |
| `uthread debug` run `30165542121` | PASS | 用户线程专项回归成功 |

第一次单核 CI 尝试曾复用默认三核构建产物，结构化快照正确报告 `configured_cpus=3/1` 并令测试失败；本 PR 已改为 `make clean` 后显式以 `CPUS=1` 重建。该失败属于验证环境污染，已由当前成功 run 闭环。

## Review 主线

1. `kernel/concurrencylab.h`：会话操作、两种模式和结构化轨迹契约。
2. `kernel/spinlock.c::run_racy_worker` 与 `wait_for_both_reads`：屏障只固定两个读取先发生，单次原子 load/store 不等于原子复合更新。
3. `kernel/spinlock.c::run_locked_worker`：`counter_lock → control_lock` 固定加锁顺序与完整临界区边界。
4. 系统调用分派与用户桩：编号 `48`，保留当前主线的 swap 调用 `46/47`。
5. `tests/guest/uthreadtest.c` 与 CI：RACY、LOCKED、negative oracle、重复执行、默认多核和单核边界。