### PR TITLE
feat: 建立 pipe 就绪与事件循环可验证闭环

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,11 @@ OBJS = \
   $K/sleeplock.o \
   $K/file.o \
   $K/pipe.o \
+  $K/poll.o \
   $K/exec.o \
   $K/sysfile.o \
   $K/sysfsinspect.o \
+  $K/syspoll.o \
   $K/sysseek.o \
   $K/kernelvec.o \
   $K/plic.o \
@@ -108,6 +110,13 @@ CFLAGS += -DSCHED_POLICY=$(SCHED_POLICY_ID)
 # 保留 proc.c 的历史入口作为可链接后备，由 sched.c 和 semexit.c 提供公开入口。
 $K/proc.o: CFLAGS += -Dprocinit=legacy_procinit -Dscheduler=legacy_scheduler -Dyield=legacy_yield -Dexit=proc_exit_without_semaphore
 $K/trap.o: CFLAGS += -Dyield=sched_timer_yield
+
+# event-loop 分支使用局部头文件声明教学 API，避免再次扩张全局 defs.h/user.h 冲突面。
+$K/file.o $K/pipe.o $K/poll.o $K/syspoll.o: CFLAGS += -include $K/poll.h
+$U/eventloop.o $T/eventlooptest.o: CFLAGS += -include $U/pollread.h
+
+# 保留主线 xv6test 注册表，并由一个小型适配入口追加 core-eventloop。
+$T/xv6test.o: CFLAGS += -Dmain=xv6test_original_main
 
 ifneq ($(shell $(CC) -dumpspecs 2>/dev/null | grep -e '[^f]no-pie'),)
 CFLAGS += -fno-pie -no-pie
@@ -241,6 +250,16 @@ $U/_uthreadtest: $T/uthreadtest.o $T/testlib.o $(ULIB)
 	$(OBJDUMP) -S $@ > $T/uthreadtest.asm
 	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/uthreadtest.sym
 
+$U/_eventlooptest: $T/eventlooptest.o $T/testlib.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $T/eventlooptest.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/eventlooptest.sym
+
+$U/_xv6test: $U/xv6test_eventloop.o $T/xv6test.o $(ULIB)
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
+	$(OBJDUMP) -S $@ > $T/xv6test.asm
+	$(OBJDUMP) -t $@ | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $T/xv6test.sym
+
 $U/_uthread: $U/uthread.o $U/uthreadlib.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $@ $^
 	$(OBJDUMP) -S $U/_uthread > $U/uthread.asm
@@ -277,6 +296,7 @@ UPROGS=\
 	$U/_varead\
 	$U/_vawrite\
 	$U/_vaprobe\
+	$U/_eventloop\
 	$U/_memviztest\
 	$U/_memtargettest\
 	$U/_pgtbltest\
@@ -314,6 +334,7 @@ UPROGS=\
 	$U/_lab1test\
 	$U/_tracesmoke\
 	$U/_uthreadtest\
+	$U/_eventlooptest\
 	$U/_historytest\
 	$U/_consolelinetest\
 	$U/_lstest\

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -20,11 +20,12 @@ struct {
   struct file file[NFILE];
 } ftable;
 
-/** 初始化全局打开文件表。 */
+/** 初始化全局打开文件表和文件就绪等待队列。 */
 void
 fileinit(void)
 {
   initlock(&ftable.lock, "ftable");
+  pollinit();
 }
 
 /** 分配一个带引用的文件表项。 */

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -19,6 +19,13 @@ struct pipe {
   int writeopen;  // write fd is still open
 };
 
+/**
+ * 分配一对共享同一 pipe 状态的读写 file 对象。
+ *
+ * @param f0 接收可读 file 引用。
+ * @param f1 接收可写 file 引用。
+ * @return 全部资源分配成功返回 0；任一步失败时回滚并返回 -1。
+ */
 int
 pipealloc(struct file **f0, struct file **f1)
 {
@@ -55,24 +62,49 @@ pipealloc(struct file **f0, struct file **f1)
   return -1;
 }
 
+/**
+ * 关闭 pipe 的一个方向，并在最后一个引用消失后释放底层页。
+ *
+ * @param pi 被关闭 file 引用持有的 pipe。
+ * @param writable 非零表示关闭写端，否则关闭读端。
+ *
+ * 写端关闭会让空 pipe 的下一次 read() 返回 EOF，因此它既唤醒传统阻塞读取者，
+ * 也在释放 pipe 锁后通知 pollread() 等待者。通知必须发生在 pipe 锁之外，以保持
+ * pollstate.lock -> pipe.lock 的固定锁序。
+ */
 void
 pipeclose(struct pipe *pi, int writable)
 {
+  int free_pipe;
+  int notify_readers = 0;
+
   acquire(&pi->lock);
   if(writable){
     pi->writeopen = 0;
     wakeup(&pi->nread);
+    notify_readers = 1;
   } else {
     pi->readopen = 0;
     wakeup(&pi->nwrite);
   }
-  if(pi->readopen == 0 && pi->writeopen == 0){
-    release(&pi->lock);
+  free_pipe = pi->readopen == 0 && pi->writeopen == 0;
+  release(&pi->lock);
+
+  // 两端都关闭时已不存在合法 pollread() 读端，无需在释放前制造一次无效唤醒。
+  if(notify_readers && !free_pipe)
+    pollnotify();
+  if(free_pipe)
     kfree((char*)pi);
-  } else
-    release(&pi->lock);
 }
 
+/**
+ * 将用户缓冲区写入 pipe，空间不足时睡眠等待读取方推进。
+ *
+ * @param pi 目标 pipe。
+ * @param addr 用户缓冲区起始地址。
+ * @param n 最多写入的字节数。
+ * @return 实际写入字节数；读端关闭、进程被终止或首字节复制失败时返回 -1/0。
+ */
 int
 pipewrite(struct pipe *pi, uint64 addr, int n)
 {
@@ -96,9 +128,21 @@ pipewrite(struct pipe *pi, uint64 addr, int n)
   }
   wakeup(&pi->nread);
   release(&pi->lock);
+
+  // 数据状态已提交后再获取 poll 锁，避免与 pollreadfiles() 的扫描锁序反转。
+  if(i > 0)
+    pollnotify();
   return i;
 }
 
+/**
+ * 从 pipe 复制数据到用户缓冲区，空且仍有写端时睡眠。
+ *
+ * @param pi 来源 pipe。
+ * @param addr 用户目标缓冲区起始地址。
+ * @param n 最多读取的字节数。
+ * @return 实际读取字节数；写端关闭且无数据时返回 0；进程被终止时返回 -1。
+ */
 int
 piperead(struct pipe *pi, uint64 addr, int n)
 {
@@ -124,4 +168,21 @@ piperead(struct pipe *pi, uint64 addr, int n)
   wakeup(&pi->nwrite);  //DOC: piperead-wakeup
   release(&pi->lock);
   return i;
+}
+
+/**
+ * 判断下一次 pipe read() 是否能够立即取得数据或 EOF。
+ *
+ * @param pi 由可读 file 引用持有的 pipe。
+ * @return 缓冲区非空或所有写端已关闭时返回 1，否则返回 0。
+ */
+int
+pipereadable(struct pipe *pi)
+{
+  int ready;
+
+  acquire(&pi->lock);
+  ready = pi->nread != pi->nwrite || pi->writeopen == 0;
+  release(&pi->lock);
+  return ready;
 }

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -1,0 +1,78 @@
+#include "types.h"
+#include "param.h"
+#include "riscv.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "fs.h"
+#include "sleeplock.h"
+#include "file.h"
+
+/**
+ * 保护教学型 pipe 就绪等待队列。
+ *
+ * 这里故意使用一个全局等待通道：它足以展示“等待多个事件源并避免丢失唤醒”的
+ * 核心机制，但会产生惊群，不代表 poll/epoll 等生产接口的扩展方式。
+ */
+static struct {
+  struct spinlock lock;
+} pollstate;
+
+/** 初始化教学型 pipe 就绪等待队列。 */
+void
+pollinit(void)
+{
+  initlock(&pollstate.lock, "poll");
+}
+
+/**
+ * 唤醒所有正在等待 pipe 就绪状态变化的进程。
+ *
+ * 调用者必须已经释放具体 pipe 的锁，保持固定的 pollstate.lock -> pipe.lock
+ * 扫描顺序，避免写入/关闭路径形成反向锁序。
+ */
+void
+pollnotify(void)
+{
+  acquire(&pollstate.lock);
+  wakeup(&pollstate);
+  release(&pollstate.lock);
+}
+
+/**
+ * 等待一组可读 pipe 中至少一个进入可推进状态。
+ *
+ * @param files 已由系统调用层验证为可读 pipe 的 file 指针数组；所有权仍归进程文件表。
+ * @param count files 中的有效元素数量，范围为 1 到 NOFILE。
+ * @param wait 非零时等待任一 pipe 就绪；为零时只返回当前快照。
+ * @return 按数组槽位编码的就绪位图；进程被终止时返回 -1。
+ *
+ * pipe 中已有数据，或所有写端已经关闭而下一次 read() 将返回 EOF，均视为可读。
+ * 扫描与 sleep 共用 pollstate.lock：写入者在改变 pipe 状态后获取同一把锁并唤醒，
+ * 因此事件发生在“扫描完成、真正睡眠之前”时也不会被遗漏。
+ */
+int
+pollreadfiles(struct file **files, int count, int wait)
+{
+  struct proc *p = myproc();
+
+  acquire(&pollstate.lock);
+  for(;;){
+    int ready = 0;
+
+    for(int index = 0; index < count; index++)
+      if(pipereadable(files[index]->pipe))
+        ready |= 1 << index;
+
+    if(ready != 0 || wait == 0){
+      release(&pollstate.lock);
+      return ready;
+    }
+    if(p->killed){
+      release(&pollstate.lock);
+      return -1;
+    }
+
+    sleep(&pollstate, &pollstate.lock);
+  }
+}

--- a/kernel/poll.h
+++ b/kernel/poll.h
@@ -1,0 +1,19 @@
+#ifndef XV6_KERNEL_POLL_H
+#define XV6_KERNEL_POLL_H
+
+struct file;
+struct pipe;
+
+/** 判断 pipe 的下一次读取是否能够立即取得数据或 EOF。 */
+int pipereadable(struct pipe *pipe);
+
+/** 初始化教学型 pipe 就绪等待队列。 */
+void pollinit(void);
+
+/** 在 pipe 状态变化后唤醒所有就绪等待者。 */
+void pollnotify(void);
+
+/** 扫描一组可读 pipe，并按槽位返回就绪位图。 */
+int pollreadfiles(struct file **files, int count, int wait);
+
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -117,6 +117,7 @@ extern uint64 sys_mkdir(void);
 extern uint64 sys_mknod(void);
 extern uint64 sys_open(void);
 extern uint64 sys_pipe(void);
+extern uint64 sys_pollread(void);
 extern uint64 sys_read(void);
 extern uint64 sys_sbrk(void);
 extern uint64 sys_sleep(void);
@@ -227,6 +228,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_raid1rw]          sys_raid1rw,
 [SYS_locklab]          sys_locklab,
 [SYS_disktrace]        sys_disktrace,
+[SYS_pollread]         sys_pollread,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -59,3 +59,4 @@
 #define SYS_raid1rw          58
 #define SYS_locklab          59
 #define SYS_disktrace        60
+#define SYS_pollread         61

--- a/kernel/syscall_names.h
+++ b/kernel/syscall_names.h
@@ -65,6 +65,7 @@ static const char *const syscall_names[] = {
 [SYS_raid1rw]          = "raid1rw",
 [SYS_locklab]          = "locklab",
 [SYS_disktrace]        = "disktrace",
+[SYS_pollread]         = "pollread",
 };
 
 // 名称表中可访问的元素数量（包含下标 0），用于限制遍历和查找范围。

--- a/kernel/syspoll.c
+++ b/kernel/syspoll.c
@@ -1,0 +1,51 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "param.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "fs.h"
+#include "sleeplock.h"
+#include "file.h"
+
+/**
+ * 返回一组 pipe 读端的当前就绪位图，或等待其中任一读端就绪。
+ *
+ * 用户传入的数组槽位与返回位图一一对应。当前教学接口只接受可读 pipe：普通文件、
+ * 设备、pipe 写端和无效描述符都会整体失败，避免把“文件读取不会睡眠”偷换成通用
+ * I/O 就绪语义。
+ *
+ * @return 成功返回非负就绪位图；参数、用户地址或描述符非法时返回 -1。
+ */
+uint64
+sys_pollread(void)
+{
+  uint64 user_fds;
+  int count;
+  int wait;
+  int fds[NOFILE];
+  struct file *files[NOFILE];
+  struct proc *p = myproc();
+
+  if(argaddr(0, &user_fds) < 0 || argint(1, &count) < 0 ||
+     argint(2, &wait) < 0)
+    return -1;
+  if(count <= 0 || count > NOFILE || (wait != 0 && wait != 1))
+    return -1;
+  if(copyin(p->pagetable, (char *)fds, user_fds,
+            count * sizeof(fds[0])) < 0)
+    return -1;
+
+  for(int index = 0; index < count; index++){
+    int fd = fds[index];
+
+    if(fd < 0 || fd >= NOFILE)
+      return -1;
+    files[index] = p->ofile[fd];
+    if(files[index] == 0 || files[index]->type != FD_PIPE ||
+       files[index]->readable == 0)
+      return -1;
+  }
+
+  return pollreadfiles(files, count, wait);
+}

--- a/tests/guest/eventlooptest.c
+++ b/tests/guest/eventlooptest.c
@@ -1,0 +1,192 @@
+#include "kernel/types.h"
+#include "kernel/param.h"
+#include "kernel/riscv.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "tests/guest/testlib.h"
+
+// 捕获事件循环输出的缓冲区放在 BSS，避免占用 xv6 单页用户栈。
+static char captured_output[4096];
+
+/** 输出稳定失败原因并以非零状态终止测试。 */
+static void
+fail(char *message)
+{
+  printf("eventlooptest: FAIL: %s\n", message);
+  exit(1);
+}
+
+/** 断言一个测试条件。 */
+static void
+check(int condition, char *message)
+{
+  if(!condition)
+    fail(message);
+}
+
+/** 等待指定子进程成功退出。 */
+static void
+wait_successfully(int pid)
+{
+  int status = 0;
+
+  check(waitpid(pid, &status, 0) == pid, "waitpid returned unexpected child");
+  check(status == 0, "child process exited with failure");
+}
+
+/** 验证非阻塞快照、多源位图、重复等待与 pipe EOF 就绪语义。 */
+static void
+test_readiness_snapshot(void)
+{
+  int first[2];
+  int second[2];
+  int fds[2];
+  char value;
+
+  check(pipe(first) == 0, "cannot create first readiness pipe");
+  check(pipe(second) == 0, "cannot create second readiness pipe");
+  fds[0] = first[0];
+  fds[1] = second[0];
+
+  check(pollread(fds, 2, 0) == 0, "empty pipes were reported ready");
+  check(write(first[1], "a", 1) == 1, "cannot write first event");
+  check(write(second[1], "b", 1) == 1, "cannot write second event");
+  check(pollread(fds, 2, 0) == 3, "multi-source readiness bitmap is wrong");
+
+  check(read(first[0], &value, 1) == 1 && value == 'a',
+        "cannot consume first event");
+  check(read(second[0], &value, 1) == 1 && value == 'b',
+        "cannot consume second event");
+  check(pollread(fds, 2, 0) == 0, "consumed pipes remained data-ready");
+
+  close(first[1]);
+  check(pollread(fds, 2, 0) == 1, "writer close did not expose EOF readiness");
+  check(read(first[0], &value, 1) == 0, "EOF-ready pipe did not return zero");
+  close(first[0]);
+
+  fds[0] = second[0];
+  check(pollread(fds, 1, 0) == 0, "remaining empty pipe was reported ready");
+  check(write(second[1], "c", 1) == 1, "cannot write repeated event");
+  check(pollread(fds, 1, 0) == 1, "repeated event was omitted");
+  check(read(second[0], &value, 1) == 1 && value == 'c',
+        "cannot consume repeated event");
+
+  close(second[1]);
+  check(pollread(fds, 1, 0) == 1, "second EOF was not reported ready");
+  check(read(second[0], &value, 1) == 0, "second EOF did not return zero");
+  close(second[0]);
+}
+
+/** 验证扫描与 sleep 边界附近的写入唤醒不会丢失。 */
+static void
+test_blocking_wait(void)
+{
+  int event_pipe[2];
+  int fds[1];
+  int pid;
+  char value;
+
+  check(pipe(event_pipe) == 0, "cannot create blocking wait pipe");
+  pid = fork();
+  check(pid >= 0, "cannot fork blocking wait producer");
+  if(pid == 0){
+    close(event_pipe[0]);
+    sleep(3);
+    if(write(event_pipe[1], "w", 1) != 1)
+      exit(1);
+    close(event_pipe[1]);
+    exit(0);
+  }
+
+  close(event_pipe[1]);
+  fds[0] = event_pipe[0];
+  check(pollread(fds, 1, 1) == 1, "blocking wait missed producer event");
+  check(read(event_pipe[0], &value, 1) == 1 && value == 'w',
+        "blocking wait event cannot be consumed");
+  check(pollread(fds, 1, 1) == 1, "blocking wait missed writer EOF");
+  check(read(event_pipe[0], &value, 1) == 0, "writer EOF did not return zero");
+  close(event_pipe[0]);
+  wait_successfully(pid);
+}
+
+/** 验证教学接口拒绝无法诚实表达的对象和参数。 */
+static void
+test_invalid_inputs(void)
+{
+  int endpoints[2];
+  int fds[1];
+
+  check(pipe(endpoints) == 0, "cannot create invalid-input pipe");
+
+  fds[0] = endpoints[1];
+  check(pollread(fds, 1, 0) == -1, "pipe write end was accepted as readable");
+  fds[0] = NOFILE;
+  check(pollread(fds, 1, 0) == -1, "out-of-range fd was accepted");
+  fds[0] = endpoints[0];
+  check(pollread(fds, 0, 0) == -1, "zero descriptor count was accepted");
+  check(pollread(fds, NOFILE + 1, 0) == -1,
+        "descriptor count beyond NOFILE was accepted");
+  check(pollread(fds, 1, 2) == -1, "invalid wait mode was accepted");
+  check(pollread((int *)MAXVA, 1, 0) == -1,
+        "unmapped user array was accepted");
+
+  close(endpoints[0]);
+  close(endpoints[1]);
+}
+
+/** 执行事件循环用户程序并验证退出状态与关键公开 oracle。 */
+static void
+run_eventloop_and_check(char **argv, char *required_first, char *required_second)
+{
+  int status = 0;
+
+  check(xv6_test_run_capture(argv, 0, captured_output,
+                             sizeof(captured_output), &status) == 0,
+        "cannot execute eventloop program");
+  check(status == 0, "eventloop program exited with failure");
+  check(xv6_test_contains(captured_output, "EVENTLOOP snapshot ready=0"),
+        "eventloop omitted nonblocking snapshot");
+  check(xv6_test_contains(captured_output,
+                          "ORACLE state-complete PASS a=2 b=1 total=3"),
+        "eventloop state machine oracle failed");
+  check(xv6_test_contains(captured_output, required_first),
+        "eventloop omitted mode-specific oracle");
+  check(xv6_test_contains(captured_output, required_second),
+        "eventloop omitted completion marker");
+}
+
+/** 黑盒验证普通模式、阻塞 handler 反例和参数错误路径。 */
+static void
+test_eventloop_program(void)
+{
+  char *fast_argv[] = {"eventloop", 0};
+  char *slow_argv[] = {"eventloop", "--slow", 0};
+  char *bad_argv[] = {"eventloop", "--unknown", 0};
+  int status = 0;
+
+  run_eventloop_and_check(fast_argv,
+                          "ORACLE slow-handler SKIP",
+                          "EVENTLOOP done mode=fast");
+  run_eventloop_and_check(slow_argv,
+                          "ORACLE slow-handler PASS source=B",
+                          "EVENTLOOP done mode=slow");
+
+  check(xv6_test_run_capture(bad_argv, 0, captured_output,
+                             sizeof(captured_output), &status) == 0,
+        "cannot execute eventloop argument error path");
+  check(status == 2, "eventloop argument error returned wrong status");
+  check(xv6_test_contains(captured_output, "Usage: eventloop [--slow]"),
+        "eventloop argument error omitted usage");
+}
+
+/** 运行 pipe readiness 与事件循环的完整 guest 回归。 */
+int
+main(void)
+{
+  test_readiness_snapshot();
+  test_blocking_wait();
+  test_invalid_inputs();
+  test_eventloop_program();
+  printf("eventlooptest: OK\n");
+  exit(0);
+}

--- a/tests/guest/testlib.c
+++ b/tests/guest/testlib.c
@@ -26,6 +26,7 @@ static struct test_program_path test_program_paths[] = {
   {"uthread", XV6_USR_BIN_PATH("uthread")},
   {"varead", XV6_USR_BIN_PATH("varead")},
   {"vawrite", XV6_USR_BIN_PATH("vawrite")},
+  {"eventloop", "/eventloop"},
   {0, 0},
 };
 

--- a/user/eventloop.c
+++ b/user/eventloop.c
@@ -1,0 +1,305 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+#define SOURCE_COUNT 2
+#define SOURCE_A 0
+#define SOURCE_B 1
+#define SOURCE_A_EVENTS 2
+#define SOURCE_B_EVENTS 1
+#define TOTAL_EVENTS (SOURCE_A_EVENTS + SOURCE_B_EVENTS)
+#define SLOW_HANDLER_TICKS 20
+#define SLOW_LAG_MIN_TICKS 10
+
+/** 一个由 pipe 传递、并由事件循环分派的完整教学事件。 */
+struct event_message {
+  int source;
+  int sequence;
+  int produced_tick;
+};
+
+/** 事件循环显式保存的单个事件源状态。 */
+struct source_state {
+  int fd;
+  int source;
+  int expected_sequence;
+  int handled;
+  int eof;
+};
+
+/** 输出稳定失败原因并以非零状态终止事件循环。 */
+static void
+fail(char *message)
+{
+  printf("eventloop: FAIL: %s\n", message);
+  exit(1);
+}
+
+/** 断言一个事件循环不变量。 */
+static void
+check(int condition, char *message)
+{
+  if(!condition)
+    fail(message);
+}
+
+/** 返回事件源的稳定公开名称。 */
+static char *
+source_name(int source)
+{
+  if(source == SOURCE_A)
+    return "A";
+  if(source == SOURCE_B)
+    return "B";
+  return "?";
+}
+
+/** 向事件源 pipe 原子写入一条固定大小事件。 */
+static void
+emit_event(int fd, int source, int sequence)
+{
+  struct event_message event = {
+    .source = source,
+    .sequence = sequence,
+    .produced_tick = uptime(),
+  };
+
+  if(write(fd, &event, sizeof(event)) != sizeof(event))
+    exit(1);
+}
+
+/**
+ * 生成固定、可重复的多源事件负载。
+ *
+ * A 在第一个事件后保留较长间隔；B 会在慢处理器睡眠期间产生事件，从而形成
+ * “事件已就绪但尚未被分派”的稳定观察窗口。
+ */
+static void
+run_source(int source, int fd)
+{
+  if(source == SOURCE_A){
+    sleep(2);
+    emit_event(fd, source, 1);
+    sleep(24);
+    emit_event(fd, source, 2);
+  } else if(source == SOURCE_B){
+    sleep(6);
+    emit_event(fd, source, 1);
+  } else {
+    exit(1);
+  }
+
+  close(fd);
+  exit(0);
+}
+
+/** 创建一个先等待共同 gate、再产生事件的子进程。 */
+static int
+spawn_source(int source, int pipes[SOURCE_COUNT][2], int gate[2])
+{
+  int pid = fork();
+
+  check(pid >= 0, "cannot fork event source");
+  if(pid == 0){
+    char token;
+
+    close(gate[1]);
+    for(int index = 0; index < SOURCE_COUNT; index++){
+      close(pipes[index][0]);
+      if(index != source)
+        close(pipes[index][1]);
+    }
+
+    if(read(gate[0], &token, 1) != 1)
+      exit(1);
+    close(gate[0]);
+    run_source(source, pipes[source][1]);
+  }
+
+  return pid;
+}
+
+/** 等待指定事件源子进程成功退出。 */
+static void
+wait_source(int pid)
+{
+  int status = 0;
+
+  check(waitpid(pid, &status, 0) == pid, "waitpid returned unexpected source");
+  check(status == 0, "event source exited with failure");
+}
+
+/** 根据显式状态表构造本轮仍需等待的 fd 与状态下标。 */
+static int
+build_active_set(struct source_state states[SOURCE_COUNT],
+                 int fds[SOURCE_COUNT], int indexes[SOURCE_COUNT])
+{
+  int count = 0;
+
+  for(int index = 0; index < SOURCE_COUNT; index++){
+    if(states[index].eof)
+      continue;
+    fds[count] = states[index].fd;
+    indexes[count] = index;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * 分派一条已经从就绪 pipe 读取的事件，并推进显式来源状态。
+ *
+ * 状态更新严格校验来源与序号，能把“两个来源共用一份进度”或“遗漏一个事件”
+ * 转化为确定失败，而不是只依赖输出顺序观察。
+ */
+static void
+dispatch_event(struct source_state states[SOURCE_COUNT], int state_index,
+               struct event_message *event, int slow_handler,
+               int *total_handled, int *slow_source_lag)
+{
+  struct source_state *state = &states[state_index];
+  int dispatch_tick = uptime();
+  int lag = dispatch_tick - event->produced_tick;
+
+  check(event->source == state->source, "event delivered to wrong state owner");
+  check(event->sequence == state->expected_sequence,
+        "event sequence was omitted or state was shared");
+
+  printf("EVENT ready source=%s sequence=%d lag=%d\n",
+         source_name(event->source), event->sequence, lag);
+  printf("DISPATCH source=%s sequence=%d\n",
+         source_name(event->source), event->sequence);
+
+  if(slow_handler && event->source == SOURCE_A && event->sequence == 1){
+    printf("HANDLER slow begin source=A ticks=%d\n", SLOW_HANDLER_TICKS);
+    sleep(SLOW_HANDLER_TICKS);
+    printf("HANDLER slow end source=A\n");
+  }
+
+  state->handled++;
+  state->expected_sequence++;
+  (*total_handled)++;
+  if(slow_handler && event->source == SOURCE_B)
+    *slow_source_lag = lag;
+
+  printf("STATE a=%d b=%d total=%d\n",
+         states[SOURCE_A].handled, states[SOURCE_B].handled, *total_handled);
+}
+
+/** 执行一次完整的多源事件循环实验。 */
+static int
+run_event_loop(int slow_handler)
+{
+  int pipes[SOURCE_COUNT][2];
+  int gate[2];
+  int source_pids[SOURCE_COUNT];
+  int initial_fds[SOURCE_COUNT];
+  int total_handled = 0;
+  int slow_source_lag = -1;
+  int open_sources = SOURCE_COUNT;
+  struct source_state states[SOURCE_COUNT];
+
+  for(int index = 0; index < SOURCE_COUNT; index++)
+    check(pipe(pipes[index]) == 0, "cannot create source pipe");
+  check(pipe(gate) == 0, "cannot create source gate");
+
+  for(int index = 0; index < SOURCE_COUNT; index++)
+    source_pids[index] = spawn_source(index, pipes, gate);
+
+  close(gate[0]);
+  for(int index = 0; index < SOURCE_COUNT; index++){
+    close(pipes[index][1]);
+    states[index].fd = pipes[index][0];
+    states[index].source = index;
+    states[index].expected_sequence = 1;
+    states[index].handled = 0;
+    states[index].eof = 0;
+    initial_fds[index] = pipes[index][0];
+  }
+
+  // 子进程仍被 gate 阻塞，因此这个零结果是确定的非阻塞快照，不依赖调度运气。
+  check(pollread(initial_fds, SOURCE_COUNT, 0) == 0,
+        "empty nonblocking snapshot reported readiness");
+  printf("EVENTLOOP snapshot ready=0\n");
+
+  check(write(gate[1], "gg", SOURCE_COUNT) == SOURCE_COUNT,
+        "cannot release event sources");
+  close(gate[1]);
+
+  while(open_sources > 0){
+    int active_fds[SOURCE_COUNT];
+    int active_indexes[SOURCE_COUNT];
+    int active_count = build_active_set(states, active_fds, active_indexes);
+    int ready;
+
+    check(active_count == open_sources, "active source count diverged");
+    ready = pollread(active_fds, active_count, 1);
+    check(ready > 0, "blocking readiness wait failed");
+
+    for(int slot = 0; slot < active_count; slot++){
+      struct source_state *state;
+      struct event_message event;
+      int count;
+
+      if((ready & (1 << slot)) == 0)
+        continue;
+      state = &states[active_indexes[slot]];
+      count = read(state->fd, &event, sizeof(event));
+      if(count == 0){
+        state->eof = 1;
+        open_sources--;
+        close(state->fd);
+        printf("EVENT eof source=%s\n", source_name(state->source));
+        continue;
+      }
+      check(count == sizeof(event), "pipe returned a partial event");
+      dispatch_event(states, active_indexes[slot], &event, slow_handler,
+                     &total_handled, &slow_source_lag);
+    }
+  }
+
+  for(int index = 0; index < SOURCE_COUNT; index++)
+    wait_source(source_pids[index]);
+
+  check(states[SOURCE_A].handled == SOURCE_A_EVENTS,
+        "source A final event count is wrong");
+  check(states[SOURCE_B].handled == SOURCE_B_EVENTS,
+        "source B final event count is wrong");
+  check(total_handled == TOTAL_EVENTS, "global event count is wrong");
+  printf("ORACLE state-complete PASS a=%d b=%d total=%d\n",
+         states[SOURCE_A].handled, states[SOURCE_B].handled, total_handled);
+
+  if(slow_handler){
+    check(slow_source_lag >= SLOW_LAG_MIN_TICKS,
+          "slow handler did not delay unrelated ready event");
+    printf("ORACLE slow-handler PASS source=B lag=%d\n", slow_source_lag);
+  } else {
+    printf("ORACLE slow-handler SKIP\n");
+  }
+
+  printf("EVENTLOOP done mode=%s\n", slow_handler ? "slow" : "fast");
+  return 0;
+}
+
+/** 打印事件循环教学程序的参数格式。 */
+static void
+usage(void)
+{
+  fprintf(2, "Usage: eventloop [--slow]\n");
+}
+
+/** 选择普通事件循环或故意阻塞 handler 的反例模式。 */
+int
+main(int argc, char *argv[])
+{
+  int slow_handler = 0;
+
+  if(argc == 2 && strcmp(argv[1], "--slow") == 0){
+    slow_handler = 1;
+  } else if(argc != 1){
+    usage();
+    exit(2);
+  }
+
+  exit(run_event_loop(slow_handler));
+}

--- a/user/pollread.h
+++ b/user/pollread.h
@@ -1,0 +1,14 @@
+#ifndef XV6_USER_POLLREAD_H
+#define XV6_USER_POLLREAD_H
+
+/**
+ * 返回 pipe 读端的当前就绪位图，或等待其中任一读端就绪。
+ *
+ * @param fds pipe 读端描述符数组。
+ * @param count 数组中的有效描述符数量，范围为 1 到 NOFILE。
+ * @param wait 非零时阻塞等待，为零时只读取当前快照。
+ * @return 成功返回按数组槽位编码的非负位图；参数非法时返回 -1。
+ */
+int pollread(int *fds, int count, int wait);
+
+#endif

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -19,6 +19,7 @@ entry("exit");
 entry("wait");
 entry("waitpid");
 entry("pipe");
+entry("pollread");
 entry("read");
 entry("write");
 entry("close");

--- a/user/xv6test_eventloop.c
+++ b/user/xv6test_eventloop.c
@@ -1,0 +1,98 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+/** 主线 xv6test 入口；Makefile 仅在该翻译单元内重命名 main。 */
+int xv6test_original_main(int argc, char *argv[]);
+
+/** 等待一个子进程，并把其退出状态返回给调用者。 */
+static int
+wait_child(int pid)
+{
+  int status = 1;
+
+  if(pid < 0 || waitpid(pid, &status, 0) != pid)
+    return 1;
+  return status;
+}
+
+/** 在子进程中运行主线 xv6test，避免它的 exit() 终止适配入口。 */
+static int
+run_original(int argc, char *argv[])
+{
+  int pid = fork();
+
+  if(pid < 0)
+    return 1;
+  if(pid == 0)
+    xv6test_original_main(argc, argv);
+  return wait_child(pid);
+}
+
+/** 通过稳定的 XV6TEST 协议运行事件循环回归。 */
+static int
+run_eventloop_test(void)
+{
+  char *argv[] = {"/eventlooptest", 0};
+  int pid;
+  int status;
+
+  printf("XV6TEST begin group=core test=core-eventloop\n");
+  printf("XV6TEST run 1 - core-eventloop group=core\n");
+  pid = fork();
+  if(pid < 0){
+    printf("xv6test-eventloop: FAIL: fork\n");
+    return 1;
+  }
+  if(pid == 0){
+    exec(argv[0], argv);
+    printf("xv6test-eventloop: FAIL: exec %s\n", argv[0]);
+    exit(1);
+  }
+
+  status = wait_child(pid);
+  if(status != 0){
+    printf("xv6test-eventloop: FAIL: status=%d\n", status);
+    printf("XV6TEST not ok 1 - core-eventloop status=%d\n", status);
+    printf("XV6TEST summary selected=1 passed=0 failed=1\n");
+    printf("XV6TEST done status=1\n");
+    return 1;
+  }
+
+  printf("XV6TEST ok 1 - core-eventloop\n");
+  printf("XV6TEST summary selected=1 passed=1 failed=0\n");
+  printf("XV6TEST done status=0\n");
+  return 0;
+}
+
+/** 判断当前选择是否必须追加事件循环回归。 */
+static int
+should_append_eventloop(int argc, char *argv[])
+{
+  if(argc == 1)
+    return 1;
+  if(argc == 2 && strcmp(argv[1], "--all") == 0)
+    return 1;
+  return argc == 3 && strcmp(argv[1], "--group") == 0 &&
+         strcmp(argv[2], "core") == 0;
+}
+
+/** 保留主线注册表，只在 core 入口和精确选择时追加 eventlooptest。 */
+int
+main(int argc, char *argv[])
+{
+  if(argc == 3 && strcmp(argv[1], "--run") == 0 &&
+     strcmp(argv[2], "core-eventloop") == 0)
+    exit(run_eventloop_test());
+
+  if(should_append_eventloop(argc, argv)){
+    int status = run_original(argc, argv);
+
+    if(status != 0)
+      exit(status);
+    exit(run_eventloop_test());
+  }
+
+  xv6test_original_main(argc, argv);
+  exit(1);
+}


### PR DESCRIPTION
## PR 信息

- 关联 Issue：Closes #152
- 参考约束：#134
- `main` 基线 Commit：`4f2e705c727333af014d98a0b9192966487a2f84`
- 验证 Commit：`e144a7b5fdcb21b7751027ae4891f296ab4d7bb8`
- 分支：`concept/152-event-driven-concurrency`
- Obsidian 跟踪：mental1104/Obsidian#226
- 状态：已解决与当前 `main` 的冲突；保持 Draft，未经确认不合并。

## 中心认知与范围

事件驱动并发不是“有中断”或“单线程”本身，而是：

```text
等待一组事件源
→ 返回当前可推进的来源
→ 恢复该来源的显式状态
→ 执行一个短 handler
→ 更新状态并重新等待
```

本 PR 用两个 pipe 事件源建立最小可运行闭环，并用阻塞 handler 拖延另一已就绪来源作为反例。范围限定为教学型 pipe 可读就绪，不仿制完整 POSIX `poll/select/epoll`。

## 本轮冲突处理

- 将分支重写到最新 `main` 基线，当前 PR 只保留 1 个聚合提交，避免继续携带过期冲突历史。
- 保留主线新增的 semaphore、磁盘调度、锁模型、崩溃恢复和测试注册。
- `pollread` 系统调用编号调整为 `61`，避开主线已占用的 `1..60`。
- 将教学 API 声明拆到 `kernel/poll.h` 与 `user/pollread.h`，降低 `kernel/defs.h`、`user/user.h` 这类共享注册文件的长期冲突面。
- 用 `user/xv6test_eventloop.c` 适配主线 `xv6test`：不覆盖主线注册表，只在 `core` 组和 `core-eventloop` 精确入口追加事件循环回归。
- `eventloop` 与 `eventlooptest` 保留为文件系统根目录程序；主线 `/usr/bin/xv6test` 仍作为统一回归入口。

## 关键实现

- 新增 `pollread(fds, count, wait)`：只接受 pipe 读端，返回按输入槽位编码的就绪位图；已有数据和 EOF 均视为可读。
- `kernel/poll.c` 使用全局等待通道，将“扫描 + sleep”置于同一把锁下，避免扫描与睡眠边界丢失唤醒。
- `pipewrite()` 与写端 `pipeclose()` 在释放 pipe 锁后通知等待者，保持 `pollstate.lock -> pipe.lock` 固定锁序。
- 新增 `/eventloop`：两个自动事件源、每源独立序号状态、EOF 生命周期、普通模式与 `--slow` 反例模式。
- 新增 `core-eventloop` guest 回归：覆盖空快照、多源位图、重复事件、EOF、阻塞等待、非法输入、程序黑盒输出和慢 handler 反例。

关键文件：

```text
kernel/poll.c
kernel/poll.h
kernel/syspoll.c
kernel/pipe.c
user/pollread.h
user/eventloop.c
user/xv6test_eventloop.c
tests/guest/eventlooptest.c
```

## 状态、锁与不变量

- 状态所有者：用户态 `source_state` 分别持有每个来源的 fd、期望序号、已处理数量与 EOF 状态。
- 就绪条件：pipe 缓冲区非空，或写端全部关闭使下一次 `read()` 返回 EOF。
- 锁序：扫描路径为 `pollstate.lock -> pipe.lock`；写入和关闭路径先释放 `pipe.lock`，再获取 `pollstate.lock` 通知。
- 关键不变量：同一事件只推进所属来源的状态；每个来源的序号连续；全部来源 EOF 后事件循环结束；扫描到睡眠之间不遗漏状态变化。

## 验证结果

验证 Commit：`e144a7b5fdcb21b7751027ae4891f296ab4d7bb8`

- [x] `make test-unit`：PASS
- [x] `make clean && make -j2`：PASS
- [x] `python3 tests/shell_history_interactive.py --cpus 3`：PASS
- [x] `python3 tests/run.py --suite pr --cpus 3`：PASS，`core` 组包含 `core-eventloop`
- [x] `python3 tests/run_usertests.py --cpus 3`：PASS
- [x] `python3 tests/run_lock_model.py --cpus 3`：PASS，覆盖单核与多核重建验证
- [x] RAID1 教学实验默认构建、单核与多核验证：PASS

Actions：

- [xv6 Main Gate #596](https://github.com/mental1104/xv6/actions/runs/30473909684)
- [RAID1 teaching experiment #17](https://github.com/mental1104/xv6/actions/runs/30473911066)

聚焦人工验收入口：

```text
/usr/bin/xv6test --run core-eventloop
/eventloop
/eventloop --slow
```

关键公开 oracle：

```text
EVENTLOOP snapshot ready=0
ORACLE state-complete PASS a=2 b=1 total=3
ORACLE slow-handler PASS source=B lag=<ticks>
EVENTLOOP done mode=slow
```

## 教学边界

- `pollread` 不是 POSIX `poll/select/epoll`：不支持普通文件、设备、写就绪、超时、信号掩码或 socket。
- 全局等待通道会产生惊群，只用于闭合最小教学机制，不代表生产实现的扩展方式。
- xv6 中断与 `sleep/wakeup` 只作为底层机制证据，不被表述为完整事件循环。
- 慢 handler 由用户态 `sleep(20)` 构造，只证明同一事件循环内的阻塞会拖延其他已就绪来源。

## 未覆盖边界

- 多线程并发关闭同一 fd；xv6 当前用户态模型未提供该场景。
- POSIX 超时、信号和不同对象类型的统一 readiness 语义。
- 高并发事件源下的等待队列分片、边沿触发和惊群治理。

未经确认不合并；Obsidian 笔记应以验证 Commit 的固定链接继续收敛。