### PR TITLE
chore: 增加 Docker 化 xv6 构建与 QEMU 运行环境

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+.git
+
+# xv6 和宿主测试生成物必须在镜像中重新构建。
+*.o
+*.d
+*.asm
+*.sym
+.gdbinit
+fs.img
+fs-large.img
+kernel/kernel
+mkfs/mkfs
+mkfs/mkfs-large
+user/_*
+user/initcode
+user/initcode.out
+ph
+barrier
+rbtree_test
+scheduler_visualizer
+
+# 本地回归和可视化产物不属于镜像输入。
+artifacts/
+test-results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 与主线 CI 使用相同的 Ubuntu 软件源和 RISC-V 工具链，避免本地环境漂移。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        binutils-riscv64-linux-gnu \
+        build-essential \
+        ca-certificates \
+        gcc-riscv64-linux-gnu \
+        gdb-multiarch \
+        python3 \
+        python3-pexpect \
+        qemu-system-misc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/xv6
+
+COPY . .
+
+# 镜像构建阶段执行一次干净编译，确保镜像不依赖宿主机生成的 xv6 产物。
+RUN make clean \
+    && make -j"$(nproc)"
+
+# 默认通过 QEMU 的无图形串口终端启动 RISC-V xv6。
+CMD ["make", "qemu"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ WORKDIR /workspace/xv6
 
 COPY . .
 
-# 镜像构建阶段执行一次干净编译，确保镜像不依赖宿主机生成的 xv6 产物。
+# 同时生成 kernel 与 fs.img，确保镜像在启动 QEMU 前已包含完整 guest 启动产物。
 RUN make clean \
-    && make -j"$(nproc)"
+    && make -j"$(nproc)" kernel/kernel fs.img
 
 # 默认通过 QEMU 的无图形串口终端启动 RISC-V xv6。
 CMD ["make", "qemu"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  xv6:
+    image: ${DOCKER_IMAGE:-xv6-dev}
+    build:
+      context: .
+
+    stdin_open: true
+    tty: true
+
+    environment:
+      QEMU_MEMORY: ${QEMU_MEMORY:-2G}
+      CPUS: ${CPUS:-3}
+
+    mem_limit: ${MEM_LIMIT:-3g}
+
+    command:
+      - bash
+      - -c
+      - |
+        make qemu QEMU_MEMORY=$${QEMU_MEMORY} CPUS=$${CPUS}
+
+  test:
+    image: ${DOCKER_IMAGE:-xv6-dev}
+    build:
+      context: .
+    command: make test

--- a/docker.mk
+++ b/docker.mk
@@ -1,20 +1,21 @@
 DOCKER ?= docker
+DOCKER_COMPOSE ?= $(DOCKER) compose
 DOCKER_IMAGE ?= xv6-dev
 
 # 构建包含当前源码、RISC-V 工具链和 QEMU 的可复现 xv6 镜像。
 docker-build:
-	$(DOCKER) build --pull -t $(DOCKER_IMAGE) .
+	$(DOCKER_COMPOSE) build
 
-# 使用交互式串口启动镜像内的 QEMU；退出 QEMU 时容器随之删除。
-docker-qemu: docker-build
-	$(DOCKER) run --rm -it $(DOCKER_IMAGE)
+# 使用 docker compose 管理 QEMU 参数、资源限制和交互终端。
+docker-qemu:
+	$(DOCKER_COMPOSE) run --rm xv6
 
 # 进入镜像内的源码目录，便于复验工具链和手工执行构建命令。
-docker-shell: docker-build
-	$(DOCKER) run --rm -it --entrypoint /bin/bash $(DOCKER_IMAGE)
+docker-shell:
+	$(DOCKER_COMPOSE) run --rm --entrypoint /bin/bash xv6
 
 # 在镜像内执行仓库现有的默认回归入口，并透传测试退出码。
-docker-test: docker-build
-	$(DOCKER) run --rm $(DOCKER_IMAGE) make test
+docker-test:
+	$(DOCKER_COMPOSE) run --rm test
 
 .PHONY: docker-build docker-qemu docker-shell docker-test

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,20 @@
+DOCKER ?= docker
+DOCKER_IMAGE ?= xv6-dev
+
+# 构建包含当前源码、RISC-V 工具链和 QEMU 的可复现 xv6 镜像。
+docker-build:
+	$(DOCKER) build --pull -t $(DOCKER_IMAGE) .
+
+# 使用交互式串口启动镜像内的 QEMU；退出 QEMU 时容器随之删除。
+docker-qemu: docker-build
+	$(DOCKER) run --rm -it $(DOCKER_IMAGE)
+
+# 进入镜像内的源码目录，便于复验工具链和手工执行构建命令。
+docker-shell: docker-build
+	$(DOCKER) run --rm -it --entrypoint /bin/bash $(DOCKER_IMAGE)
+
+# 在镜像内执行仓库现有的默认回归入口，并透传测试退出码。
+docker-test: docker-build
+	$(DOCKER) run --rm $(DOCKER_IMAGE) make test
+
+.PHONY: docker-build docker-qemu docker-shell docker-test


### PR DESCRIPTION
## PR 提交信息

- 关联 Issue：Closes #254
- 变更类型：工程基础设施
- 基线 Commit：`29a86feef076087f6ce3cc3b34c03d9fc65dfbd0`
- 影响范围：Docker 构建上下文、容器内 RISC-V 工具链、QEMU 启动与测试入口
- 一句话摘要：在不修改 xv6 内核和现有构建逻辑的前提下，为 x86 Linux 宿主提供可复现的容器化构建、启动和回归入口。

## 实现了什么

- 新增基于 Ubuntu 24.04 的 `Dockerfile`，安装与主线 CI 对齐的 `gcc-riscv64-linux-gnu`、`binutils-riscv64-linux-gnu`、`qemu-system-misc` 和 `python3-pexpect`，并补充宿主测试编译与 GDB 依赖。
- 镜像构建阶段执行 `make clean` 和 `make kernel/kernel fs.img`，同时生成内核与文件系统镜像，避免运行时依赖宿主机缓存产物。
- 镜像默认执行 `make qemu`，保持仓库当前 `virt` 机器、`-nographic` 串口、磁盘和 CPU 配置；Docker 只封装 Linux 用户态工具链，RISC-V xv6 仍运行在 QEMU guest 中。
- 新增 `.dockerignore`，排除 Git 元数据、编译产物、磁盘镜像和回归日志，确保镜像从干净源码重新构建。
- 新增独立 `docker.mk`，通过 `docker-build`、`docker-qemu`、`docker-shell` 和 `docker-test` 复用现有 `Makefile` 与测试入口，不侵入 xv6 原有本地工作流。

## 如何通过 CLI 回归观察此 PR 现象

### 前置条件

```bash
git checkout infra/254-docker-xv6
docker version
```

宿主机需要能够运行 Linux 容器，并为 QEMU guest 提供至少 2 GiB 可用内存。

### 操作步骤

```bash
make -f docker.mk docker-build
make -f docker.mk docker-qemu
```

进入 xv6 shell 后执行：

```text
$ echo docker-xv6
$ ls
```

使用 `Ctrl-a x` 退出 QEMU。完整回归入口：

```bash
make -f docker.mk docker-test
```

### 预期现象

```text
xv6 kernel is booting
...
init: starting sh
$ echo docker-xv6
docker-xv6
```

## 自动化测试结果

| 命令或检查项 | 结果 | 关键证据 |
|---|---|---|
| `make -n -f docker.mk docker-build` | 通过 | 展开为 `docker build --pull -t xv6-dev .` |
| `make -n -f docker.mk docker-qemu` | 通过 | 依次展开镜像构建和 `docker run --rm -it xv6-dev` |
| `make -n -f docker.mk docker-shell` | 通过 | 展开为使用 `/bin/bash` 覆盖镜像默认命令 |
| `make -n -f docker.mk docker-test` | 通过 | 展开为容器内执行仓库现有 `make test` |
| `docker build -t xv6-dev .` | 未运行 | 当前执行环境没有可用 Docker CLI/daemon，不能把静态检查写成镜像构建通过 |
| `docker run --rm -it xv6-dev` | 未运行 | 依赖上一步实际构建镜像 |
| `make clean && make` / QEMU 回归 | 未运行 | 当前执行环境无法拉取完整工作树并运行容器工具链；合并前必须在 x86 Linux Docker 环境补齐 |

## Review 主线

1. `Dockerfile`
   - 先确认基础镜像、依赖集合以及 `kernel/kernel fs.img` 的干净构建是否与当前 CI、Makefile 一致。
2. `.dockerignore`
   - 再检查宿主生成物是否被完整排除，避免缓存产物污染镜像验证。
3. `docker.mk`
   - 最后检查四个入口是否正确透传 Docker 和测试退出码，并确认没有改变原有 `make` 工作流。