### PR TITLE
Route xv6 Actions to post-merge main gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,37 @@
-name: xv6 CI
+name: xv6 Main Gate
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  schedule:
-    # 新加坡时间 02:30 执行完整慢速回归，避免占用白天的 PR 反馈窗口。
-    - cron: "30 18 * * *"
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: xv6-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
+  validate-main:
+    name: Validate main ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::xv6 Main Gate can only run against main."
+            exit 1
+          fi
+
   regression:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: validate-main
     runs-on: ubuntu-24.04
     timeout-minutes: 50
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # PR 事件需要同时读取 base/head commit，才能可靠计算 changed files。
-          fetch-depth: 0
 
       - name: Install toolchain
         run: |
@@ -56,146 +61,15 @@ jobs:
           make clean
           make -j2
 
-      - name: Select PR regression suites
-        if: github.event_name == 'pull_request'
-        id: plan
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed-files.txt
-          echo "Changed files:"
-          cat /tmp/changed-files.txt
-          python3 tests/ci_plan.py < /tmp/changed-files.txt | tee -a "$GITHUB_OUTPUT"
-          if grep -Eq '^(tests/guest/usertests_2g\.c|kernel/file\.c|tests/guest/xv6test\.c|tests/run_usertests\.py)$' /tmp/changed-files.txt; then
-            echo 'full_usertests=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'full_usertests=false' >> "$GITHUB_OUTPUT"
-          fi
-          if grep -Eq '^(kernel/(console\.c|jobctl\.h|proc\.h|sysproc\.c|trap\.c|wait\.h)|user/sh\.c|tests/guest/consolelinetest\.c|tests/shell_history_interactive\.py)$' /tmp/changed-files.txt; then
-            echo 'job_control=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'job_control=false' >> "$GITHUB_OUTPUT"
-          fi
-          if grep -Eq '^(kernel/(concurrencylab\.h|proc\.c|sleeplock\.c|spinlock\.c|swtch\.S)|tests/guest/uthreadtest\.c|tests/host/(barrier\.c|ph\.c))$' /tmp/changed-files.txt; then
-            echo 'concurrency_single_core=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'concurrency_single_core=false' >> "$GITHUB_OUTPUT"
-          fi
-          if grep -Eq '^(kernel/(bio\.c|file\.c|fs\.c|fs\.h|fsinspect\.c|fsinspect\.h|log\.c|sysfile\.c|sysfsinspect\.c|virtio_disk\.c)|mkfs/mkfs\.c|tests/guest/fileapitest\.c)$' /tmp/changed-files.txt; then
-            echo 'filesystem=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'filesystem=false' >> "$GITHUB_OUTPUT"
-          fi
-          if grep -Eq '^(Makefile|kernel/(defs\.h|locklab\.c|locklab\.h|main\.c|syscall\.c|syscall\.h|syscall_names\.h|syslocklab\.c)|tests/guest/(locktest\.c|xv6test\.c)|tests/run_lock_model\.py|tests/test_run_lock_model\.py|user/(init\.c|user\.h|usys\.pl))$' /tmp/changed-files.txt; then
-            echo 'lock_model=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'lock_model=false' >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Run shell history interaction regression
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.shell_history == 'true'
-        run: python3 tests/shell_history_interactive.py --cpus 3
-
-      # 先消费初始的三核构建，再执行会重建 CPUS=1 的补充回归。否则 make 不会
-      # 因命令行 CFLAGS 变化自动重编译，后续三核 QEMU 会加载带 XV6_CPUS=1 的旧对象。
-      - name: Run selected PR QEMU regression
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.suites != ''
-        env:
-          SELECTED_SUITES: ${{ steps.plan.outputs.suites }}
-        run: |
-          IFS=',' read -r -a suites <<< "$SELECTED_SUITES"
-          args=()
-          for suite in "${suites[@]}"; do
-            if [[ -n "$suite" ]]; then
-              args+=(--suite "$suite")
-            fi
-          done
-          printf 'Selected PR suites: %s\n' "${suites[*]}"
-          python3 tests/run.py "${args[@]}" --cpus 3
-
-      - name: Run lock model single-core and multi-core matrix
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.lock_model == 'true'
-        run: python3 tests/run_lock_model.py --cpus 3
-
-      - name: Run job-control regression single-core
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.job_control == 'true'
-        run: python3 tests/run.py --suite usertests-core --cpus 1
-
-      - name: Run filesystem regression single-core
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.filesystem == 'true'
-        run: |
-          set -o pipefail
-          mkdir -p test-results/infrastructure
-          rm -rf test-results/usertests-core
-          # CPUS participates in the kernel build; rebuild rather than reusing the
-          # default three-CPU image when collecting the supplementary one-CPU result.
-          make clean
-          make -j2 CPUS=1 2>&1 | tee test-results/infrastructure/filesystem-single-core-build.log
-          make test-suite SUITE=usertests-core CPUS=1 2>&1 | tee test-results/infrastructure/filesystem-single-core-run.log
-
-      - name: Run concurrency regression single-core
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.concurrency_single_core == 'true'
-        run: |
-          set -o pipefail
-          mkdir -p test-results/infrastructure
-          rm -rf test-results/lab7-thread
-          # CPUS changes a compile-time kernel constant; force a clean one-CPU image.
-          make clean
-          make -j2 CPUS=1 2>&1 | tee test-results/infrastructure/concurrency-single-core-build.log
-          make test-suite SUITE=lab7-thread CPUS=1 2>&1 | tee test-results/infrastructure/concurrency-single-core-run.log
-
-      - name: Run VM regression single-core
-        if: >-
-          github.event_name == 'pull_request' &&
-          contains(steps.plan.outputs.suites, 'lab-vm')
-        run: |
-          set -o pipefail
-          mkdir -p test-results/infrastructure
-          rm -rf test-results/lab-vm
-          # CPUS changes a compile-time kernel constant. Rebuild after the
-          # default three-CPU suite instead of reusing its stale kernel image.
-          make clean
-          make -j2 CPUS=1 2>&1 | tee test-results/infrastructure/vm-single-core-build.log
-          make test-suite SUITE=lab-vm CPUS=1 2>&1 | tee test-results/infrastructure/vm-single-core-run.log
-
-      - name: Run complete usertests for lifecycle-sensitive changes
-        if: >-
-          github.event_name == 'pull_request' &&
-          steps.plan.outputs.full_usertests == 'true'
-        run: |
-          dump_usertests_log() {
-            local log="test-results/usertests-full/usertests-full.log"
-            echo "::group::Failing usertests guest output (last 160 lines)"
-            if [[ -f "$log" ]]; then
-              tail -n 160 "$log"
-            else
-              echo "No usertests log was created at $log"
-            fi
-            echo "::endgroup::"
-          }
-
-          # 逐项 runner 为每个测试设置独立看门狗，并有意跳过旧 writebig 的
-          # MAXFILE 密集写。三级间接和文件上界由已选中的 lab9-bigfile 专项覆盖。
-          python3 tests/run_usertests.py --cpus 3 || { dump_usertests_log; exit 1; }
-
-      - name: Run scheduled or manual full regression
-        if: github.event_name != 'pull_request'
+      - name: Run complete main regression
         run: |
           python3 tests/shell_history_interactive.py --cpus 3
           make test-full CPUS=3
+
+      # 锁模型 runner 会分别重建并验证单核、多核配置；放在完整回归之后，
+      # 避免它留下的编译期 CPUS 配置污染前面的通用 QEMU 回归。
+      - name: Run lock model regression
+        run: python3 tests/run_lock_model.py --cpus 3
 
       # _start_qemu() can fail before the Python runner creates its first log.
       # Capture one bounded serial boot attempt so startup panics are preserved.
@@ -214,3 +88,28 @@ jobs:
           name: xv6-test-results-${{ github.run_id }}
           path: test-results/
           if-no-files-found: ignore
+
+  notify-manual-failure:
+    name: Notify manual failure
+    needs: [validate-main, regression]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure email
+        uses: dawidd6/action-send-mail@v6
+        with:
+          connection_url: ${{ secrets.SMTP_CONNECTION_URL }}
+          from: ${{ secrets.MAIL_FROM }}
+          to: ${{ secrets.MAIL_TO }}
+          subject: "[CI Failed] ${{ github.repository }} main manual gate"
+          body: |
+            main 分支手动门禁执行失败。
+
+            仓库：${{ github.repository }}
+            提交：${{ github.sha }}
+            执行人：${{ github.actor }}
+            运行地址：${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/scheduler-ci.yml
+++ b/.github/workflows/scheduler-ci.yml
@@ -1,27 +1,56 @@
-name: Scheduler family CI
+name: Scheduler family Main Gate
 
 on:
-  pull_request:
+  push:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "Makefile"
+      - "kernel/proc.c"
+      - "kernel/proc.h"
+      - "kernel/sched.c"
+      - "kernel/sched.h"
+      - "kernel/schedstat.h"
+      - "kernel/schedtrace.c"
+      - "kernel/schedtrace.h"
+      - "kernel/sysproc.c"
+      - "kernel/trap.c"
+      - "user/schedviz.c"
+      - "tests/guest/schedtest.c"
+      - "tests/host/scheduler_smoke.c"
+      - "tests/host/scheduler_visualizer.c"
+      - "tests/run.py"
+      - "tests/run_usertests.py"
+      - ".github/workflows/scheduler-ci.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: scheduler-ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
+  validate-main:
+    name: Validate main ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Scheduler family Main Gate can only run against main."
+            exit 1
+          fi
+
   scheduler:
+    needs: validate-main
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         policy: [rr, fifo, sjf, stcf, mlfq, cfs]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,13 +80,13 @@ jobs:
         run: ./scheduler_smoke --policy ${{ matrix.policy }} --cpus 1
 
   smp-smoke:
+    needs: validate-main
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         policy: [rr, mlfq, cfs]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,9 +113,9 @@ jobs:
         run: ./scheduler_smoke --policy ${{ matrix.policy }} --cpus 3
 
   regression:
+    needs: validate-main
     runs-on: ubuntu-24.04
     timeout-minutes: 50
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,7 +142,7 @@ jobs:
       - name: Run shell interaction regression
         run: python3 tests/shell_history_interactive.py --cpus 3
 
-      - name: Run pull-request regression suites
+      - name: Run regression suites
         run: python3 tests/run.py --suite pr --cpus 3
 
       - name: Run complete usertests
@@ -137,3 +166,28 @@ jobs:
           name: scheduler-regression-${{ github.run_id }}
           path: test-results/
           if-no-files-found: ignore
+
+  notify-manual-failure:
+    name: Notify manual failure
+    needs: [validate-main, scheduler, smp-smoke, regression]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure email
+        uses: dawidd6/action-send-mail@v6
+        with:
+          connection_url: ${{ secrets.SMTP_CONNECTION_URL }}
+          from: ${{ secrets.MAIL_FROM }}
+          to: ${{ secrets.MAIL_TO }}
+          subject: "[CI Failed] ${{ github.repository }} scheduler manual gate"
+          body: |
+            main 分支 Scheduler family 手动门禁执行失败。
+
+            仓库：${{ github.repository }}
+            提交：${{ github.sha }}
+            执行人：${{ github.actor }}
+            运行地址：${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/uthread-debug.yml
+++ b/.github/workflows/uthread-debug.yml
@@ -1,22 +1,32 @@
 name: uthread debug
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: uthread-debug-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
 
 jobs:
+  validate-main:
+    name: Validate main ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::uthread debug can only run against main."
+            exit 1
+          fi
+
   lab7:
-    if: github.event.pull_request.draft == false
+    needs: validate-main
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,3 +76,27 @@ jobs:
         run: |
           test "${{ steps.cpus3.outcome }}" = success
           test "${{ steps.cpus1.outcome }}" = success
+
+  notify-manual-failure:
+    name: Notify manual failure
+    needs: [validate-main, lab7]
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure email
+        uses: dawidd6/action-send-mail@v6
+        with:
+          connection_url: ${{ secrets.SMTP_CONNECTION_URL }}
+          from: ${{ secrets.MAIL_FROM }}
+          to: ${{ secrets.MAIL_TO }}
+          subject: "[CI Failed] ${{ github.repository }} uthread manual gate"
+          body: |
+            main 分支 uthread 手动门禁执行失败。
+
+            仓库：${{ github.repository }}
+            提交：${{ github.sha }}
+            执行人：${{ github.actor }}
+            运行地址：${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## What changed

- replace PR and scheduled execution in the general xv6 workflow with automatic `main` push and manual `main` dispatch
- simplify the general gate to the complete regression path instead of retaining PR-only path selection code
- run the scheduler family matrix after relevant scheduler-related files reach `main`, with manual full execution still available
- make `uthread debug` manual-only because the normal main regression already owns routine Lab 7 coverage
- cancel superseded automatic main runs while preserving independent manual runs
- send SMTP mail only when a manual main gate fails

## Why

The current repository has several expensive QEMU workflows that were repeatedly triggered while AI agents iterated on PR branches. The new boundary reserves Actions for integrated main-state validation and explicit diagnostics.

## Validation

- preserved the existing toolchain, QEMU regression commands, scheduler matrices, diagnostic artifacts, and failure logs
- removed PR-specific selection branches only from the workflow that now always performs the complete main regression
- statically parsed all three resulting workflow files
- verified only the three existing workflow files changed

## Required secrets

The failure-notification path requires `SMTP_CONNECTION_URL`, `MAIL_FROM`, and `MAIL_TO`. Automatic main failures do not send mail.