### PR TITLE
refactor: 统一 kalloc 页面生命周期调试标记

### DIFF
--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -26,6 +26,24 @@ struct {
   uint64 free_count;
 } kmem[NCPU];
 
+/**
+ * kalloc 页面生命周期的调试填充值。
+ *
+ * 0xA5 与 0x5A 互为按位取反，十六进制转储中容易辨认，并避开 0、1
+ * 等常见初始化值。它们只表示页面仍保持“刚分配”或“刚释放”的未覆写
+ * 状态，不能证明调用者属于用户态或内核态，也不能作为所有权判定依据。
+ */
+enum kalloc_page_fill {
+  KALLOC_PAGE_FILL_ALLOCATED = 0xA5,
+  KALLOC_PAGE_FILL_FREED = 0x5A,
+};
+
+_Static_assert(KALLOC_PAGE_FILL_ALLOCATED != KALLOC_PAGE_FILL_FREED,
+               "kalloc page fill patterns must differ");
+_Static_assert(KALLOC_PAGE_FILL_ALLOCATED <= 0xFF &&
+               KALLOC_PAGE_FILL_FREED <= 0xFF,
+               "kalloc page fill patterns must fit one byte");
+
 #define NPHYPAGES ((PHYSTOP - KERNBASE) / PGSIZE)
 #define KALLOC_AUDIT_BYTES ((NPHYPAGES + 7) / 8)
 
@@ -170,8 +188,9 @@ freerange(void *pa_start, void *pa_end)
  * @param pa 页对齐物理地址；必须来自 kalloc 管理范围且当前引用数为正。
  *
  * 重复释放由 pageref 的 `ref <= 0` 守卫触发 `panic("kfree ref")`，这是
- * allocator 的负向 oracle。页面只有在引用数降到 0 后才会被毒化并重新挂链；
- * freelist 指针和 free_count 始终在同一个 kmem 锁临界区内同步更新。
+ * allocator 的负向 oracle。页面只有在引用数降到 0 后才会按
+ * KALLOC_PAGE_FILL_FREED 毒化并重新挂链；freelist 指针和 free_count 始终在
+ * 同一个 kmem 锁临界区内同步更新。
  */
 void
 kfree(void *pa)
@@ -194,7 +213,7 @@ kfree(void *pa)
   if(!should_free)
     return;
 
-  memset(pa, 1, PGSIZE);
+  memset(pa, KALLOC_PAGE_FILL_FREED, PGSIZE);
   r = (struct run*)pa;
 
   push_off();
@@ -214,7 +233,8 @@ kfree(void *pa)
  *
  * 该固定粒度分配器只执行链表头部移除，不实现可变大小分割、相邻合并或
  * first/best/worst-fit。freelist 与 free_count 在同一锁内更新；若链表非空但
- * 计数为 0，说明元数据已失配并立即 panic，而不是让计数静默下溢。
+ * 计数为 0，说明元数据已失配并立即 panic，而不是让计数静默下溢。成功页会按
+ * KALLOC_PAGE_FILL_ALLOCATED 填充，供调试时识别尚未被调用者覆写的内容。
  */
 void *
 kalloc(void)
@@ -257,7 +277,7 @@ kalloc(void)
     acquire(&pageref.lock);
     pageref.count[pa_index((uint64)r)] = 1;
     release(&pageref.lock);
-    memset((char*)r, 5, PGSIZE);
+    memset((char*)r, KALLOC_PAGE_FILL_ALLOCATED, PGSIZE);
   }
   return (void*)r;
 }


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #249
- 变更类型：重构
- 影响范围：`kernel/kalloc.c` 的新分配页与最后释放页调试填充
- 基线 Commit：`be9429a92a26cef9bb6fb4857f8db936f9ed62ac`
- 一句话摘要：用统一枚举维护 `0xA5` / `0x5A` 页面模式，移除 `5` / `1` 魔数并明确其诊断边界。

## 实现了什么

- 新增 `enum kalloc_page_fill`，集中维护两种生命周期填充值：
  - `KALLOC_PAGE_FILL_ALLOCATED = 0xA5`：`kalloc()` 返回后、调用者尚未覆写的页面；
  - `KALLOC_PAGE_FILL_FREED = 0x5A`：`kfree()` 最后一个引用消失后、尚未再次分配的页面主体。
- 增加编译期断言，约束两种模式不同且能由单字节 `memset()` 表达。
- 更新 `kalloc()` / `kfree()` 注释，明确模式只是一种调试启发式：不能证明页面由用户态还是内核态持有，也不能替代引用计数和 freelist 元数据。
- 保持引用计数、per-CPU freelist、跨 CPU 偷取和锁边界不变；未新增测试源码或 Obsidian 文档改动。
- 教学边界：释放页开头会被 `struct run::next` 覆盖，因此 `0x5A` 只应在其余未覆写区域观察；用户代码仍可能主动写出相同模式。

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `gcc -Wall -Werror -std=gnu11 -c /tmp/kalloc_enum_check.c` | 通过 | 独立编译了本 PR 的枚举与两条 `_Static_assert`，退出状态为 0；该结果只验证语法和常量表达式，不代表 xv6 完整构建。 |
| `make clean && make` | 未运行 | 当前执行环境无法通过 shell 拉取仓库，`git clone` 返回 `Could not resolve host: github.com`；GitHub connector 仅完成了仓库写入。 |
| `python3 tests/run.py --suite lab8-locks --cpus 3` | 未运行 | 缺少可执行的本地 checkout 与 QEMU 环境。 |
| `python3 tests/run.py --suite pr --cpus 3` | 未运行 | 同上；本仓库通用工作流只在 `main` push 或手动触发，当前 Draft PR 的 `kernel/kalloc.c` 变更不会触发可用 PR workflow。 |
| Commit checks / workflow runs | 未运行 | 当前 Head `1574698f1958fcfed2358b70919bcd108e12c94d` 没有 status checks 或 Actions runs。 |

## Review 主线

1. `kernel/kalloc.c::enum kalloc_page_fill`
   - 先确认 `0xA5` / `0x5A` 的命名、互补关系、单字节约束和启发式边界。
2. `kernel/kalloc.c::kfree`
   - 检查仅在引用计数降到 0 后使用 `KALLOC_PAGE_FILL_FREED`，随后 freelist 指针覆盖页头的既有顺序保持不变。
3. `kernel/kalloc.c::kalloc`
   - 确认取页、更新 `free_count` 和设置引用计数的控制流不变，只把成功页填充替换为 `KALLOC_PAGE_FILL_ALLOCATED`。
