### PR TITLE
fix: enforce symlink depth by followed links

### DIFF
--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -300,19 +300,33 @@ read_symlink_target_locked(struct inode *ip, char *path)
   return 0;
 }
 
-// Follow symbolic links and return an unlocked inode reference.
+/**
+ * 跟随符号链接并返回最终 inode 的未锁定引用。
+ *
+ * @param ip 当前路径解析得到的未锁定 inode 引用；函数始终接管该引用。
+ * @param path 可复用的路径缓冲区，每次跳转后会被目标路径覆盖。
+ * @return 成功返回最终非符号链接 inode 的未锁定引用；读取、解析失败或超过
+ * MAXSYMLINK 个符号链接时返回 0，并释放函数已持有的 inode 引用。
+ */
 static struct inode*
 follow_symlinks(struct inode *ip, char *path)
 {
   int remaining = MAXSYMLINK;
 
-  while(remaining-- > 0){
+  for(;;){
     ilock(ip);
 
     if(ip->type != T_SYMLINK){
       iunlock(ip);
-      break;
+      return ip;
     }
+
+    // 深度额度只由实际的符号链接跳转消耗，检查最终普通 inode 不占额度。
+    if(remaining == 0){
+      iunlockput(ip);
+      return 0;
+    }
+    remaining--;
 
     if(read_symlink_target_locked(ip, path) < 0){
       iunlockput(ip);
@@ -324,13 +338,6 @@ follow_symlinks(struct inode *ip, char *path)
     if(ip == 0)
       return 0;
   }
-
-  if(remaining <= 0){
-    iput(ip);
-    return 0;
-  }
-
-  return ip;
 }
 
 // Return the inode locked on success.

--- a/tests/guest/symlinktest.c
+++ b/tests/guest/symlinktest.c
@@ -12,7 +12,15 @@
 #define fail(msg) do {printf("FAILURE: " msg "\n"); failed = 1; goto done;} while (0);
 static int failed = 0;
 
+static char *depth_paths[] = {
+  "/testsymlink/d0", "/testsymlink/d1", "/testsymlink/d2",
+  "/testsymlink/d3", "/testsymlink/d4", "/testsymlink/d5",
+  "/testsymlink/d6", "/testsymlink/d7", "/testsymlink/d8",
+  "/testsymlink/d9", "/testsymlink/d10", "/testsymlink/d11",
+};
+
 static void testsymlink(void);
+static void testdepth(void);
 static void concur(void);
 static void cleanup(void);
 
@@ -21,10 +29,13 @@ main(int argc, char *argv[])
 {
   cleanup();
   testsymlink();
+  testdepth();
   concur();
+  cleanup();
   exit(failed);
 }
 
+/** 删除本测试创建的所有路径，使连续运行共享同一镜像时仍从干净状态开始。 */
 static void
 cleanup(void)
 {
@@ -37,19 +48,29 @@ cleanup(void)
   unlink("/testsymlink/4");
   unlink("/testsymlink/z");
   unlink("/testsymlink/y");
+  for(int i = 0; i < sizeof(depth_paths) / sizeof(depth_paths[0]); i++)
+    unlink(depth_paths[i]);
   unlink("/testsymlink");
 }
 
-// stat a symbolic link using O_NOFOLLOW
+/**
+ * 使用 O_NOFOLLOW 读取符号链接自身的元数据。
+ *
+ * @param pn 待检查路径。
+ * @param st 接收文件状态的调用者缓冲区。
+ * @return 成功返回 0；路径无法打开或 fstat 失败时返回 -1。函数始终关闭临时 fd。
+ */
 static int
 stat_slink(char *pn, struct stat *st)
 {
+  int result = -1;
   int fd = open(pn, O_RDONLY | O_NOFOLLOW);
   if(fd < 0)
     return -1;
-  if(fstat(fd, st) != 0)
-    return -1;
-  return 0;
+  if(fstat(fd, st) == 0)
+    result = 0;
+  close(fd);
+  return result;
 }
 
 static void
@@ -126,9 +147,54 @@ testsymlink(void)
     fail("Value read from 4 differed from value written to 1\n");
 
   printf("test symlinks: ok\n");
-done:
+ done:
   close(fd1);
   close(fd2);
+}
+
+/** 验证恰好十次符号链接跳转成功，而第十一次跳转被深度上限拒绝。 */
+static void
+testdepth(void)
+{
+  int fd = -1;
+
+  printf("Start: test symlink depth boundary\n");
+
+  for(int i = 0; i < 10; i++)
+    if(symlink(depth_paths[i + 1], depth_paths[i]) < 0)
+      fail("failed to create ten-link chain");
+
+  fd = open(depth_paths[10], O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("failed to create ten-link target");
+  close(fd);
+  fd = -1;
+
+  fd = open(depth_paths[0], O_RDONLY);
+  if(fd < 0)
+    fail("ten symbolic links should be accepted");
+  close(fd);
+  fd = -1;
+
+  if(unlink(depth_paths[10]) < 0)
+    fail("failed to replace ten-link target");
+  if(symlink(depth_paths[11], depth_paths[10]) < 0)
+    fail("failed to extend chain to eleven links");
+
+  fd = open(depth_paths[11], O_CREATE | O_RDWR);
+  if(fd < 0)
+    fail("failed to create eleven-link target");
+  close(fd);
+  fd = -1;
+
+  fd = open(depth_paths[0], O_RDONLY);
+  if(fd >= 0)
+    fail("eleven symbolic links should exceed the limit");
+
+  printf("test symlink depth boundary: ok\n");
+ done:
+  if(fd >= 0)
+    close(fd);
 }
 
 static void


### PR DESCRIPTION
## 中心行为

修正 `follow_symlinks()` 的深度计数：只有实际跟随 `T_SYMLINK` 时才消耗额度，检查最终普通 inode 不再占用一个跳转名额。

## 基线

- `main`: `087ac031a2a6c7a77ab59ba71a4ee433fa11875f`
- Issue: #238
- 归档任务: #164

## 改动

- `kernel/sysfile.c`
  - 允许恰好跟随 `MAXSYMLINK == 10` 个符号链接；
  - 第 11 个符号链接返回失败；
  - 深度耗尽时通过 `iunlockput()` 同时释放 inode 锁和引用；
  - 保持悬空链接、循环链接与 `O_NOFOLLOW` 语义不变。
- `tests/guest/symlinktest.c`
  - 新增 10 跳成功、11 跳失败的精确边界回归；
  - 测试前后清理深度链路，支持同一镜像重复运行；
  - 修复 `stat_slink()` 临时文件描述符未关闭的问题，避免并发循环在 fd 耗尽后静默弱化断言。

## 测试映射

- guest test: `tests/guest/symlinktest.c`
- xv6test name: `lab9-symlink`
- suite: `lab9-symlink`
- 独立 QEMU snapshot: 沿用现有 suite，不新增 runner 或 workflow。

## 实际验证

GitHub Actions `xv6 CI` run `30187786921`：

- `Unit-test regression grader`: success
- `Build xv6`: success
- `Run selected PR QEMU regression`: success
- `Run filesystem regression single-core`: success
- 整个 regression job: success
- 为验证清理与可重复性，手动 rerun 同一 regression job；第二次上述构建、选定 QEMU 回归与单核文件系统回归再次 success。

同一 head 的 `Scheduler family CI` run `30187786928`：

- PR regression suites: success
- complete usertests: success
- scheduler / SMP smoke jobs: success
- workflow: success

本会话没有可用的本地 RISC-V/QEMU 工作区，因此未声称执行本地 `make`；以上为真实 GitHub runner 结果。

## 静态检查

- 与基线比较仅修改 `kernel/sysfile.c`、`tests/guest/symlinktest.c`；
- 未修改 GitHub Actions workflow、测试 runner 或磁盘格式；
- 深度失败、读取失败和目标解析失败均释放当前 inode 资源；
- 最终普通 inode 成功返回时保留引用，由后续 `struct file` 接管。

## 边界

这是教学实现中的深度边界修复，不扩展到相对目标路径语义、目录遍历中间分量跟随或 Linux `ELOOP` 错误码。

Closes #238
Related to #164