### PR TITLE
[Concept Lab] 实体化：文件系统实现

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
           else
             echo 'concurrency_single_core=false' >> "$GITHUB_OUTPUT"
           fi
+          if grep -Eq '^(kernel/(bio\.c|file\.c|fs\.c|fs\.h|fsinspect\.c|fsinspect\.h|log\.c|sysfile\.c|sysfsinspect\.c|virtio_disk\.c)|mkfs/mkfs\.c|tests/guest/fileapitest\.c)$' /tmp/changed-files.txt; then
+            echo 'filesystem=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'filesystem=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run shell history interaction regression
         if: >-
@@ -109,6 +114,20 @@ jobs:
           done
           printf 'Selected PR suites: %s\n' "${suites[*]}"
           python3 tests/run.py "${args[@]}" --cpus 3
+
+      - name: Run filesystem regression single-core
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.plan.outputs.filesystem == 'true'
+        run: |
+          set -o pipefail
+          mkdir -p test-results/infrastructure
+          rm -rf test-results/usertests-core
+          # CPUS participates in the kernel build; rebuild rather than reusing the
+          # default three-CPU image when collecting the supplementary one-CPU result.
+          make clean
+          make -j2 CPUS=1 2>&1 | tee test-results/infrastructure/filesystem-single-core-build.log
+          make test-suite SUITE=usertests-core CPUS=1 2>&1 | tee test-results/infrastructure/filesystem-single-core-run.log
 
       - name: Run concurrency regression single-core
         if: >-

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,14 @@ OBJS = \
   $K/sysmemviz.o \
   $K/bio.o \
   $K/fs.o \
+  $K/fsinspect.o \
   $K/log.o \
   $K/sleeplock.o \
   $K/file.o \
   $K/pipe.o \
   $K/exec.o \
   $K/sysfile.o \
+  $K/sysfsinspect.o \
   $K/sysseek.o \
   $K/kernelvec.o \
   $K/plic.o \

--- a/kernel/bio.c
+++ b/kernel/bio.c
@@ -21,6 +21,7 @@
 #include "riscv.h"
 #include "defs.h"
 #include "fs.h"
+#include "fsinspect.h"
 #include "buf.h"
 
 #define NBUCKET 13
@@ -32,16 +33,73 @@ struct {
   struct spinlock steal_lock;
 } bcache;
 
+struct {
+  struct spinlock lock;
+  struct fsinspect_cache_stats value;
+} bcache_stats;
+
 uint ihash(uint blockno){
   return blockno % NBUCKET;
 }
 
 char buf[NBUCKET][20];
 
+/** 记录一次已经完成归类的缓存查找。 */
+static void
+record_cache_lookup(int hit)
+{
+  acquire(&bcache_stats.lock);
+  bcache_stats.value.requests++;
+  if(hit)
+    bcache_stats.value.hits++;
+  else
+    bcache_stats.value.misses++;
+  release(&bcache_stats.lock);
+}
+
+/** 记录一次从其他哈希桶迁移空闲 buffer 的慢路径。 */
+static void
+record_cache_steal(void)
+{
+  acquire(&bcache_stats.lock);
+  bcache_stats.value.steals++;
+  release(&bcache_stats.lock);
+}
+
+/** 记录一次真实设备读取。 */
+static void
+record_disk_read(void)
+{
+  acquire(&bcache_stats.lock);
+  bcache_stats.value.disk_reads++;
+  release(&bcache_stats.lock);
+}
+
+/** 记录一次真实设备写入。 */
+static void
+record_disk_write(void)
+{
+  acquire(&bcache_stats.lock);
+  bcache_stats.value.disk_writes++;
+  release(&bcache_stats.lock);
+}
+
+/** 把累计 buffer cache 计数复制到调用者持有的快照。 */
+void
+bcache_stats_snapshot(struct fsinspect_cache_stats *out)
+{
+  acquire(&bcache_stats.lock);
+  *out = bcache_stats.value;
+  release(&bcache_stats.lock);
+}
+
 void
 binit(void)
 {
   struct buf *b;
+
+  initlock(&bcache_stats.lock, "bcache.stats");
+  memset(&bcache_stats.value, 0, sizeof(bcache_stats.value));
 
   for(int i = 0; i < NBUCKET; i++) {
     snprintf(buf[i], 20, "bcache.bucket%d", i);//13 BUCKETS  
@@ -98,6 +156,7 @@ find_unused_locked(uint idx)
   return 0;
 }
 
+/** 初始化一个准备承载指定磁盘块的空闲 buffer。 */
 static void
 prepare_buf(struct buf *b, uint dev, uint blockno)
 {
@@ -107,6 +166,7 @@ prepare_buf(struct buf *b, uint dev, uint blockno)
   b->refcnt = 1;
 }
 
+/** 从当前哈希链摘除一个调用者已锁定所在桶的 buffer。 */
 static void
 unlink_buf(struct buf *b)
 {
@@ -114,6 +174,7 @@ unlink_buf(struct buf *b)
   b->next->prev = b->prev;
 }
 
+/** 把 buffer 插入目标桶的最近使用端；调用者持有目标桶锁。 */
 static void
 insert_buf_front(uint idx, struct buf *b)
 {
@@ -125,22 +186,31 @@ insert_buf_front(uint idx, struct buf *b)
   head->next = b;
 }
 
-// Try to find the requested block or recycle an unused local buffer.
-// Caller must hold bcache.lock[idx].
+/**
+ * 在目标桶中查找已有副本，或复用一个本地空闲 buffer。
+ *
+ * @param idx 调用者已锁定的目标桶。
+ * @param dev 设备号。
+ * @param blockno 磁盘块号。
+ * @param hit 找到已有副本时写入 1；复用空闲 buffer 时写入 0。
+ * @return 已增加引用或重新初始化的 buffer；没有本地候选时返回 0。
+ */
 static struct buf *
-try_get_local_locked(uint idx, uint dev, uint blockno)
+try_get_local_locked(uint idx, uint dev, uint blockno, int *hit)
 {
   struct buf *b;
 
   b = find_cached_locked(idx, dev, blockno);
   if(b != 0){
     b->refcnt++;
+    *hit = 1;
     return b;
   }
 
   b = find_unused_locked(idx);
   if(b != 0){
     prepare_buf(b, dev, blockno);
+    *hit = 0;
     return b;
   }
 
@@ -155,6 +225,7 @@ bget(uint dev, uint blockno)
 {
   uint home_idx = ihash(blockno);
   int holding_steal_lock = 0;
+  int cache_hit = 0;
   struct buf *b;
 
   /*
@@ -163,9 +234,11 @@ bget(uint dev, uint blockno)
    */
   acquire(&bcache.lock[home_idx]);
 
-  b = try_get_local_locked(home_idx, dev, blockno);
-  if(b != 0)
+  b = try_get_local_locked(home_idx, dev, blockno, &cache_hit);
+  if(b != 0){
+    record_cache_lookup(cache_hit);
     goto found;
+  }
 
   release(&bcache.lock[home_idx]);
 
@@ -182,9 +255,11 @@ bget(uint dev, uint blockno)
    * The target bucket may have changed while its lock was released.
    * Recheck it to avoid creating duplicate buffers for one disk block.
    */
-  b = try_get_local_locked(home_idx, dev, blockno);
-  if(b != 0)
+  b = try_get_local_locked(home_idx, dev, blockno, &cache_hit);
+  if(b != 0){
+    record_cache_lookup(cache_hit);
     goto found;
+  }
 
   /*
    * Keep the target bucket locked while moving a buffer into it.
@@ -207,6 +282,8 @@ bget(uint dev, uint blockno)
     release(&bcache.lock[victim_idx]);
 
     insert_buf_front(home_idx, b);
+    record_cache_lookup(0);
+    record_cache_steal();
     goto found;
   }
 
@@ -238,6 +315,7 @@ bread(uint dev, uint blockno)
   if(!b->valid) {
     virtio_disk_rw(b, 0);
     b->valid = 1;
+    record_disk_read();
   }
   return b;
 }
@@ -249,6 +327,7 @@ bwrite(struct buf *b)
   if(!holdingsleep(&b->lock))
     panic("bwrite");
   virtio_disk_rw(b, 1);
+  record_disk_write();
 }
 
 // Release a locked buffer.
@@ -292,5 +371,3 @@ bunpin(struct buf *b) {
   b->refcnt--;
   release(&bcache.lock[idx]);
 }
-
-

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -1,6 +1,9 @@
 struct buf;
 struct context;
 struct file;
+struct fsinspect_cache_stats;
+struct fsinspect_log_stats;
+struct fsinspect_snapshot;
 struct inode;
 struct pipe;
 struct proc;
@@ -20,6 +23,7 @@ void            brelse(struct buf*);
 void            bwrite(struct buf*);
 void            bpin(struct buf*);
 void            bunpin(struct buf*);
+void            bcache_stats_snapshot(struct fsinspect_cache_stats*);
 
 // console.c
 void            consoleinit(void);
@@ -62,6 +66,9 @@ void            stati(struct inode*, struct stat*);
 int             writei(struct inode*, int, uint64, uint64, uint);
 void            itrunc(struct inode*);
 
+// fsinspect.c
+void            fsinspect_collect(struct inode*, struct fsinspect_snapshot*);
+
 // ramdisk.c
 void            ramdiskinit(void);
 void            ramdiskintr(void);
@@ -79,6 +86,7 @@ void            initlog(int, struct superblock*);
 void            log_write(struct buf*);
 void            begin_op(void);
 void            end_op(void);
+void            log_stats_snapshot(struct fsinspect_log_stats*);
 
 // pipe.c
 int             pipealloc(struct file**, struct file**);

--- a/kernel/fsinspect.c
+++ b/kernel/fsinspect.c
@@ -1,0 +1,112 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "fsinspect.h"
+#include "buf.h"
+#include "file.h"
+
+extern struct superblock sb;
+
+/** 统计磁盘 inode 表中 type 非零的已分配 inode。 */
+static uint64
+count_allocated_inodes(uint dev)
+{
+  uint64 count = 0;
+
+  for(uint inum = 1; inum < sb.ninodes; inum++){
+    struct buf *bp = bread(dev, IBLOCK(inum, sb));
+    struct dinode *dip = (struct dinode*)bp->data + inum % IPB;
+    if(dip->type != 0)
+      count++;
+    brelse(bp);
+  }
+
+  return count;
+}
+
+/** 统计数据区位图中已经置位的块，不把固定元数据块计入文件数据分配。 */
+static uint64
+count_allocated_blocks(uint dev)
+{
+  uint data_start = sb.size - sb.nblocks;
+  uint64 count = 0;
+
+  for(uint b = data_start; b < sb.size;){
+    uint bitmap_base = b - b % BPB;
+    struct buf *bp = bread(dev, BBLOCK(b, sb));
+    uint first_bit = b - bitmap_base;
+
+    for(uint bit = first_bit; bit < BPB && bitmap_base + bit < sb.size; bit++)
+      if(bp->data[bit / 8] & (1 << (bit % 8)))
+        count++;
+
+    brelse(bp);
+    b = bitmap_base + BPB;
+  }
+
+  return count;
+}
+
+/**
+ * 读取一级间接根的第一个叶子地址。
+ *
+ * @param ip 调用者已持有 sleeplock 的 inode。
+ * @return 逻辑块 NDIRECT 对应的数据块；根或首项不存在时返回零。
+ */
+static uint
+first_indirect_data_block(struct inode *ip)
+{
+  uint root = ip->addrs[NDIRECT];
+  if(root == 0)
+    return 0;
+
+  struct buf *bp = bread(ip->dev, root);
+  uint first = ((uint*)bp->data)[0];
+  brelse(bp);
+  return first;
+}
+
+/**
+ * 收集文件系统全局状态，并可选地加入一个已锁定 inode 的块映射边界。
+ *
+ * @param ip 已锁定的 inode；传入 0 时只收集全局状态。
+ * @param out 调用者持有的输出快照。
+ */
+void
+fsinspect_collect(struct inode *ip, struct fsinspect_snapshot *out)
+{
+  memset(out, 0, sizeof(*out));
+  out->version = FSINSPECT_VERSION;
+  out->total_blocks = sb.size;
+  out->data_blocks = sb.nblocks;
+  out->data_start = sb.size - sb.nblocks;
+  out->inode_count = sb.ninodes;
+  out->log_start = sb.logstart;
+  out->log_blocks = sb.nlog;
+  out->inode_start = sb.inodestart;
+  out->bitmap_start = sb.bmapstart;
+
+  // 先取运行时计数，让本次扫描本身产生的缓存访问只进入下一张快照。
+  bcache_stats_snapshot(&out->cache);
+  log_stats_snapshot(&out->log);
+
+  out->allocated_inodes = count_allocated_inodes(ROOTDEV);
+  out->allocated_blocks = count_allocated_blocks(ROOTDEV);
+
+  if(ip == 0)
+    return;
+
+  out->has_inode = 1;
+  out->inode_number = ip->inum;
+  out->inode_type = ip->type;
+  out->inode_nlink = ip->nlink;
+  out->inode_size = ip->size;
+  out->direct_first = ip->addrs[0];
+  out->direct_last = ip->addrs[NDIRECT - 1];
+  out->indirect_root = ip->addrs[NDIRECT];
+  out->indirect_first = first_indirect_data_block(ip);
+}

--- a/kernel/fsinspect.h
+++ b/kernel/fsinspect.h
@@ -1,0 +1,63 @@
+#ifndef XV6_KERNEL_FSINSPECT_H
+#define XV6_KERNEL_FSINSPECT_H
+
+#define FSINSPECT_VERSION 1
+#define FSINSPECT_GLOBAL_FD (-1)
+
+/** 描述 buffer cache 自启动以来累计的公开观察计数。 */
+struct fsinspect_cache_stats {
+  uint64 requests;
+  uint64 hits;
+  uint64 misses;
+  uint64 disk_reads;
+  uint64 disk_writes;
+  uint64 steals;
+};
+
+/** 描述物理 redo log 自启动以来累计的公开观察计数。 */
+struct fsinspect_log_stats {
+  uint64 commits;
+  uint64 committed_blocks;
+  uint64 recoveries;
+};
+
+/**
+ * 提供一个只读文件系统观察结果，连接磁盘布局、资源分配、inode 块映射、日志和缓存。
+ *
+ * has_inode 为零时仅有全局字段有效；非零时 inode 字段来自调用者提供的已打开
+ * 普通文件或设备 inode。direct_first、direct_last 与 indirect_first 分别观察逻辑块
+ * 0、NDIRECT-1 和 NDIRECT，未建立映射时保持零。
+ *
+ * 全局计数通过顺序扫描得到，不冻结其他 CPU 的文件系统操作，因此不是原子一致性
+ * 快照。测试必须隔离其他写入者，并比较同一启动实例中的前后增量。
+ */
+struct fsinspect_snapshot {
+  uint version;
+  uint has_inode;
+
+  uint total_blocks;
+  uint data_blocks;
+  uint data_start;
+  uint inode_count;
+  uint log_start;
+  uint log_blocks;
+  uint inode_start;
+  uint bitmap_start;
+
+  uint64 allocated_inodes;
+  uint64 allocated_blocks;
+
+  uint inode_number;
+  short inode_type;
+  short inode_nlink;
+  uint64 inode_size;
+  uint direct_first;
+  uint direct_last;
+  uint indirect_root;
+  uint indirect_first;
+
+  struct fsinspect_cache_stats cache;
+  struct fsinspect_log_stats log;
+};
+
+#endif

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -5,6 +5,7 @@
 #include "spinlock.h"
 #include "sleeplock.h"
 #include "fs.h"
+#include "fsinspect.h"
 #include "buf.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
@@ -33,8 +34,41 @@ struct log {
 
 struct log log;
 
+struct {
+  struct spinlock lock;
+  struct fsinspect_log_stats value;
+} log_stats;
+
 static void recover_from_log(void);
 static void commit(void);
+
+/** 记录一次已经完整安装并清除提交标记的事务。 */
+static void
+record_commit(int blocks)
+{
+  acquire(&log_stats.lock);
+  log_stats.value.commits++;
+  log_stats.value.committed_blocks += blocks;
+  release(&log_stats.lock);
+}
+
+/** 记录启动时重放一个已发布事务。 */
+static void
+record_recovery(void)
+{
+  acquire(&log_stats.lock);
+  log_stats.value.recoveries++;
+  release(&log_stats.lock);
+}
+
+/** 把累计 redo log 计数复制到调用者持有的快照。 */
+void
+log_stats_snapshot(struct fsinspect_log_stats *out)
+{
+  acquire(&log_stats.lock);
+  *out = log_stats.value;
+  release(&log_stats.lock);
+}
 
 /** 返回编码最大日志头所需的固定磁盘块数。 */
 static int
@@ -68,6 +102,8 @@ void
 initlog(int dev, struct superblock *sb)
 {
   initlock(&log.lock, "log");
+  initlock(&log_stats.lock, "log.stats");
+  memset(&log_stats.value, 0, sizeof(log_stats.value));
   log.start = sb->logstart;
   log.header_blocks = log_header_block_count();
   log.size = sb->nlog - log.header_blocks;
@@ -176,9 +212,12 @@ static void
 recover_from_log(void)
 {
   read_head();
+  int recovered = log.lh.n;
   install_trans(1);
   log.lh.n = 0;
   write_head();
+  if(recovered > 0)
+    record_recovery();
 }
 
 /** 在持锁状态判断能否再预留一个最坏文件系统操作。 */
@@ -243,11 +282,13 @@ static void
 commit(void)
 {
   if(log.lh.n > 0){
+    int committed = log.lh.n;
     write_log();
     write_head();
     install_trans(0);
     log.lh.n = 0;
     write_head();
+    record_commit(committed);
   }
 }
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -88,7 +88,7 @@ argaddr(int n, uint64 *ip)
 
 // Fetch the nth word-sized system call argument as a null-terminated string.
 // Copies into buf, at most max.
-// Returns string length if OK (including nul), -1 for error.
+// Returns string length if OK (including nul), -1 if error.
 int
 argstr(int n, char *buf, int max)
 {
@@ -106,6 +106,7 @@ extern uint64 sys_execve(void);
 extern uint64 sys_exit(void);
 extern uint64 sys_fork(void);
 extern uint64 sys_fstat(void);
+extern uint64 sys_fsinspect(void);
 extern uint64 sys_getpid(void);
 extern uint64 sys_kill(void);
 extern uint64 sys_link(void);
@@ -196,6 +197,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_swapout]          sys_swapout,
 [SYS_swapinfo]         sys_swapinfo,
 [SYS_concurrencylab]   sys_concurrencylab,
+[SYS_fsinspect]        sys_fsinspect,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -47,3 +47,4 @@
 #define SYS_swapout          46
 #define SYS_swapinfo         47
 #define SYS_concurrencylab   48
+#define SYS_fsinspect        49

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -53,6 +53,7 @@ static const char *const syscall_names[] = {
 [SYS_swapout]          = "swapout",
 [SYS_swapinfo]         = "swapinfo",
 [SYS_concurrencylab]   = "concurrencylab",
+[SYS_fsinspect]        = "fsinspect",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/sysfsinspect.c
+++ b/kernel/sysfsinspect.c
@@ -1,0 +1,48 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "fsinspect.h"
+#include "file.h"
+#include "proc.h"
+
+/**
+ * 将文件系统快照复制到用户态；fd=-1 只返回全局状态。
+ *
+ * 普通文件和设备描述符会附带 inode 身份、链接计数、大小以及直接块到一级间接块
+ * 的边界映射。pipe 和无效描述符不具备 inode 语义，返回 -1 且不修改文件系统。
+ */
+uint64
+sys_fsinspect(void)
+{
+  int fd;
+  uint64 user_addr;
+  struct inode *ip = 0;
+  struct fsinspect_snapshot snapshot;
+  struct proc *p = myproc();
+
+  if(argint(0, &fd) < 0 || argaddr(1, &user_addr) < 0)
+    return -1;
+
+  if(fd != FSINSPECT_GLOBAL_FD){
+    if(fd < 0 || fd >= NOFILE)
+      return -1;
+    struct file *f = p->ofile[fd];
+    if(f == 0 || (f->type != FD_INODE && f->type != FD_DEVICE))
+      return -1;
+    ip = f->ip;
+    ilock(ip);
+  }
+
+  fsinspect_collect(ip, &snapshot);
+
+  if(ip != 0)
+    iunlock(ip);
+
+  if(copyout(p->pagetable, user_addr, (char*)&snapshot, sizeof(snapshot)) < 0)
+    return -1;
+  return 0;
+}

--- a/tests/guest/fileapitest.c
+++ b/tests/guest/fileapitest.c
@@ -1,10 +1,31 @@
 #include "kernel/types.h"
+#include "kernel/param.h"
 #include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "kernel/fsinspect.h"
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
 #define PRIMARY_PATH "fa_primary"
 #define ALIAS_PATH "fa_alias"
+#define FSWALK_DIR "/tmp/fswalk"
+#define FSWALK_PATH "/tmp/fswalk/data"
+#define FSWALK_BLOCKS (NDIRECT + 1)
+
+static int fswalk_fd = -1;
+static char fswalk_block[BSIZE];
+
+/** 清理文件系统 Golden Trace 持有的描述符与目录项。 */
+static void
+cleanup_fswalk(void)
+{
+  if(fswalk_fd >= 0){
+    close(fswalk_fd);
+    fswalk_fd = -1;
+  }
+  unlink(FSWALK_PATH);
+  unlink(FSWALK_DIR);
+}
 
 /**
  * 立即报告断言失败并以非零状态终止测试。
@@ -14,6 +35,7 @@
 static void
 fail(const char *reason)
 {
+  cleanup_fswalk();
   printf("fileapitest: %s\n", reason);
   exit(1);
 }
@@ -53,6 +75,7 @@ cleanup_workspace(void)
 {
   unlink(PRIMARY_PATH);
   unlink(ALIAS_PATH);
+  cleanup_fswalk();
 }
 
 /**
@@ -202,8 +225,181 @@ test_link_unlink_lifetime(void)
     fail("missing-path operations unexpectedly succeeded");
 }
 
+/** 读取一个全局或 fd 关联的文件系统观察结果。 */
+static void
+fswalk_snapshot(int fd, struct fsinspect_snapshot *out)
+{
+  if(fsinspect(fd, out) < 0)
+    fail("fsinspect failed");
+  if(out->version != FSINSPECT_VERSION)
+    fail("unexpected fsinspect version");
+}
+
+/** 用逻辑块编号派生出的固定字节填满一个数据块。 */
+static void
+fswalk_fill_block(int logical_block)
+{
+  char value = 'A' + logical_block;
+
+  for(int i = 0; i < BSIZE; i++)
+    fswalk_block[i] = value;
+}
+
+/** 验证读回块与写入时的固定字节完全一致。 */
+static void
+fswalk_check_block(int logical_block)
+{
+  char expected = 'A' + logical_block;
+
+  for(int i = 0; i < BSIZE; i++)
+    if(fswalk_block[i] != expected)
+      fail("filesystem read data mismatch");
+}
+
 /**
- * 构造文件 API 的状态闭环并通过退出状态向 xv6test 报告结果。
+ * 验证目录、inode、块映射、位图、日志和缓存围绕同一文件生命周期协同变化。
+ *
+ * 观察接口只读且不冻结其他 CPU；本测试通过独占路径和无并发写入者比较前后增量。
+ */
+static void
+test_filesystem_implementation(void)
+{
+  struct fsinspect_snapshot before_directory;
+  struct fsinspect_snapshot directory_state;
+  struct fsinspect_snapshot after_write;
+  struct fsinspect_snapshot before_boundary;
+  struct fsinspect_snapshot after_boundary;
+  struct fsinspect_snapshot invalid_before;
+  struct fsinspect_snapshot invalid_after;
+  struct fsinspect_snapshot invalid_output;
+  struct fsinspect_snapshot after_read;
+  struct fsinspect_snapshot after_unlink;
+  struct fsinspect_snapshot after_close;
+  struct fsinspect_snapshot after_cleanup;
+  char byte = 'x';
+  int unexpected;
+
+  cleanup_fswalk();
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &before_directory);
+
+  if(mkdir(FSWALK_DIR) < 0)
+    fail("cannot create filesystem test directory");
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &directory_state);
+  if(directory_state.allocated_inodes != before_directory.allocated_inodes + 1)
+    fail("directory inode allocation delta is not one");
+  if(directory_state.allocated_blocks != before_directory.allocated_blocks + 1)
+    fail("directory data block allocation delta is not one");
+
+  fswalk_fd = open(FSWALK_PATH, O_CREATE | O_RDWR);
+  if(fswalk_fd < 0)
+    fail("cannot create filesystem test file");
+
+  for(int logical = 0; logical < FSWALK_BLOCKS; logical++){
+    fswalk_fill_block(logical);
+    if(write(fswalk_fd, fswalk_block, BSIZE) != BSIZE)
+      fail("filesystem block write failed");
+  }
+
+  fswalk_snapshot(fswalk_fd, &after_write);
+  if(!after_write.has_inode || after_write.inode_type != T_FILE)
+    fail("fd snapshot does not describe a regular inode");
+  if(after_write.inode_size != (uint64)FSWALK_BLOCKS * BSIZE)
+    fail("filesystem file size does not match written blocks");
+  if(after_write.allocated_inodes != directory_state.allocated_inodes + 1)
+    fail("file inode allocation delta is not one");
+  if(after_write.allocated_blocks !=
+     directory_state.allocated_blocks + FSWALK_BLOCKS + 1)
+    fail("data plus indirect block allocation delta is unexpected");
+  if(after_write.direct_first == 0 || after_write.direct_last == 0)
+    fail("direct block boundary was not mapped");
+  if(after_write.indirect_root == 0 || after_write.indirect_first == 0)
+    fail("first indirect block was not mapped");
+  if(after_write.direct_first == after_write.direct_last ||
+     after_write.direct_last == after_write.indirect_root ||
+     after_write.indirect_root == after_write.indirect_first)
+    fail("inode block roles unexpectedly alias");
+  if(after_write.log.commits <= directory_state.log.commits)
+    fail("filesystem writes did not commit redo-log transactions");
+  if(after_write.cache.requests <= directory_state.cache.requests)
+    fail("filesystem writes did not enter buffer cache");
+
+  fswalk_snapshot(fswalk_fd, &before_boundary);
+  if(lseek(fswalk_fd, MAXFILE_BYTES, SEEK_SET) != (int64)MAXFILE_BYTES)
+    fail("cannot seek to maximum file boundary");
+  if(write(fswalk_fd, &byte, 1) != -1)
+    fail("write beyond maximum file size unexpectedly succeeded");
+  fswalk_snapshot(fswalk_fd, &after_boundary);
+  if(after_boundary.inode_size != before_boundary.inode_size)
+    fail("failed boundary write changed file size");
+  if(after_boundary.allocated_blocks != before_boundary.allocated_blocks ||
+     after_boundary.allocated_inodes != before_boundary.allocated_inodes)
+    fail("failed boundary write changed allocation state");
+
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &invalid_before);
+  if(fsinspect(NOFILE + 1, &invalid_output) != -1)
+    fail("invalid descriptor inspection unexpectedly succeeded");
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &invalid_after);
+  if(invalid_after.allocated_blocks != invalid_before.allocated_blocks ||
+     invalid_after.allocated_inodes != invalid_before.allocated_inodes)
+    fail("invalid inspection changed allocation state");
+
+  if(lseek(fswalk_fd, 0, SEEK_SET) != 0)
+    fail("cannot rewind filesystem test file");
+  for(int logical = 0; logical < FSWALK_BLOCKS; logical++){
+    if(read(fswalk_fd, fswalk_block, BSIZE) != BSIZE)
+      fail("filesystem block read failed");
+    fswalk_check_block(logical);
+  }
+  fswalk_snapshot(fswalk_fd, &after_read);
+  if(after_read.cache.hits <= after_boundary.cache.hits)
+    fail("filesystem read path did not observe buffer cache hits");
+
+  if(unlink(FSWALK_PATH) < 0)
+    fail("cannot unlink open filesystem test file");
+  unexpected = open(FSWALK_PATH, O_RDONLY);
+  if(unexpected >= 0){
+    close(unexpected);
+    fail("unlinked filesystem path remained reachable");
+  }
+  fswalk_snapshot(fswalk_fd, &after_unlink);
+  if(after_unlink.inode_nlink != 0)
+    fail("final unlink did not clear inode link count");
+  if(after_unlink.allocated_inodes != after_read.allocated_inodes ||
+     after_unlink.allocated_blocks != after_read.allocated_blocks)
+    fail("open unlinked inode was reclaimed too early");
+
+  close_checked(fswalk_fd, "cannot close filesystem test file");
+  fswalk_fd = -1;
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &after_close);
+  if(after_close.allocated_inodes != directory_state.allocated_inodes)
+    fail("final close did not release filesystem inode");
+  if(after_close.allocated_blocks != directory_state.allocated_blocks)
+    fail("final close did not release data and indirect blocks");
+
+  if(unlink(FSWALK_DIR) < 0)
+    fail("cannot remove filesystem test directory");
+  fswalk_snapshot(FSINSPECT_GLOBAL_FD, &after_cleanup);
+  if(after_cleanup.allocated_inodes != before_directory.allocated_inodes ||
+     after_cleanup.allocated_blocks != before_directory.allocated_blocks)
+    fail("filesystem cleanup did not restore allocation counts");
+
+  printf("FSWALK layout total=%d data_start=%d inode_start=%d bitmap_start=%d\n",
+         after_write.total_blocks, after_write.data_start,
+         after_write.inode_start, after_write.bitmap_start);
+  printf("FSWALK write inode_delta=1 block_delta=%d direct_first=%d direct_last=%d indirect_root=%d indirect_first=%d\n",
+         FSWALK_BLOCKS + 1, after_write.direct_first, after_write.direct_last,
+         after_write.indirect_root, after_write.indirect_first);
+  printf("FSWALK boundary rejected=1 allocation_unchanged=1\n");
+  printf("FSWALK read bytes=%d cache_hit_delta=%d\n",
+         FSWALK_BLOCKS * BSIZE,
+         (int)(after_read.cache.hits - after_boundary.cache.hits));
+  printf("FSWALK unlink nlink=0 retained_until_close=1\n");
+  printf("FSWALK reclaim inode_restored=1 block_restored=1 commits=%d\n",
+         (int)(after_cleanup.log.commits - before_directory.log.commits));
+}
+
+/**
+ * 构造文件 API 与文件系统实现的状态闭环，并通过退出状态向 xv6test 报告结果。
  *
  * @return 全部状态、错误和资源回收断言通过时以 exit(0) 终止；失败路径由 fail()
  *         以 exit(1) 终止。
@@ -214,8 +410,9 @@ main(void)
   cleanup_workspace();
   test_offset_ownership();
   test_link_unlink_lifetime();
+  test_filesystem_implementation();
   cleanup_workspace();
 
-  printf("fileapitest: verified offsets, links, unlink lifetime, and cleanup\n");
+  printf("fileapitest: verified offsets, links, filesystem mappings, unlink lifetime, and cleanup\n");
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -7,6 +7,7 @@ struct sysinfo;
 struct procinfo;
 struct memviz_snapshot;
 struct memviz_va_query;
+struct fsinspect_snapshot;
 struct sched_stats;
 struct schedtrace_snapshot;
 struct user_context;
@@ -72,6 +73,15 @@ int sched_set_hint(int ticks);
 int sched_set_weight(int weight);
 int sched_get_stats(struct sched_stats *stats);
 int schedtrace(int op, struct schedtrace_snapshot *snapshot, int arg);
+
+/**
+ * 读取文件系统全局状态，并可选附带一个打开 inode 的块映射边界。
+ *
+ * @param fd 普通文件或设备描述符；FSINSPECT_GLOBAL_FD 只读取全局状态。
+ * @param snapshot 接收 kernel/fsinspect.h 定义的结构化观察结果。
+ * @return 成功返回 0；描述符、对象类型或用户地址非法时返回 -1。
+ */
+int fsinspect(int fd, struct fsinspect_snapshot *snapshot);
 
 /**
  * 驱动显式启用的并发入门教学会话。

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -62,3 +62,4 @@ entry("getprocs");
 entry("swapout");
 entry("swapinfo");
 entry("concurrencylab");
+entry("fsinspect");


### PR DESCRIPTION
## 中心认知与范围

本 PR 为 `文件系统：实现` 建立一个最小、只读、可自动验收的 xv6 观察闭环：文件创建、跨直接块边界写入、读取、`unlink` 与最终引用关闭，会共同改变目录项、inode、块映射、数据位图、redo log 与 buffer cache 状态。

本轮不新增生产级文件系统特性，不改变 xv6 的磁盘格式、分配策略或日志原子性边界；新增的 `fsinspect` 仅用于教学观察和测试断言。

Related to #154
Related to #134
Obsidian: mental1104/Obsidian#217

## 基线

- 本轮开始记录的 `main`：`4fe136143f78eaf10457604d1695486038b5f93e`
- 合并前同步的 `main`：`254152efd670c49a83d8fbb417c2ee4dc28e2cd9`
- 实现提交：`f762ffe8611ef5027242ef45141f3af6d1d00314`

## 关键实现

- `kernel/fsinspect.h`：定义只读观察 ABI，并明确全局计数不是冻结其他 CPU 的原子快照。
- `kernel/fsinspect.c`：扫描磁盘 inode 表与数据区位图，并读取直接块到一级间接块的边界映射。
- `kernel/sysfsinspect.c`：提供 `fsinspect(fd, snapshot)` 系统调用；`fd=-1` 只读取全局状态。
- `kernel/bio.c`：记录 cache request/hit/miss、真实设备读写和跨桶迁移次数。
- `kernel/log.c`：记录提交次数、提交块数和启动恢复次数。
- `tests/guest/fileapitest.c`：在现有文件 API 生命周期测试中加入 `FSWALK` Golden Trace，不复制内核实现。
- `.github/workflows/ci.yml`：默认 PR 回归验证 CPUS=3；文件系统相关变更再 clean build 并补跑 CPUS=1。

## 测试契约

`core-fileapi` 中的文件系统 Golden Trace 断言：

1. 创建目录分配 1 个 inode 与 1 个目录数据块；
2. 写入 `NDIRECT + 1` 个块会跨越最后一个直接块并建立一级间接根，块增量为数据块加 1 个索引块；
3. 在 `MAXFILE_BYTES` 处写入 1 字节失败，文件大小与分配计数保持不变；
4. 读取内容与写入模式一致，并出现 buffer cache hit；
5. `unlink` 后路径不可再打开，但已打开 fd 保持 inode 与数据块存活；
6. 最后一个 fd 关闭后释放 inode、数据块和间接索引块；
7. 删除测试目录后，inode 与数据块计数恢复到初始状态；
8. 非法 fd 的观察请求失败且不改变分配状态。

## 验证结果

- [x] `make clean && make -j2`
- [x] `make test-unit`
- [x] PR 选择性 QEMU 回归，CPUS=3
- [x] `make clean && make -j2 CPUS=1 && make test-suite SUITE=usertests-core CPUS=1`
- [x] VM 回归，CPUS=1
- [x] uthread，CPUS=3 与 CPUS=1
- [x] 调度器 regression、完整 usertests、reparent 单核清理、各策略单核与 SMP smoke

证据：

- xv6 CI：Actions run `30166187552`，job `89699506581`，success。
- uthread debug：Actions run `30166187547`，CPUS=3/1 均 success。
- scheduler：Actions run `30166187550`，全部 job success。

## 教学边界

- 当前 xv6 没有 inode bitmap；inode 分配通过扫描磁盘 inode 表中的 `type == 0` 完成。观察结果因此统计 inode 表，而不是虚构 inode 位图。
- `allocated_blocks` 只统计数据区位图中的置位块，不包含 boot/super/log/inode/bitmap 固定元数据块。
- `fsinspect` 会顺序扫描 inode 表和数据位图，不冻结其他 CPU 的并发文件系统操作；测试使用独占路径、无其他写入者并只比较前后增量。
- cache/log 计数自启动累计，测试不依赖固定绝对值。
- 该接口用于 xv6 教学与回归，不对应 Linux 的稳定用户 ABI，也不应作为高频生产监控方案。