### PR TITLE
[Concept Lab] 实体化：RV64 用户态动态内存分配器

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,7 @@ UPROGS=\
 	$U/_sysinfotest\
 	$U/_bttest\
 	$U/_alarmtest\
+	$U/_alloctest\
 	$U/_lazytests\
 	$U/_cowtest\
 	$U/_fileapitest\

--- a/tests/README.md
+++ b/tests/README.md
@@ -76,7 +76,10 @@ xv6test --run lab3-memviz
 xv6test --run lab3-vaaccess
 xv6test --group lab4
 xv6test --group lab5
+/usr/bin/alloctest
 /usr/bin/lazytests memory-api
+xv6test --run core-allocator
+xv6test --run core-memory-api
 xv6test --group lab6
 xv6test --group lab7
 xv6test --group lab8
@@ -146,6 +149,21 @@ XV6TEST done status=0
 任一层索引、PTE 权限、页内偏移、fault 隔离或资源回收不符合预期时，guest 测试会打印 `vaaccesstest: FAIL: <reason>` 并以非零状态退出。
 
 `lazytests memory-api` 在现有 Lab5 guest 程序内复用 `malloc/free`、`sbrk`、`fork/wait` 和缺页路径，验证：首次分配扩展用户态 arena、`free` 只回收到分配器 free list、再次分配不增长 break、父子分配器状态与 COW 隔离、`sbrk` 增长/触页/收缩回环、过量收缩失败且不改变 break、页内一字节越界可能暂时可见，以及收缩后再次访问必然以 `exit(-1)` 终止子进程。页内越界用例是击穿错误直觉的反例，不代表该访问成为合法 API 行为。
+
+### RV64 用户态动态内存分配器闭环
+
+`/usr/bin/alloctest` 直接持有 `user/umalloc.c` 的分配器行为契约。它把每个场景放进独立子进程，并以退出状态作为唯一通过 oracle；自然语言输出只用于定位失败阶段。当前覆盖：16 字节对齐与活跃块不重叠、非对齐初始 program break、first-fit 分割与剩余块复用、最小块避免 splinter、四种相邻块合并、`free(NULL)`、`calloc` 清零与乘法溢出、`realloc` 原地缩小/扩张/搬迁/失败保留、`sbrk(int)` 无法表达的大请求、固定 seed 压力序列、`fork` 后分配器与 COW 隔离，以及重复生命周期后的 arena 复用。
+
+聚焦入口：
+
+```text
+/usr/bin/alloctest
+/usr/bin/lazytests memory-api
+xv6test --run core-allocator
+xv6test --run core-memory-api
+```
+
+`core-allocator` 与 `core-memory-api` 都注册在 `core` group，因此 `make test-suite SUITE=usertests-core` 会同时覆盖新的块级契约和原有的 `malloc/free`、`sbrk`、缺页与进程生命周期闭环。该回归证明的是单进程用户态分配器行为；它不宣称具备生产分配器的线程安全、跨线程 arena、页回收给内核或碎片性能保证。
 
 `sbrkmuch` 同时属于 Lab3 地址空间增长和 Lab8 allocator 行为，因此按两个稳定测试名注册；这是有意保留的跨 Lab 共享回归。默认 PR suite 的 Lab8 入口只保留 `createdelete` 和 `fourfiles` 两个较快用例，避免 `sbrkmuch`、`bigwrite` 这类高成本 usertests 阻塞每次 PR 回归。
 

--- a/tests/ci_plan.py
+++ b/tests/ci_plan.py
@@ -73,11 +73,13 @@ VM_PATHS = {
     "kernel/vm.c",
     "kernel/vmcopyin.c",
     "tests/guest/addressspacelifecycle.c",
+    "tests/guest/alloctest.c",
     "tests/guest/cowtest.c",
     "tests/guest/lazytests.c",
     "tests/guest/memviztest.c",
     "tests/guest/ostepintrotest.c",
     "tests/guest/vaaccesstest.c",
+    "user/umalloc.c",
 }
 CONCURRENCY_PATHS = {
     "kernel/proc.c",

--- a/tests/guest/alloctest.c
+++ b/tests/guest/alloctest.c
@@ -1,0 +1,696 @@
+#include "kernel/param.h"
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/riscv.h"
+#include "user/user.h"
+
+#define ARRAY_SIZE(values) (sizeof(values) / sizeof((values)[0]))
+#define STRESS_SLOTS 24
+#define STRESS_STEPS 600
+
+/** 输出失败阶段并以非零状态结束当前测试子进程。 */
+static void
+fail(char *phase, char *reason)
+{
+  printf("alloctest: %s: %s\n", phase, reason);
+  exit(1);
+}
+
+/** 使用与槽位和偏移相关的确定性字节填充一个活跃块。 */
+static void
+fill_pattern(unsigned char *pointer, uint64 size, unsigned char tag)
+{
+  for(uint64 index = 0; index < size; index++)
+    pointer[index] = (unsigned char)(tag ^ index ^ (index >> 8));
+}
+
+/** 校验活跃块的确定性字节模式未被其他分配器操作覆盖。 */
+static void
+verify_pattern(unsigned char *pointer, uint64 size, unsigned char tag,
+               char *phase)
+{
+  for(uint64 index = 0; index < size; index++)
+    if(pointer[index] != (unsigned char)(tag ^ index ^ (index >> 8)))
+      fail(phase, "payload pattern changed");
+}
+
+/** 验证不同大小请求都保持 16 字节对齐、互不重叠且数据可读回。 */
+static void
+test_alignment_and_overlap(void)
+{
+  static uint64 sizes[] = {
+    1, 2, 7, 8, 9, 15, 16, 17, 31, 32, 33,
+    PGSIZE - 1, PGSIZE, PGSIZE + 1, 2 * PGSIZE + 17,
+  };
+  unsigned char *pointers[ARRAY_SIZE(sizes)];
+
+  for(uint64 index = 0; index < ARRAY_SIZE(sizes); index++){
+    pointers[index] = malloc(sizes[index]);
+    if(pointers[index] == 0)
+      fail("alignment", "malloc returned null");
+    if(((uint64)pointers[index] & 0xf) != 0)
+      fail("alignment", "payload is not 16-byte aligned");
+
+    for(uint64 previous = 0; previous < index; previous++){
+      uint64 left_start = (uint64)pointers[previous];
+      uint64 left_end = left_start + sizes[previous];
+      uint64 right_start = (uint64)pointers[index];
+      uint64 right_end = right_start + sizes[index];
+      if(left_start < right_end && right_start < left_end)
+        fail("alignment", "live payload ranges overlap");
+    }
+    fill_pattern(pointers[index], sizes[index], (unsigned char)(index + 11));
+  }
+
+  for(uint64 index = 0; index < ARRAY_SIZE(sizes); index++){
+    verify_pattern(pointers[index], sizes[index],
+                   (unsigned char)(index + 11), "alignment");
+    free(pointers[index]);
+  }
+}
+
+/** 验证调用者预先制造非对齐 break 后，malloc 仍返回 16 字节对齐 payload。 */
+static void
+test_unaligned_initial_break(void)
+{
+  char *before = sbrk(1);
+  void *pointer;
+
+  if(before == (char *)-1)
+    fail("unaligned-break", "sbrk(1) failed");
+  pointer = malloc(7);
+  if(pointer == 0)
+    fail("unaligned-break", "malloc returned null");
+  if(((uint64)pointer & 0xf) != 0)
+    fail("unaligned-break", "allocator did not repair initial alignment");
+  free(pointer);
+}
+
+/** 验证大空闲块能够被分割并由后续请求复用，且不额外增长 break。 */
+static void
+test_split_and_reuse(void)
+{
+  unsigned char *large = malloc(512);
+  void *guard = malloc(64);
+  char *break_before;
+  void *small;
+  void *remainder;
+
+  if(large == 0 || guard == 0)
+    fail("split", "setup allocation failed");
+  free(large);
+  break_before = sbrk(0);
+
+  small = malloc(64);
+  remainder = malloc(400);
+  if(small != large)
+    fail("split", "first-fit did not reuse the released block");
+  if(remainder == 0)
+    fail("split", "legal split remainder was not reusable");
+  if(sbrk(0) != break_before)
+    fail("split", "reuse unexpectedly grew program break");
+
+  free(small);
+  free(remainder);
+  free(guard);
+}
+
+/** 验证不足 32 字节的尾部不会形成可破坏链表的 splinter。 */
+static void
+test_no_splinter(void)
+{
+  unsigned char *block = malloc(49);
+  void *guard = malloc(32);
+  char *break_before;
+  unsigned char *replacement;
+
+  if(block == 0 || guard == 0)
+    fail("no-splinter", "setup allocation failed");
+  free(block);
+  break_before = sbrk(0);
+  replacement = malloc(48);
+  if(replacement != block)
+    fail("no-splinter", "released 80-byte block was not reused");
+  fill_pattern(replacement, 48, 0x51);
+  verify_pattern(replacement, 48, 0x51, "no-splinter");
+  free(replacement);
+
+  replacement = malloc(49);
+  if(replacement != block)
+    fail("no-splinter", "whole-block placement damaged later reuse");
+  if(sbrk(0) != break_before)
+    fail("no-splinter", "whole-block reuse unexpectedly grew break");
+  free(replacement);
+  free(guard);
+}
+
+/** 验证前后均已分配时，释放块仍能独立复用。 */
+static void
+test_coalesce_neither(void)
+{
+  void *a = malloc(48);
+  void *b = malloc(48);
+  void *c = malloc(48);
+  char *break_before;
+  void *result;
+
+  if(a == 0 || b == 0 || c == 0)
+    fail("coalesce-neither", "setup allocation failed");
+  free(b);
+  break_before = sbrk(0);
+  result = malloc(48);
+  if(result != b || sbrk(0) != break_before)
+    fail("coalesce-neither", "standalone free block was not reused");
+  free(a);
+  free(result);
+  free(c);
+}
+
+/** 验证释放当前块时能够与后继空闲块合并。 */
+static void
+test_coalesce_next(void)
+{
+  void *a = malloc(48);
+  void *b = malloc(48);
+  void *c = malloc(48);
+  void *d = malloc(48);
+  char *break_before;
+  void *result;
+
+  if(a == 0 || b == 0 || c == 0 || d == 0)
+    fail("coalesce-next", "setup allocation failed");
+  free(c);
+  free(b);
+  break_before = sbrk(0);
+  result = malloc(96);
+  if(result != b || sbrk(0) != break_before)
+    fail("coalesce-next", "next-only merged space was not reused");
+  free(a);
+  free(result);
+  free(d);
+}
+
+/** 验证释放当前块时能够与前驱空闲块合并。 */
+static void
+test_coalesce_previous(void)
+{
+  void *a = malloc(48);
+  void *b = malloc(48);
+  void *c = malloc(48);
+  void *d = malloc(48);
+  char *break_before;
+  void *result;
+
+  if(a == 0 || b == 0 || c == 0 || d == 0)
+    fail("coalesce-previous", "setup allocation failed");
+  free(b);
+  free(c);
+  break_before = sbrk(0);
+  result = malloc(96);
+  if(result != b || sbrk(0) != break_before)
+    fail("coalesce-previous", "previous-only merged space was not reused");
+  free(a);
+  free(result);
+  free(d);
+}
+
+/** 验证释放当前块时能够同时合并前驱与后继空闲块。 */
+static void
+test_coalesce_both(void)
+{
+  void *a = malloc(48);
+  void *b = malloc(48);
+  void *c = malloc(48);
+  void *d = malloc(48);
+  void *e = malloc(48);
+  char *break_before;
+  void *result;
+
+  if(a == 0 || b == 0 || c == 0 || d == 0 || e == 0)
+    fail("coalesce-both", "setup allocation failed");
+  free(b);
+  free(d);
+  free(c);
+  break_before = sbrk(0);
+  result = malloc(176);
+  if(result != b || sbrk(0) != break_before)
+    fail("coalesce-both", "three-block merged space was not reused");
+  free(a);
+  free(result);
+  free(e);
+}
+
+/** 验证零大小 API 与 free(0) 不崩溃且不改变 program break。 */
+static void
+test_zero_and_null_contracts(void)
+{
+  char *before = sbrk(0);
+
+  free(0);
+  if(malloc(0) != 0)
+    fail("zero-null", "malloc(0) did not return null");
+  if(calloc(0, 8) != 0 || calloc(8, 0) != 0)
+    fail("zero-null", "zero-sized calloc did not return null");
+  if(realloc(0, 0) != 0)
+    fail("zero-null", "realloc(NULL, 0) did not return null");
+  if(sbrk(0) != before)
+    fail("zero-null", "zero/null API changed program break");
+
+  void *pointer = malloc(32);
+  if(pointer == 0)
+    fail("zero-null", "allocator unusable after free(NULL)");
+  free(pointer);
+}
+
+/** 验证 calloc 清零、相邻块隔离及乘法溢出失败回滚。 */
+static void
+test_calloc_contracts(void)
+{
+  unsigned char *left = malloc(32);
+  unsigned char *zeroed = calloc(37, 7);
+  unsigned char *right = malloc(32);
+  char *break_before_failure;
+  uint64 maximum = ~(uint64)0;
+
+  if(left == 0 || zeroed == 0 || right == 0)
+    fail("calloc", "setup allocation failed");
+  fill_pattern(left, 32, 0x21);
+  fill_pattern(right, 32, 0x42);
+  for(uint64 index = 0; index < 37 * 7; index++)
+    if(zeroed[index] != 0)
+      fail("calloc", "calloc payload was not fully zeroed");
+  fill_pattern(zeroed, 37 * 7, 0x63);
+  verify_pattern(left, 32, 0x21, "calloc");
+  verify_pattern(right, 32, 0x42, "calloc");
+
+  break_before_failure = sbrk(0);
+  if(calloc(maximum / 3 + 1, 3) != 0)
+    fail("calloc", "overflowing multiplication unexpectedly succeeded");
+  if(sbrk(0) != break_before_failure)
+    fail("calloc", "overflow failure changed program break");
+  verify_pattern(left, 32, 0x21, "calloc");
+  verify_pattern(right, 32, 0x42, "calloc");
+  verify_pattern(zeroed, 37 * 7, 0x63, "calloc");
+
+  free(left);
+  free(zeroed);
+  free(right);
+}
+
+/** 验证 realloc(NULL, n) 与 realloc(ptr, 0) 的标准化教学契约。 */
+static void
+test_realloc_null_and_zero(void)
+{
+  unsigned char *pointer = realloc(0, 64);
+  char *break_before_reuse;
+  void *replacement;
+
+  if(pointer == 0 || ((uint64)pointer & 0xf) != 0)
+    fail("realloc-null-zero", "realloc(NULL, n) did not allocate");
+  fill_pattern(pointer, 64, 0x71);
+  if(realloc(pointer, 0) != 0)
+    fail("realloc-null-zero", "realloc(ptr, 0) did not return null");
+
+  break_before_reuse = sbrk(0);
+  replacement = malloc(64);
+  if(replacement != pointer || sbrk(0) != break_before_reuse)
+    fail("realloc-null-zero", "realloc(ptr, 0) did not free reusable space");
+  free(replacement);
+}
+
+/** 验证 realloc 原地缩小后分割出的合法剩余块可被复用。 */
+static void
+test_realloc_shrink_split(void)
+{
+  unsigned char *pointer = malloc(256);
+  void *guard = malloc(64);
+  char *break_before;
+  unsigned char *shrunk;
+  void *reuse;
+
+  if(pointer == 0 || guard == 0)
+    fail("realloc-shrink-split", "setup allocation failed");
+  fill_pattern(pointer, 256, 0x31);
+  break_before = sbrk(0);
+  shrunk = realloc(pointer, 32);
+  if(shrunk != pointer)
+    fail("realloc-shrink-split", "shrink moved the block");
+  verify_pattern(shrunk, 32, 0x31, "realloc-shrink-split");
+  reuse = malloc(160);
+  if(reuse == 0 || sbrk(0) != break_before)
+    fail("realloc-shrink-split", "split remainder was not reused");
+  free(shrunk);
+  free(reuse);
+  free(guard);
+}
+
+/** 验证 realloc 缩小时不足最小块的剩余空间不会被错误分割。 */
+static void
+test_realloc_shrink_no_splinter(void)
+{
+  unsigned char *pointer = malloc(49);
+  void *guard = malloc(32);
+  unsigned char *shrunk;
+
+  if(pointer == 0 || guard == 0)
+    fail("realloc-shrink-nosplit", "setup allocation failed");
+  fill_pattern(pointer, 49, 0x23);
+  shrunk = realloc(pointer, 48);
+  if(shrunk != pointer)
+    fail("realloc-shrink-nosplit", "small shrink moved the block");
+  verify_pattern(shrunk, 48, 0x23, "realloc-shrink-nosplit");
+  free(shrunk);
+  free(guard);
+}
+
+/** 验证 realloc 优先吞并紧邻后继空闲块并保留原数据前缀。 */
+static void
+test_realloc_grow_in_place(void)
+{
+  unsigned char *pointer = malloc(64);
+  void *next = malloc(128);
+  void *guard = malloc(64);
+  char *break_before;
+  unsigned char *grown;
+  void *split_reuse;
+
+  if(pointer == 0 || next == 0 || guard == 0)
+    fail("realloc-grow-in-place", "setup allocation failed");
+  fill_pattern(pointer, 64, 0x44);
+  free(next);
+  break_before = sbrk(0);
+  grown = realloc(pointer, 160);
+  if(grown != pointer)
+    fail("realloc-grow-in-place", "adjacent growth moved the block");
+  verify_pattern(grown, 64, 0x44, "realloc-grow-in-place");
+  split_reuse = malloc(16);
+  if(split_reuse == 0 || sbrk(0) != break_before)
+    fail("realloc-grow-in-place", "growth remainder was not reusable");
+  free(grown);
+  free(split_reuse);
+  free(guard);
+}
+
+/** 验证无法原地增长时 realloc 移动块并完整保留旧 payload 前缀。 */
+static void
+test_realloc_move(void)
+{
+  unsigned char *pointer = malloc(64);
+  void *guard = malloc(64);
+  unsigned char *moved;
+
+  if(pointer == 0 || guard == 0)
+    fail("realloc-move", "setup allocation failed");
+  fill_pattern(pointer, 64, 0x55);
+  moved = realloc(pointer, PGSIZE);
+  if(moved == 0 || moved == pointer)
+    fail("realloc-move", "blocked growth did not move to a new block");
+  verify_pattern(moved, 64, 0x55, "realloc-move");
+  free(moved);
+  free(guard);
+}
+
+/** 验证 realloc 超大请求失败时原指针、数据与 program break 都保持有效。 */
+static void
+test_realloc_failure_preserves_old(void)
+{
+  unsigned char *pointer = malloc(128);
+  char *break_before;
+  void *result;
+
+  if(pointer == 0)
+    fail("realloc-failure", "setup allocation failed");
+  fill_pattern(pointer, 128, 0x6a);
+  break_before = sbrk(0);
+  result = realloc(pointer, ~(uint64)0);
+  if(result != 0)
+    fail("realloc-failure", "overflowing growth unexpectedly succeeded");
+  if(sbrk(0) != break_before)
+    fail("realloc-failure", "overflow failure changed program break");
+  verify_pattern(pointer, 128, 0x6a, "realloc-failure");
+
+  result = realloc(pointer, 0x80000000ULL);
+  if(result != 0)
+    fail("realloc-failure", "sbrk-unrepresentable growth unexpectedly succeeded");
+  if(sbrk(0) != break_before)
+    fail("realloc-failure", "sbrk boundary failure changed program break");
+  verify_pattern(pointer, 128, 0x6a, "realloc-failure");
+  free(pointer);
+}
+
+/** 验证 malloc 的元数据加法、对齐溢出和 sbrk(int) 边界在初始化前安全失败。 */
+static void
+test_malloc_overflow(void)
+{
+  char *before = sbrk(0);
+
+  if(malloc(~(uint64)0) != 0)
+    fail("malloc-overflow", "maximum request unexpectedly succeeded");
+  if(malloc((~(uint64)0) - 7) != 0)
+    fail("malloc-overflow", "alignment overflow unexpectedly succeeded");
+  if(malloc(0x80000000ULL) != 0)
+    fail("malloc-overflow", "sbrk-unrepresentable request unexpectedly succeeded");
+  if(sbrk(0) != before)
+    fail("malloc-overflow", "overflow failure changed program break");
+}
+
+/** 返回固定 seed 的 xorshift32 下一状态，避免压力测试依赖随机时序。 */
+static uint
+next_random(uint *state)
+{
+  uint value = *state;
+  value ^= value << 13;
+  value ^= value >> 17;
+  value ^= value << 5;
+  *state = value;
+  return value;
+}
+
+/** 描述确定性压力测试中的一个活跃 payload 槽位。 */
+struct stress_slot {
+  unsigned char *pointer;
+  uint64 size;
+  unsigned char tag;
+};
+
+/** 校验所有压力测试活跃槽位仍保持各自字节模式。 */
+static void
+verify_live_slots(struct stress_slot *slots)
+{
+  for(int index = 0; index < STRESS_SLOTS; index++)
+    if(slots[index].pointer != 0)
+      verify_pattern(slots[index].pointer, slots[index].size,
+                     slots[index].tag, "stress");
+}
+
+/** 固定 seed 反复执行 allocate/write/verify/realloc/free，覆盖链表长期演化。 */
+static void
+test_deterministic_stress(void)
+{
+  struct stress_slot slots[STRESS_SLOTS];
+  uint state = 0x218c0deU;
+
+  for(int index = 0; index < STRESS_SLOTS; index++){
+    slots[index].pointer = 0;
+    slots[index].size = 0;
+    slots[index].tag = 0;
+  }
+
+  for(int step = 0; step < STRESS_STEPS; step++){
+    uint random = next_random(&state);
+    int slot_index = random % STRESS_SLOTS;
+    struct stress_slot *slot = &slots[slot_index];
+
+    verify_live_slots(slots);
+    if(slot->pointer == 0){
+      slot->size = 1 + (next_random(&state) % 512);
+      slot->tag = (unsigned char)(1 + slot_index * 7 + step);
+      slot->pointer = malloc(slot->size);
+      if(slot->pointer == 0)
+        fail("stress", "ordinary allocation returned null");
+      fill_pattern(slot->pointer, slot->size, slot->tag);
+      continue;
+    }
+
+    switch(random % 3){
+    case 0:
+      free(slot->pointer);
+      slot->pointer = 0;
+      slot->size = 0;
+      break;
+    case 1: {
+      uint64 new_size = 1 + (next_random(&state) % 768);
+      unsigned char *old_pointer = slot->pointer;
+      uint64 old_size = slot->size;
+      unsigned char old_tag = slot->tag;
+      unsigned char *resized;
+
+      if(step % 97 == 0)
+        new_size = ~(uint64)0;
+      resized = realloc(old_pointer, new_size);
+      if(new_size == ~(uint64)0){
+        if(resized != 0)
+          fail("stress", "overflowing realloc unexpectedly succeeded");
+        verify_pattern(old_pointer, old_size, old_tag, "stress");
+        break;
+      }
+      if(resized == 0)
+        fail("stress", "ordinary realloc returned null");
+      verify_pattern(resized, old_size < new_size ? old_size : new_size,
+                     old_tag, "stress");
+      slot->pointer = resized;
+      slot->size = new_size;
+      slot->tag = (unsigned char)(old_tag + 29);
+      fill_pattern(slot->pointer, slot->size, slot->tag);
+      break;
+    }
+    default:
+      slot->tag = (unsigned char)(slot->tag + 11);
+      fill_pattern(slot->pointer, slot->size, slot->tag);
+      break;
+    }
+  }
+
+  verify_live_slots(slots);
+  for(int index = 0; index < STRESS_SLOTS; index++)
+    free(slots[index].pointer);
+}
+
+/** 验证 fork 后父子 allocator/free-list 与 COW payload 写入互不污染。 */
+static void
+test_fork_isolation(void)
+{
+  unsigned char *parent = malloc(128);
+  int pid;
+  int status = 0;
+
+  if(parent == 0)
+    fail("fork-isolation", "parent allocation failed");
+  fill_pattern(parent, 128, 0x7d);
+  pid = fork();
+  if(pid < 0)
+    fail("fork-isolation", "fork failed");
+  if(pid == 0){
+    unsigned char *child;
+    free(parent);
+    child = malloc(128);
+    if(child == 0)
+      exit(1);
+    fill_pattern(child, 128, 0x2e);
+    verify_pattern(child, 128, 0x2e, "fork-isolation-child");
+    free(child);
+    exit(0);
+  }
+
+  if(wait(&status) != pid || status != 0)
+    fail("fork-isolation", "child allocator path failed");
+  verify_pattern(parent, 128, 0x7d, "fork-isolation");
+  free(parent);
+}
+
+/** 验证重复分配释放轮次在预热后持续复用 arena，而不单调增长 break。 */
+static void
+test_repeated_lifecycle(void)
+{
+  unsigned char *pointers[16];
+  uint64 sizes[16];
+  char *warm_break = 0;
+
+  for(int round = 0; round < 40; round++){
+    for(int index = 0; index < 16; index++){
+      sizes[index] = 1 + ((index * 37) % 320);
+      pointers[index] = malloc(sizes[index]);
+      if(pointers[index] == 0)
+        fail("lifecycle", "allocation failed");
+      fill_pattern(pointers[index], sizes[index],
+                   (unsigned char)(round + index + 1));
+    }
+    for(int index = 0; index < 16; index++)
+      verify_pattern(pointers[index], sizes[index],
+                     (unsigned char)(round + index + 1), "lifecycle");
+    for(int index = 1; index < 16; index += 2)
+      free(pointers[index]);
+    for(int index = 0; index < 16; index += 2)
+      free(pointers[index]);
+
+    if(round == 1)
+      warm_break = sbrk(0);
+    else if(round > 1 && sbrk(0) != warm_break)
+      fail("lifecycle", "repeated rounds stopped reusing allocator arena");
+  }
+}
+
+/** 描述一个在独立子进程中执行并由退出状态持有 oracle 的测试用例。 */
+struct test_case {
+  char *name;
+  void (*function)(void);
+};
+
+/**
+ * 在独立子进程中运行一个测试，避免前一场景的 free-list 状态掩盖后续缺陷。
+ *
+ * @param test 要执行的测试名称和函数。
+ * @return 子进程退出状态为 0 时返回 0，否则返回 -1。
+ */
+static int
+run_test(struct test_case *test)
+{
+  int pid = fork();
+  int status = 0;
+
+  if(pid < 0){
+    printf("alloctest: %s: fork failed\n", test->name);
+    return -1;
+  }
+  if(pid == 0){
+    test->function();
+    exit(0);
+  }
+  if(wait(&status) != pid || status != 0){
+    printf("alloctest: %s: FAILED status=%d\n", test->name, status);
+    return -1;
+  }
+  printf("alloctest: %s: OK\n", test->name);
+  return 0;
+}
+
+/** 执行 RV64 用户态动态内存分配器的完整确定性 guest 回归。 */
+int
+main(void)
+{
+  struct test_case tests[] = {
+    {"alignment-and-overlap", test_alignment_and_overlap},
+    {"unaligned-initial-break", test_unaligned_initial_break},
+    {"split-and-reuse", test_split_and_reuse},
+    {"no-splinter", test_no_splinter},
+    {"coalesce-neither", test_coalesce_neither},
+    {"coalesce-next", test_coalesce_next},
+    {"coalesce-previous", test_coalesce_previous},
+    {"coalesce-both", test_coalesce_both},
+    {"zero-and-null-contracts", test_zero_and_null_contracts},
+    {"calloc-contracts", test_calloc_contracts},
+    {"realloc-null-and-zero", test_realloc_null_and_zero},
+    {"realloc-shrink-split", test_realloc_shrink_split},
+    {"realloc-shrink-no-splinter", test_realloc_shrink_no_splinter},
+    {"realloc-grow-in-place", test_realloc_grow_in_place},
+    {"realloc-move", test_realloc_move},
+    {"realloc-failure-preserves-old", test_realloc_failure_preserves_old},
+    {"malloc-overflow", test_malloc_overflow},
+    {"deterministic-stress", test_deterministic_stress},
+    {"fork-isolation", test_fork_isolation},
+    {"repeated-lifecycle", test_repeated_lifecycle},
+    {0, 0},
+  };
+  int failed = 0;
+
+  for(struct test_case *test = tests; test->name != 0; test++)
+    if(run_test(test) < 0)
+      failed = 1;
+
+  if(failed){
+    printf("alloctest: SOME TESTS FAILED\n");
+    exit(1);
+  }
+  printf("alloctest: ALL TESTS PASSED\n");
+  exit(0);
+}

--- a/tests/guest/xv6test.c
+++ b/tests/guest/xv6test.c
@@ -69,6 +69,8 @@ static char *lab9_symlink_argv[] = {XV6_TEST_PATH("symlinktest"), 0};
 static char *largefs_4gib_argv[] = {XV6_TEST_PATH("largefile"), 0};
 static char *lab10_mmap_argv[] = {XV6_TEST_PATH("mmaptest"), 0};
 static char *core_sbrkbugs_argv[] = {XV6_TEST_PATH("usertests"), "sbrkbugs", 0};
+static char *core_allocator_argv[] = {XV6_TEST_PATH("alloctest"), 0};
+static char *core_memory_api_argv[] = {XV6_TEST_PATH("lazytests"), "memory-api", 0};
 static char *core_forkforkfork_argv[] = {XV6_TEST_PATH("usertests"), "forkforkfork", 0};
 static char *core_linkunlink_argv[] = {XV6_TEST_PATH("usertests"), "linkunlink", 0};
 static char *core_openiput_argv[] = {XV6_TEST_PATH("usertests"), "openiput", 0};
@@ -155,6 +157,8 @@ static struct xv6_test_case tests[] = {
   {"largefs", "largefs-4gib", largefs_4gib_argv, 0},
   {"lab10", "lab10-mmap", lab10_mmap_argv, 0},
   {"core", "core-sbrkbugs", core_sbrkbugs_argv, 0},
+  {"core", "core-allocator", core_allocator_argv, 0},
+  {"core", "core-memory-api", core_memory_api_argv, 0},
   {"core", "core-forkforkfork", core_forkforkfork_argv, 0},
   {"core", "core-linkunlink", core_linkunlink_argv, 0},
   {"core", "core-openiput", core_openiput_argv, 0},

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -42,6 +42,16 @@ class CiPlanSelectionTests(unittest.TestCase):
         self.assertEqual(PLANNER.VM_SUITES, plan.suites)
         self.assertFalse(plan.run_shell_history)
 
+    def test_allocator_change_runs_vm_regression(self) -> None:
+        """块分配器同时依赖 sbrk、lazy page fault、fork/COW 与地址空间回收。"""
+
+        plan = PLANNER.build_ci_plan(
+            ("user/umalloc.c", "tests/guest/alloctest.c")
+        )
+
+        self.assertEqual(PLANNER.VM_SUITES, plan.suites)
+        self.assertFalse(plan.run_shell_history)
+
     def test_ostep_intro_runs_vm_and_core_regression(self) -> None:
         """概念实验必须进入多核 VM 回归，并触发工作流中的单核 VM 补充验证。"""
 

--- a/user/init.c
+++ b/user/init.c
@@ -94,6 +94,7 @@ static struct image_file image_files[] = {
   {"/sysinfotest", XV6_TEST_PATH("sysinfotest")},
   {"/bttest", XV6_TEST_PATH("bttest")},
   {"/alarmtest", XV6_TEST_PATH("alarmtest")},
+  {"/alloctest", XV6_TEST_PATH("alloctest")},
   {"/lazytests", XV6_TEST_PATH("lazytests")},
   {"/cowtest", XV6_TEST_PATH("cowtest")},
   {"/fileapitest", XV6_TEST_PATH("fileapitest")},
@@ -235,6 +236,9 @@ setup_image_layout(void)
     ensure_directory(*directory);
   for(struct image_file *file = image_files; file->source != 0; file++)
     place_file(file->source, file->destination);
+
+  // 对外暴露稳定命令路径，同时让统一测试注册表继续使用测试目录中的实现。
+  ensure_file_link(XV6_TEST_PATH("alloctest"), XV6_USR_BIN_PATH("alloctest"));
 
   // 原始 usertests 的 copyout 用例读取相对路径 README；它不是可执行文件搜索。
   ensure_file_link("/README", "/root/README");

--- a/user/init.c
+++ b/user/init.c
@@ -239,6 +239,7 @@ setup_image_layout(void)
 
   // 对外暴露稳定命令路径，同时让统一测试注册表继续使用测试目录中的实现。
   ensure_file_link(XV6_TEST_PATH("alloctest"), XV6_USR_BIN_PATH("alloctest"));
+  ensure_file_link(XV6_TEST_PATH("lazytests"), XV6_USR_BIN_PATH("lazytests"));
 
   // 原始 usertests 的 copyout 用例读取相对路径 README；它不是可执行文件搜索。
   ensure_file_link("/README", "/root/README");

--- a/user/umalloc.c
+++ b/user/umalloc.c
@@ -1,90 +1,435 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "kernel/riscv.h"
 #include "user/user.h"
-#include "kernel/param.h"
 
-// Memory allocator by Kernighan and Ritchie,
-// The C programming Language, 2nd ed.  Section 8.7.
+#define ALIGNMENT 16ULL
+#define WORD_SIZE 8ULL
+#define OVERHEAD (2ULL * WORD_SIZE)
+#define MIN_BLOCK_SIZE 32ULL
+#define ALLOCATED_FLAG 0x1ULL
+#define FLAG_MASK 0xFULL
+#define MAX_SBRK_INCREMENT 0x7ffffff0ULL
 
-typedef long Align;
+static char *heap_listp;
+static void *free_list_head;
 
-union header {
-  struct {
-    union header *ptr;
-    uint size;
-  } s;
-  Align x;
-};
-
-typedef union header Header;
-
-static Header base;
-static Header *freep;
-
-void
-free(void *ap)
+/** 读取一个 8 字节块元数据 word。 */
+static uint64
+load_word(void *address)
 {
-  Header *bp, *p;
-
-  bp = (Header*)ap - 1;
-  for(p = freep; !(bp > p && bp < p->s.ptr); p = p->s.ptr)
-    if(p >= p->s.ptr && (bp > p || bp < p->s.ptr))
-      break;
-  if(bp + bp->s.size == p->s.ptr){
-    bp->s.size += p->s.ptr->s.size;
-    bp->s.ptr = p->s.ptr->s.ptr;
-  } else
-    bp->s.ptr = p->s.ptr;
-  if(p + p->s.size == bp){
-    p->s.size += bp->s.size;
-    p->s.ptr = bp->s.ptr;
-  } else
-    p->s.ptr = bp;
-  freep = p;
+  return *(uint64 *)address;
 }
 
-static Header*
-morecore(uint nu)
+/** 写入一个 8 字节块元数据 word。 */
+static void
+store_word(void *address, uint64 value)
 {
-  char *p;
-  Header *hp;
+  *(uint64 *)address = value;
+}
 
-  if(nu < 4096)
-    nu = 4096;
-  p = sbrk(nu * sizeof(Header));
-  if(p == (char*)-1)
+/** 将字节数向上取整到 16 字节边界。 */
+static uint64
+align_up(uint64 value)
+{
+  return (value + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+}
+
+/** 返回 payload 指针对应的 header 地址。 */
+static char *
+header_of(void *payload)
+{
+  return (char *)payload - WORD_SIZE;
+}
+
+/** 返回块总大小，不包含低四位状态标志。 */
+static uint64
+block_size(void *payload)
+{
+  return load_word(header_of(payload)) & ~FLAG_MASK;
+}
+
+/** 判断块是否处于已分配状态。 */
+static int
+block_allocated(void *payload)
+{
+  return (load_word(header_of(payload)) & ALLOCATED_FLAG) != 0;
+}
+
+/** 返回物理相邻的后继块 payload。 */
+static void *
+next_block(void *payload)
+{
+  return (char *)payload + block_size(payload);
+}
+
+/** 返回物理相邻的前驱块 payload。 */
+static void *
+previous_block(void *payload)
+{
+  uint64 previous_size = load_word((char *)payload - OVERHEAD) & ~FLAG_MASK;
+  return (char *)payload - previous_size;
+}
+
+/** 读取空闲块 payload 中保存的前驱空闲块指针。 */
+static void *
+free_previous(void *payload)
+{
+  return *(void **)payload;
+}
+
+/** 读取空闲块 payload 中保存的后继空闲块指针。 */
+static void *
+free_next(void *payload)
+{
+  return *(void **)((char *)payload + WORD_SIZE);
+}
+
+/** 设置空闲块 payload 中保存的前驱空闲块指针。 */
+static void
+set_free_previous(void *payload, void *previous)
+{
+  *(void **)payload = previous;
+}
+
+/** 设置空闲块 payload 中保存的后继空闲块指针。 */
+static void
+set_free_next(void *payload, void *next)
+{
+  *(void **)((char *)payload + WORD_SIZE) = next;
+}
+
+/**
+ * 同时写入块的 header 与 footer。
+ *
+ * @param payload 块 payload 起始地址，必须保持 16 字节对齐。
+ * @param size 块总大小，必须是 16 的倍数。
+ * @param allocated 非零表示已分配，零表示空闲。
+ */
+static void
+write_block(void *payload, uint64 size, int allocated)
+{
+  uint64 value = size | (allocated ? ALLOCATED_FLAG : 0);
+  store_word(header_of(payload), value);
+  store_word((char *)payload + size - OVERHEAD, value);
+}
+
+/** 将空闲块插入显式双向链表头部。 */
+static void
+insert_free_block(void *payload)
+{
+  set_free_previous(payload, 0);
+  set_free_next(payload, free_list_head);
+  if(free_list_head != 0)
+    set_free_previous(free_list_head, payload);
+  free_list_head = payload;
+}
+
+/**
+ * 从显式双向空闲链表中摘除一个块。
+ *
+ * @param payload 必须恰好位于空闲链表一次；函数不修改物理块元数据。
+ */
+static void
+remove_free_block(void *payload)
+{
+  void *previous = free_previous(payload);
+  void *next = free_next(payload);
+
+  if(previous != 0)
+    set_free_next(previous, next);
+  else
+    free_list_head = next;
+  if(next != 0)
+    set_free_previous(next, previous);
+}
+
+/**
+ * 将空闲块与物理相邻空闲块立即合并，并只保留一个 free-list 入口。
+ *
+ * @param payload 已写为空闲状态、但尚未插入 free list 的块。
+ * @return 合并后块的 payload 起始地址。
+ */
+static void *
+coalesce(void *payload)
+{
+  void *previous = previous_block(payload);
+  void *next = next_block(payload);
+  int previous_is_allocated = block_allocated(previous);
+  int next_is_allocated = block_allocated(next);
+  uint64 size = block_size(payload);
+
+  if(!previous_is_allocated){
+    remove_free_block(previous);
+    size += block_size(previous);
+    payload = previous;
+  }
+  if(!next_is_allocated){
+    remove_free_block(next);
+    size += block_size(next);
+  }
+
+  write_block(payload, size, 0);
+  insert_free_block(payload);
+  return payload;
+}
+
+/**
+ * 初始化一页用户堆，建立 padding、prologue、首个空闲块和 epilogue。
+ *
+ * @return 成功返回 0；sbrk 无法一次增长一页时返回 -1，且全局状态不改变。
+ */
+static int
+initialize_heap(void)
+{
+  char *current = sbrk(0);
+  char *start;
+  char *base;
+  void *first_free;
+  uint64 leading;
+  uint64 first_free_size = PGSIZE - 4 * WORD_SIZE;
+
+  if(current == (char *)-1)
+    return -1;
+  leading = (ALIGNMENT - ((uint64)current & (ALIGNMENT - 1))) &
+            (ALIGNMENT - 1);
+  start = sbrk((int)(PGSIZE + leading));
+  if(start == (char *)-1)
+    return -1;
+  base = start + leading;
+
+  // leading 只修正调用者可能先用 sbrk 造成的非对齐 break；正式 arena 仍为一页。
+  store_word(base, 0);
+  store_word(base + WORD_SIZE, OVERHEAD | ALLOCATED_FLAG);
+  store_word(base + 2 * WORD_SIZE, OVERHEAD | ALLOCATED_FLAG);
+
+  first_free = base + 4 * WORD_SIZE;
+  write_block(first_free, first_free_size, 0);
+  store_word(base + PGSIZE - WORD_SIZE, ALLOCATED_FLAG);
+
+  heap_listp = base + 2 * WORD_SIZE;
+  free_list_head = 0;
+  insert_free_block(first_free);
+  return 0;
+}
+
+/**
+ * 按页级 chunk 扩展用户堆，并把旧 epilogue 改写为新空闲块 header。
+ *
+ * @param minimum_size 新块至少需要容纳的总字节数。
+ * @return 成功返回已合并空闲块；当前 sbrk(int) 无法安全表达增长时返回 0。
+ */
+static void *
+extend_heap(uint64 minimum_size)
+{
+  uint64 size = minimum_size < PGSIZE ? PGSIZE : align_up(minimum_size);
+  char *old_break;
+  void *payload;
+
+  if(size > MAX_SBRK_INCREMENT)
     return 0;
-  hp = (Header*)p;
-  hp->s.size = nu;
-  free((void*)(hp + 1));
-  return freep;
+  old_break = sbrk((int)size);
+  if(old_break == (char *)-1)
+    return 0;
+
+  payload = old_break;
+  write_block(payload, size, 0);
+  store_word(old_break + size - WORD_SIZE, ALLOCATED_FLAG);
+  return coalesce(payload);
 }
 
-void*
-malloc(uint nbytes)
+/**
+ * 将用户请求换算为包含 header/footer 的合法块大小。
+ *
+ * @param requested 用户请求的 payload 字节数，必须大于 0。
+ * @param adjusted 接收 16 字节对齐后的块总大小。
+ * @return 计算成功返回 0；加法或对齐上整溢出时返回 -1。
+ */
+static int
+adjust_request(uint64 requested, uint64 *adjusted)
 {
-  Header *p, *prevp;
-  uint nunits;
+  uint64 maximum = ~(uint64)0;
 
-  nunits = (nbytes + sizeof(Header) - 1)/sizeof(Header) + 1;
-  if((prevp = freep) == 0){
-    base.s.ptr = freep = prevp = &base;
-    base.s.size = 0;
+  if(requested > maximum - OVERHEAD - (ALIGNMENT - 1))
+    return -1;
+  *adjusted = align_up(requested + OVERHEAD);
+  if(*adjusted < MIN_BLOCK_SIZE)
+    *adjusted = MIN_BLOCK_SIZE;
+  return 0;
+}
+
+/** 在空闲链表中按 first-fit 查找第一个足够大的块。 */
+static void *
+find_first_fit(uint64 adjusted_size)
+{
+  for(void *payload = free_list_head; payload != 0; payload = free_next(payload))
+    if(block_size(payload) >= adjusted_size)
+      return payload;
+  return 0;
+}
+
+/**
+ * 从空闲块中放置一个已分配块；合法剩余空间会形成新的空闲块。
+ *
+ * @param payload 已从 first-fit 找到且仍位于 free list 的空闲块。
+ * @param adjusted_size 需要放置的块总大小。
+ */
+static void
+place_block(void *payload, uint64 adjusted_size)
+{
+  uint64 current_size = block_size(payload);
+  uint64 remainder = current_size - adjusted_size;
+
+  remove_free_block(payload);
+  if(remainder >= MIN_BLOCK_SIZE){
+    void *split = (char *)payload + adjusted_size;
+    write_block(payload, adjusted_size, 1);
+    write_block(split, remainder, 0);
+    insert_free_block(split);
+  } else {
+    write_block(payload, current_size, 1);
   }
-  for(p = prevp->s.ptr; ; prevp = p, p = p->s.ptr){
-    if(p->s.size >= nunits){
-      if(p->s.size == nunits)
-        prevp->s.ptr = p->s.ptr;
-      else {
-        p->s.size -= nunits;
-        p += p->s.size;
-        p->s.size = nunits;
-      }
-      freep = prevp;
-      return (void*)(p + 1);
+}
+
+/**
+ * 申请一段 16 字节对齐的用户态动态内存。
+ *
+ * @param size 需要的 payload 字节数；0 固定返回 0。
+ * @return 成功返回由调用者持有的 payload；溢出或 sbrk 失败返回 0。
+ */
+void *
+malloc(uint64 size)
+{
+  uint64 adjusted_size;
+  void *payload;
+
+  if(size == 0 || adjust_request(size, &adjusted_size) < 0)
+    return 0;
+
+  // 未初始化时，单块请求若已超过 sbrk(int) 的安全增长上限，不能先改变 break。
+  if(heap_listp == 0 && adjusted_size > MAX_SBRK_INCREMENT)
+    return 0;
+  if(heap_listp == 0 && initialize_heap() < 0)
+    return 0;
+
+  payload = find_first_fit(adjusted_size);
+  if(payload == 0){
+    payload = extend_heap(adjusted_size);
+    if(payload == 0)
+      return 0;
+  }
+
+  place_block(payload, adjusted_size);
+  return payload;
+}
+
+/**
+ * 释放 malloc/calloc/realloc 返回的块并立即合并物理相邻空闲块。
+ *
+ * @param pointer 需要释放的 payload；0 为安全空操作。非法指针与 double free 未定义。
+ */
+void
+free(void *pointer)
+{
+  uint64 size;
+
+  if(pointer == 0)
+    return;
+  size = block_size(pointer);
+  write_block(pointer, size, 0);
+  coalesce(pointer);
+}
+
+/**
+ * 申请 nmemb 个元素并把请求的全部 payload 字节清零。
+ *
+ * @param nmemb 元素数量；0 固定返回 0。
+ * @param size 单个元素字节数；0 固定返回 0。
+ * @return 成功返回清零后的 payload；乘法溢出或分配失败返回 0。
+ */
+void *
+calloc(uint64 nmemb, uint64 size)
+{
+  uint64 total;
+  unsigned char *payload;
+
+  if(nmemb == 0 || size == 0)
+    return 0;
+  if(nmemb > (~(uint64)0) / size)
+    return 0;
+  total = nmemb * size;
+  payload = malloc(total);
+  if(payload == 0)
+    return 0;
+
+  for(uint64 index = 0; index < total; index++)
+    payload[index] = 0;
+  return payload;
+}
+
+/**
+ * 调整已分配块的 payload 容量，优先原地缩小或吞并紧邻后继空闲块。
+ *
+ * @param pointer 原 payload；0 时等价于 malloc(size)。
+ * @param size 新 payload 字节数；0 时释放原块并返回 0。
+ * @return 成功返回新 payload；失败返回 0，原块及其数据仍保持有效。
+ */
+void *
+realloc(void *pointer, uint64 size)
+{
+  uint64 adjusted_size;
+  uint64 current_size;
+  uint64 old_payload_size;
+  uint64 remainder;
+  void *next;
+  void *replacement;
+
+  if(pointer == 0)
+    return malloc(size);
+  if(size == 0){
+    free(pointer);
+    return 0;
+  }
+  if(adjust_request(size, &adjusted_size) < 0)
+    return 0;
+
+  current_size = block_size(pointer);
+  old_payload_size = current_size - OVERHEAD;
+  if(adjusted_size <= current_size){
+    remainder = current_size - adjusted_size;
+    if(remainder >= MIN_BLOCK_SIZE){
+      void *split = (char *)pointer + adjusted_size;
+      write_block(pointer, adjusted_size, 1);
+      write_block(split, remainder, 0);
+      coalesce(split);
     }
-    if(p == freep)
-      if((p = morecore(nunits)) == 0)
-        return 0;
+    return pointer;
   }
+
+  next = next_block(pointer);
+  if(!block_allocated(next) && current_size + block_size(next) >= adjusted_size){
+    uint64 combined_size = current_size + block_size(next);
+    remove_free_block(next);
+    remainder = combined_size - adjusted_size;
+    if(remainder >= MIN_BLOCK_SIZE){
+      void *split = (char *)pointer + adjusted_size;
+      write_block(pointer, adjusted_size, 1);
+      write_block(split, remainder, 0);
+      coalesce(split);
+    } else {
+      write_block(pointer, combined_size, 1);
+    }
+    return pointer;
+  }
+
+  // 先完成新分配再释放旧块，确保失败不会丢失原指针、原数据或 free-list 状态。
+  replacement = malloc(size);
+  if(replacement == 0)
+    return 0;
+
+  uint64 copy_size = old_payload_size < size ? old_payload_size : size;
+  for(uint64 index = 0; index < copy_size; index++)
+    ((unsigned char *)replacement)[index] = ((unsigned char *)pointer)[index];
+  free(pointer);
+  return replacement;
 }

--- a/user/user.h
+++ b/user/user.h
@@ -238,15 +238,47 @@ int ucontext_switch(struct user_context *save,
 int stat(const char*, struct stat*);
 char* strcpy(char*, const char*);
 void *memmove(void*, const void*, int);
-char* strchr(const char*, char c);
+char* strchr(char*, char c);
 int strcmp(const char*, const char*);
 void fprintf(int, const char*, ...);
 void printf(const char*, ...);
 char* gets(char*, int max);
 uint strlen(const char*);
 void* memset(void*, int, uint);
-void* malloc(uint);
-void free(void*);
+
+/**
+ * 申请一段 16 字节对齐的用户态动态内存。
+ *
+ * @param size 需要的 payload 字节数；0 固定返回 0。
+ * @return 成功返回由调用者持有的 payload；溢出或 sbrk 失败返回 0。
+ */
+void *malloc(uint64 size);
+
+/**
+ * 释放 malloc/calloc/realloc 返回的块并立即合并物理相邻空闲块。
+ *
+ * @param pointer 需要释放的 payload；0 为安全空操作。非法指针与 double free 未定义。
+ */
+void free(void *pointer);
+
+/**
+ * 申请 nmemb 个元素并把请求的全部 payload 字节清零。
+ *
+ * @param nmemb 元素数量；0 固定返回 0。
+ * @param size 单个元素字节数；0 固定返回 0。
+ * @return 成功返回清零后的 payload；乘法溢出或分配失败返回 0。
+ */
+void *calloc(uint64 nmemb, uint64 size);
+
+/**
+ * 调整已分配块的 payload 容量。
+ *
+ * @param pointer 原 payload；0 时等价于 malloc(size)。
+ * @param size 新 payload 字节数；0 时释放原块并返回 0。
+ * @return 成功返回新 payload；失败返回 0，原块及其数据仍保持有效。
+ */
+void *realloc(void *pointer, uint64 size);
+
 int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);

--- a/user/user.h
+++ b/user/user.h
@@ -238,7 +238,7 @@ int ucontext_switch(struct user_context *save,
 int stat(const char*, struct stat*);
 char* strcpy(char*, const char*);
 void *memmove(void*, const void*, int);
-char* strchr(char*, char c);
+char* strchr(const char*, char c);
 int strcmp(const char*, const char*);
 void fprintf(int, const char*, ...);
 void printf(const char*, ...);


### PR DESCRIPTION
## 中心认知

`malloc/free/calloc/realloc` 的块级状态由进程内用户态分配器持有；内核只通过 `sbrk(int)` 扩展该进程的地址空间。实现必须同时维护物理相邻顺序与显式空闲链表顺序，才能在 first-fit、分割和立即合并之间保持可验证不变量。

## 范围

- 基线：`6d331a459106c7c0fc80e936109a36f88a94e5f1`
- 将 K&R allocator 替换为 RV64 边界标记 + 显式双向空闲链表实现
- 提供 `malloc(uint64)`、`free`、`calloc`、`realloc`
- 16 字节 payload 对齐；8 字节 header/footer；最小块 32 字节
- first-fit、合法剩余块分割、四种相邻状态立即合并
- 页级 `sbrk` 扩展，并拒绝当前 `sbrk(int)` 无法安全表达的增长
- 保留 `/usr/bin/alloctest` 与 `/usr/bin/lazytests memory-api` 两个稳定聚焦入口

## 关键文件

- `user/umalloc.c`：块布局、free list、分割、合并、扩堆与 API 语义
- `user/user.h`：公开 64 位用户态分配接口
- `user/init.c`：安装专用测试实现并建立 `/usr/bin` 稳定硬链接
- `tests/guest/alloctest.c`：独立子进程、确定性退出状态 oracle
- `tests/guest/xv6test.c`：注册 `core-allocator` 与 `core-memory-api`
- `tests/ci_plan.py` / `tests/test_ci_plan.py`：把 allocator 改动纳入多核与单核 VM 回归
- `Makefile`：构建并安装 `alloctest`
- `tests/README.md`：测试入口、责任边界和教学边界

## 回归契约

`alloctest` 覆盖：

- 对齐、活跃块不重叠、非对齐初始 break
- first-fit 分割、剩余块复用、避免 splinter
- 前后邻接四种立即合并组合
- `free(NULL)`、零大小契约
- `calloc` 清零、相邻块保护、乘法溢出
- `realloc` 原地缩小、原地扩张、搬迁复制、失败保留旧块
- `uint64` 加法/对齐溢出与 `sbrk(int)` 边界
- 固定 seed 压力序列、fork/COW 隔离、重复生命周期复用

所有行为断言位于 guest；宿主 runner 只消费退出状态和 `XV6TEST done status=0`。

## 验证结果

固定 Head：`ad00f944f816fac2582a3526a855dca30fc59901`

GitHub Actions `xv6 CI` run 585（run `30266636908`）实际完成并通过：

- `make test-unit`
- `make clean && make -j2`
- 3 CPU PR suites：`lab-basic`、`lab-vm`、`lab7-thread`、`lab8-locks`、`lab9-symlink`、`lab10-mmap`、`usertests-core`
- lock model 单核/多核矩阵
- `make clean && make -j2 CPUS=1`
- `make test-suite SUITE=lab-vm CPUS=1`
- 完整逐项 usertests（3 CPU）

同一 Head 的 `uthread debug` 与 `RAID1 teaching experiment` 工作流已通过；Scheduler family CI 仍按仓库既有矩阵执行，不作为本功能的替代证据。

本地辅助检查（不冒充 xv6 运行证据）：

- allocator 同构宿主测试：GCC 14，`-Wall -Wextra -Werror -ffreestanding -fno-builtin`，通过
- `alloctest.c` 使用 xv6 兼容 stub 做语法与告警检查，通过
- Makefile 解析检查，通过

## 教学边界

- 不实现线程安全、多 arena、per-CPU cache 或后台整理
- 不把空闲块主动归还内核；`free` 只改变用户态 allocator 状态
- 已分配块也保留 footer，以换取边界标记模型的可读性
- 不检测非法内部指针、悬空指针或 double free
- 不以一次功能回归声称生产级碎片率或吞吐量

## 文档联动

- Obsidian Issue：mental1104/Obsidian#293
- 目标笔记：`Atlas/100-Computer Science/130-Operating System/虚拟化/内存 API.md`
- 笔记将在本 PR 合并并取得固定 Commit SHA 后更新代码链接与运行证据。

Closes #218