### PR TITLE
refactor: 枚举并分发 trap 中断类型

### DIFF
--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -19,12 +19,36 @@ extern char trampoline[], uservec[], userret[];
 // in kernelvec.S, calls kerneltrap().
 void kernelvec();
 
-extern int devintr();
+#define SCAUSE_INTERRUPT_FLAG (1ULL << 63)
+#define SCAUSE_CODE_MASK (~SCAUSE_INTERRUPT_FLAG)
+#define SIP_SSIP (1L << 1)
 
-enum scause_code {
+/** 当前 xv6 显式处理的同步异常原因码。 */
+enum scause_exception_code {
+  SCAUSE_USER_ECALL = 8,
   SCAUSE_LOAD_PAGE_FAULT = 13,
   SCAUSE_STORE_PAGE_FAULT = 15,
 };
+
+/**
+ * 当前 xv6 实际识别的 Supervisor interrupt 原因码。
+ *
+ * 枚举值只对应 `scause` 的低位原因码；最高位 interrupt 标志由
+ * `SCAUSE_INTERRUPT_FLAG` 单独解析。
+ */
+enum scause_interrupt_code {
+  SCAUSE_SUPERVISOR_SOFTWARE_INTERRUPT = 1,
+  SCAUSE_SUPERVISOR_EXTERNAL_INTERRUPT = 9,
+};
+
+/** `devintr()` 对调用者返回的设备中断分类。 */
+enum devintr_result {
+  DEVINTR_NONE = 0,
+  DEVINTR_DEVICE = 1,
+  DEVINTR_TIMER = 2,
+};
+
+static enum devintr_result devintr(uint64 scause);
 
 void
 trapinit(void)
@@ -133,7 +157,7 @@ handle_user_page_fault(struct proc *p, uint64 scause, uint64 va)
 void
 usertrap(void)
 {
-  int which_dev = 0;
+  enum devintr_result which_dev = DEVINTR_NONE;
 
   if((r_sstatus() & SSTATUS_SPP) != 0)
     panic("usertrap: not from user mode");
@@ -143,26 +167,32 @@ usertrap(void)
   w_stvec((uint64)kernelvec);
 
   struct proc *p = myproc();
+  uint64 scause = r_scause();
 
   // save user program counter.
   p->trapframe->epc = r_sepc();
 
-  if(r_scause() == 8){
+  switch(scause){
+  case SCAUSE_USER_ECALL:
     if(p->killed)
       exit(-1);
     p->trapframe->epc += 4;
     intr_on();
     syscall();
-  } else if((which_dev = devintr()) != 0){
-    // device interrupt
-  } else if(r_scause() == SCAUSE_LOAD_PAGE_FAULT ||
-            r_scause() == SCAUSE_STORE_PAGE_FAULT){
-    if(handle_user_page_fault(p, r_scause(), r_stval()) < 0)
+    break;
+  case SCAUSE_LOAD_PAGE_FAULT:
+  case SCAUSE_STORE_PAGE_FAULT:
+    if(handle_user_page_fault(p, scause, r_stval()) < 0)
       p->killed = 1;
-  } else {
-    printf("usertrap(): unexpected scause %p pid=%d\n", r_scause(), p->pid);
-    printf("            sepc=%p stval=%p\n", r_sepc(), r_stval());
-    p->killed = 1;
+    break;
+  default:
+    which_dev = devintr(scause);
+    if(which_dev == DEVINTR_NONE){
+      printf("usertrap(): unexpected scause %p pid=%d\n", scause, p->pid);
+      printf("            sepc=%p stval=%p\n", r_sepc(), r_stval());
+      p->killed = 1;
+    }
+    break;
   }
 
   // consoleintr() 只记录 Ctrl-C/Ctrl-Z；在不持有 cons.lock 时应用到整个 PGID。
@@ -179,7 +209,7 @@ usertrap(void)
     exit(-1);
 
   // give up the CPU if this is a timer interrupt.
-  if(which_dev == 2){
+  if(which_dev == DEVINTR_TIMER){
     p->total_ticks++;
     if(p->alarm_interval > 0 && p->total_ticks == p->alarm_interval){
       p->total_ticks = 0;
@@ -245,17 +275,18 @@ usertrapret(void)
 void
 kerneltrap()
 {
-  int which_dev = 0;
   uint64 sepc = r_sepc();
   uint64 sstatus = r_sstatus();
   uint64 scause = r_scause();
+  enum devintr_result which_dev;
 
   if((sstatus & SSTATUS_SPP) == 0)
     panic("kerneltrap: not from supervisor mode");
   if(intr_get() != 0)
     panic("kerneltrap: interrupts enabled");
 
-  if((which_dev = devintr()) == 0){
+  which_dev = devintr(scause);
+  if(which_dev == DEVINTR_NONE){
     printf("scause %p\n", scause);
     printf("sepc=%p stval=%p\n", r_sepc(), r_stval());
     panic("kerneltrap");
@@ -265,7 +296,7 @@ kerneltrap()
   console_apply_pending_control();
 
   // give up the CPU if this is a timer interrupt.
-  if(which_dev == 2 && myproc() != 0 && myproc()->state == RUNNING)
+  if(which_dev == DEVINTR_TIMER && myproc() != 0 && myproc()->state == RUNNING)
     yield();
 
   // the yield() may have caused some traps to occur,
@@ -283,30 +314,40 @@ clockintr()
   release(&tickslock);
 }
 
-// check if it's an external interrupt or software interrupt,
-// and handle it.
-// returns 2 if timer interrupt,
-// 1 if other device,
-// 0 if not recognized.
-int
-devintr()
+/**
+ * 识别并处理当前 xv6 支持的 Supervisor 设备中断。
+ *
+ * @param scause 本次 trap 的完整 `scause` 值，包含最高位 interrupt 标志。
+ * @return `DEVINTR_DEVICE` 表示 PLIC 外部设备中断，`DEVINTR_TIMER` 表示
+ * Machine Timer 转发的 Supervisor software interrupt；其他情况返回
+ * `DEVINTR_NONE`，由调用者继续按异常或未知 trap 处理。
+ */
+static enum devintr_result
+devintr(uint64 scause)
 {
-  uint64 scause = r_scause();
+  if((scause & SCAUSE_INTERRUPT_FLAG) == 0)
+    return DEVINTR_NONE;
 
-  if((scause & 0x8000000000000000L) &&
-     (scause & 0xff) == 9){
-    // this is a supervisor external interrupt, via PLIC.
-
+  switch(scause & SCAUSE_CODE_MASK){
+  case SCAUSE_SUPERVISOR_EXTERNAL_INTERRUPT: {
     // irq indicates which device interrupted.
     int irq = plic_claim();
 
-    if(irq == UART0_IRQ){
+    switch(irq){
+    case UART0_IRQ:
       uartintr();
-    } else if(irq >= VIRTIO0_IRQ && irq <= VIRTIO2_IRQ){
+      break;
+    case VIRTIO0_IRQ:
+    case VIRTIO1_IRQ:
+    case VIRTIO2_IRQ:
       // QEMU 的三个连续 virtio-mmio 插槽分别使用 IRQ 1、2、3。
       virtio_disk_intr(irq - VIRTIO0_IRQ);
-    } else if(irq){
+      break;
+    case 0:
+      break;
+    default:
       printf("unexpected interrupt irq=%d\n", irq);
+      break;
     }
 
     // the PLIC allows each device to raise at most one
@@ -314,21 +355,19 @@ devintr()
     if(irq)
       plic_complete(irq);
 
-    return 1;
-  } else if(scause == 0x8000000000000001L){
+    return DEVINTR_DEVICE;
+  }
+  case SCAUSE_SUPERVISOR_SOFTWARE_INTERRUPT:
     // software interrupt from a machine-mode timer interrupt,
     // forwarded by timervec in kernelvec.S.
-
-    if(cpuid() == 0){
+    if(cpuid() == 0)
       clockintr();
-    }
 
     // acknowledge the software interrupt by clearing
     // the SSIP bit in sip.
-    w_sip(r_sip() & ~2);
-
-    return 2;
-  } else {
-    return 0;
+    w_sip(r_sip() & ~SIP_SSIP);
+    return DEVINTR_TIMER;
+  default:
+    return DEVINTR_NONE;
   }
 }


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #251
- 变更类型：重构
- 影响范围：`kernel/trap.c` 的同步异常分类、Supervisor interrupt 识别、PLIC IRQ 分发和 timer 结果判断
- 基线 Commit：`be9429a92a26cef9bb6fb4857f8db936f9ed62ac`
- 一句话摘要：以具名枚举和 `switch` 替代 trap 路径中的中断魔数与 `if/else` 分发，同时保持现有行为不变。

## 实现了什么

- 将当前实际处理的同步异常原因码收敛到 `enum scause_exception_code`，补齐 U-mode `ecall`、load page fault 与 store page fault。
- 新增 `enum scause_interrupt_code`，显式维护 Supervisor software interrupt 与 Supervisor external interrupt；用具名 flag/mask 解析 `scause`，不再依赖 `0x8000000000000000L` 和 `0xff`。
- 新增 `enum devintr_result`，替换调用方对 `devintr()` 返回值 `0 / 1 / 2` 的裸值判断。
- `usertrap()` 单次读取 `scause`，通过 `switch` 分发系统调用和页错误；其他原因再交给 `devintr(scause)` 判断中断。
- `devintr()` 改为 `switch` 分发受支持的 Supervisor interrupt；PLIC 内层再用 `switch` 显式列出 UART0 与 VirtIO0/1/2。
- 保持 Machine Timer → SSIP、CPU0 更新 `ticks`、Alarm 计数与 `yield()`、未知 IRQ 输出、PLIC claim/complete、用户态 kill 和内核态 panic 语义不变。
- 相对 `main` 只修改 `kernel/trap.c`；未修改测试、workflow 或 Markdown。

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `gcc -std=gnu11 -Wall -Wextra -Werror /tmp/trap_dispatch_check.c` | 通过 | 使用与本 PR 相同的枚举和两层 `switch` 编译并执行 host 检查；覆盖同步异常拒绝、未支持 Supervisor timer 拒绝、UART、VirtIO2 和 Machine Timer/SSIP 清除映射，退出状态为 0。该检查只验证分发语法与映射，不替代 xv6 完整构建。 |
| `make clean && make` | 未运行 | 当前执行环境无法通过 shell 获取仓库，`git clone` 返回 `Could not resolve host: github.com`；环境也没有 RISC-V 交叉编译器。 |
| `python3 tests/run.py --suite lab4-alarm --cpus 3` | 未运行 | 缺少本地 checkout、RISC-V 工具链和 QEMU。 |
| `python3 tests/run.py --suite lab-vm --cpus 3` | 未运行 | 同上。 |
| Commit workflow runs | 未运行 | 当前 `main` 的通用 workflow 只响应 `main` push 或手动触发；Head `3b5807f1b49ad505a56a985c51ea1eba6f33db50` 当前没有 Actions run。 |

## Review 主线

1. `kernel/trap.c::scause_exception_code / scause_interrupt_code / devintr_result`
   - 先确认标准原因码、interrupt 标志和 xv6 内部返回分类没有混成同一层枚举。
2. `kernel/trap.c::usertrap / kerneltrap`
   - 检查 `scause` 只读取一次，系统调用、页错误、设备中断和未知 trap 的既有终止语义保持不变。
3. `kernel/trap.c::devintr`
   - 最后核对 Supervisor software/external 两类中断和 UART0、VirtIO0/1/2 的映射，以及 claim 为 0、未知 IRQ、SSIP 清除和 PLIC complete 路径。

Related to mental1104/Obsidian#297